### PR TITLE
Fix bug tracker card filtering so newly created cards appear at the top of the open list instead of at the bottom

### DIFF
--- a/app/brain/board/routes.py
+++ b/app/brain/board/routes.py
@@ -86,8 +86,8 @@ def list_board_items():
         )
 
     rows = query.order_by(
-        BoardItem.position.asc().nullslast(),
-        BoardItem.updated_at.desc()
+        BoardItem.position.asc().nullsfirst(),
+        BoardItem.created_at.desc()
     ).all()
     return jsonify({'items': [item.to_dict(activity_count=count or 0) for item, count in rows]})
 

--- a/frontend/src/pages/Board.jsx
+++ b/frontend/src/pages/Board.jsx
@@ -264,10 +264,10 @@ export default function Board() {
     }
     for (const s of STATUSES) {
         columns[s.value].sort((a, b) => {
-            const pa = a.position ?? Number.MAX_SAFE_INTEGER;
-            const pb = b.position ?? Number.MAX_SAFE_INTEGER;
+            const pa = a.position ?? Number.NEGATIVE_INFINITY;
+            const pb = b.position ?? Number.NEGATIVE_INFINITY;
             if (pa !== pb) return pa - pb;
-            return new Date(b.updated_at) - new Date(a.updated_at);
+            return new Date(b.created_at) - new Date(a.created_at);
         });
     }
 


### PR DESCRIPTION
## Ticket #156

Fix bug tracker card filtering so newly created cards appear at the top of the open list instead of at the bottom

---

*Built by Danny OS (Claude Code)*
*Cost: $0.2085 | Turns: 12*