### PR TITLE
Rank-gated Trello stage sync to break bounce-back loop.

### DIFF
--- a/app/api/helpers.py
+++ b/app/api/helpers.py
@@ -102,6 +102,37 @@ STAGE_ORDER = {
 
 STAGE_ORDER_EXEMPT = {"Hold"}
 
+# Single source of truth for "how far along is this stage on the release lifecycle."
+# Used by the inbound Trello rank gate in TrelloListMapper: when an inbound webhook
+# arrives, we compare rank(db.stage) against rank(target_trello_list); if DB is at
+# or ahead of the inbound list, we skip the apply (echoes, backward Trello drags,
+# and same-zone moves all collapse to this single check).
+#
+# Variants (e.g. "Cut start" + "Cut Start") share a rank — they are the same
+# conceptual stage. Hold is a sentinel above every real rank so a release on Hold
+# is never advanced or rolled back by Trello drags; only Brain transitions out.
+#
+# This dict is DB stage names only. The 6 actual Trello lists live in
+# TrelloListMapper.VALID_TRELLO_LISTS — the rank derivation is in list_mapper.py.
+STAGE_PROGRESSION_RANK = {
+    "Released":                       0,
+    "Material Ordered":               1,
+    "Cut start":                      2, "Cut Start":           2,
+    "Cut Complete":                   3,
+    "Fitup Start":                    4,
+    "Fitup Complete":                 5, "Fit Up Complete.":    5,
+    "Weld Start":                     6,
+    "Weld Complete":                  7,
+    "Welded QC":                      9,
+    "Paint Start":                   10,
+    "Paint complete":                11, "Paint Complete":     11,
+    "Store at MHMW for shipping":    12, "Store at Shop":      12,
+    "Shipping planning":             13, "Shipping Planning":  13,
+    "Shipping completed":            14, "Shipping Complete":  14,
+    "Complete":                      15,
+    "Hold":                          99,
+}
+
 
 def _normalize_stage(stage: Optional[str]) -> Optional[str]:
     """Resolve a stage name (including variants) to the canonical key in STAGE_TO_GROUP."""

--- a/app/brain/job_log/features/stage/command.py
+++ b/app/brain/job_log/features/stage/command.py
@@ -188,23 +188,34 @@ class UpdateStageCommand:
                 JobEventService.close(fab_order_event.id)
                 extras['fab_order'] = fab_order_to_set
 
-        # Trello outbox — only push when the target stage is itself a Trello milestone
-        # list. Sub-stages (e.g. "Paint Start", "Welded QC", "Fitup Start") collapse onto
-        # the same Trello list as their neighbors, so pushing them produces a redundant
-        # API call and a bounce-back webhook that overwrites the user's fine-grained stage.
+        # Trello outbox — push only when the DB stage's forward-mapped Trello list
+        # actually differs from the card's current list. This avoids redundant API
+        # calls and bounce-back webhooks for same-zone moves (e.g. Welded QC →
+        # Paint Start, both forward-mapping to "Fit Up Complete."). Hold is a pause
+        # that never moves the card.
         from app.trello.list_mapper import TrelloListMapper
 
         outbox_item_created = False
-        is_milestone_stage = self.stage in TrelloListMapper.VALID_TRELLO_LISTS
         new_list_id = None
-        if is_milestone_stage:
-            try:
-                from app.brain.job_log.routes import get_list_id_by_stage
-                new_list_id = get_list_id_by_stage(self.stage)
-            except Exception:
-                new_list_id = None
+        target_list = None
+        is_hold = self.stage == "Hold"
 
-        if is_milestone_stage and new_list_id and job_record.trello_card_id:
+        if is_hold:
+            should_push = False
+        else:
+            target_list = TrelloListMapper.DB_STAGE_TO_TRELLO_LIST.get(self.stage)
+            should_push = (
+                target_list is not None
+                and target_list != job_record.trello_list_name
+            )
+            if should_push:
+                try:
+                    from app.brain.job_log.routes import get_list_id_by_stage
+                    new_list_id = get_list_id_by_stage(self.stage)
+                except Exception:
+                    new_list_id = None
+
+        if should_push and new_list_id and job_record.trello_card_id:
             try:
                 OutboxService.add(
                     destination='trello',
@@ -213,8 +224,9 @@ class UpdateStageCommand:
                 )
                 outbox_item_created = True
                 logger.info(
-                    f"Outbox item created for Trello milestone update "
-                    f"(job {self.job_id}-{self.release}, stage={self.stage})"
+                    f"Outbox item created for Trello list move "
+                    f"(job {self.job_id}-{self.release}, stage={self.stage}, "
+                    f"target_list={target_list})"
                 )
             except Exception as outbox_error:
                 logger.error(
@@ -222,15 +234,30 @@ class UpdateStageCommand:
                     exc_info=True,
                 )
         else:
-            if not is_milestone_stage:
+            if is_hold:
                 logger.info(
-                    "Skipping Trello push for sub-stage change",
+                    "Skipping Trello push for Hold transition — card stays on its current list",
+                    extra={'job': self.job_id, 'release': self.release},
+                )
+            elif target_list is None:
+                logger.info(
+                    "Skipping Trello push — stage has no forward-mapped Trello list",
                     extra={'job': self.job_id, 'release': self.release, 'stage': self.stage},
+                )
+            elif not should_push:
+                logger.info(
+                    "Skipping Trello push — target list matches current list",
+                    extra={
+                        'job': self.job_id, 'release': self.release,
+                        'stage': self.stage,
+                        'current_list': job_record.trello_list_name,
+                        'target_list': target_list,
+                    },
                 )
             elif not new_list_id:
                 logger.warning(
-                    f"Could not get list ID for milestone stage '{self.stage}', "
-                    f"skipping Trello update",
+                    f"Could not resolve Trello list ID for stage '{self.stage}' "
+                    f"(target_list={target_list}), skipping Trello update",
                     extra={'job': self.job_id, 'release': self.release, 'stage': self.stage},
                 )
             elif not job_record.trello_card_id:

--- a/app/trello/list_mapper.py
+++ b/app/trello/list_mapper.py
@@ -20,8 +20,26 @@ Excel/database status fields and Trello list names.
 
 from typing import Optional
 from app.logging_config import get_logger
+from app.api.helpers import STAGE_PROGRESSION_RANK
 
 logger = get_logger(__name__)
+
+
+def _compute_trello_list_rank(stage_to_list, valid_lists, rank_map):
+    """Compute each Trello list's progression rank as the floor of its zone.
+
+    Floor = lowest progression rank among the DB stages that forward-map to this
+    list, excluding Hold (Hold's sentinel rank would otherwise raise the floor of
+    "Fit Up Complete." since Hold maps there).
+    """
+    return {
+        list_name: min(
+            rank_map[s]
+            for s, target in stage_to_list.items()
+            if target == list_name and s in rank_map and s != "Hold"
+        )
+        for list_name in valid_lists
+    }
 
 
 class TrelloListMapper:
@@ -82,7 +100,14 @@ class TrelloListMapper:
         "Shipping Complete":            "Shipping completed",
         "Complete":                     "Shipping completed",
     }
-    
+
+    # Derived: each Trello list's progression rank = floor of its zone (lowest DB
+    # stage rank whose forward-map is that list, excluding Hold). Used by the
+    # inbound rank gate in apply_trello_list_to_db.
+    TRELLO_LIST_RANK = _compute_trello_list_rank(
+        DB_STAGE_TO_TRELLO_LIST, VALID_TRELLO_LISTS, STAGE_PROGRESSION_RANK,
+    )
+
     @classmethod
     def determine_trello_list_from_db(cls, rec) -> Optional[str]:
         """
@@ -186,20 +211,27 @@ class TrelloListMapper:
         return None
 
     @classmethod
-    def apply_trello_list_to_db(cls, job, trello_list_name: str, operation_id: str) -> None:
+    def apply_trello_list_to_db(cls, job, trello_list_name: str, operation_id: str) -> bool:
         """
-        Update database record stage based on Trello list movement.
-        
-        This is used when syncing from Trello to database to update
-        the stage field based on which list the card was moved to.
-        
+        Update database record stage based on Trello list movement, gated by progression rank.
+
+        The rank gate skips the apply when DB stage is at or ahead of the inbound
+        Trello list's zone — this collapses three otherwise-tricky cases into one
+        check:
+          - echoes of our own outbound pushes (same forward-map → equal or lower
+            inbound rank than DB),
+          - backward Trello drags (intentionally blocked; rollbacks happen in Brain),
+          - same-zone moves where DB has finer-grained state than the Trello list.
+
         Args:
             job: Database record (Job model instance) to update
             trello_list_name: Name of the Trello list the card was moved to
             operation_id: Sync operation ID for logging
-            
+
         Returns:
-            None (modifies job in place)
+            True if job.stage was updated, False if the inbound was skipped
+            (unknown list name, or DB rank ≥ inbound list rank). Callers use
+            this to decide whether to record a stage-change audit event.
         """
         # Validate that the Trello list name is one we recognise
         if trello_list_name not in cls.VALID_TRELLO_LISTS:
@@ -210,32 +242,48 @@ class TrelloListMapper:
                 trello_list=trello_list_name,
                 current_stage=job.stage,
             )
-            return
+            return False
 
-        # Log the current state before applying changes
+        db_rank = STAGE_PROGRESSION_RANK.get(job.stage, -1)
+        trello_rank = cls.TRELLO_LIST_RANK[trello_list_name]
+
+        if db_rank >= trello_rank:
+            logger.info(
+                "Inbound Trello list skipped — DB progression at or ahead of Trello zone",
+                operation_id=operation_id,
+                job_id=job.id,
+                db_stage=job.stage,
+                db_rank=db_rank,
+                trello_list=trello_list_name,
+                trello_rank=trello_rank,
+            )
+            return False
+
+        # DB is behind — Trello has advanced; catch up.
         old_stage = job.stage
         logger.info(
             "Applying Trello list to database record",
             operation_id=operation_id,
             job_id=job.id,
             trello_list=trello_list_name,
-            current_stage=old_stage
+            current_stage=old_stage,
+            db_rank=db_rank,
+            trello_rank=trello_rank,
         )
 
-        # Set the stage directly from the Trello list name
         job.stage = trello_list_name
-        
+
         # Update stage_group based on stage
         from app.api.helpers import get_stage_group_from_stage
         job.stage_group = get_stage_group_from_stage(trello_list_name)
-        
-        # Log the new state after applying changes
+
         logger.info(
             "Applied Trello list to database record",
             operation_id=operation_id,
             job_id=job.id,
-            new_stage=job.stage
+            new_stage=job.stage,
         )
+        return True
     
     @classmethod
     def is_valid_shipping_state(cls, list_name: str) -> bool:
@@ -249,4 +297,20 @@ class TrelloListMapper:
             True if the list is a valid shipping state
         """
         return list_name in cls.VALID_SHIPPING_STATES
+
+
+# Fail fast at import time if the rank table doesn't cover every key in the
+# forward map. Hold is excluded from the requirement because its sentinel rank
+# (99) is intentionally filtered out of TRELLO_LIST_RANK above. This catches
+# silent drift the moment it lands rather than at first webhook.
+_missing_rank_keys = (
+    set(TrelloListMapper.DB_STAGE_TO_TRELLO_LIST.keys())
+    - {"Hold"}
+    - set(STAGE_PROGRESSION_RANK.keys())
+)
+assert not _missing_rank_keys, (
+    f"STAGE_PROGRESSION_RANK is missing keys present in DB_STAGE_TO_TRELLO_LIST: "
+    f"{_missing_rank_keys}"
+)
+del _missing_rank_keys
 

--- a/app/trello/sync.py
+++ b/app/trello/sync.py
@@ -385,60 +385,83 @@ def sync_from_trello(event_info):
             
             # Capture old stage value before applying list mapping
             old_stage_before_list_move = rec.stage
-            
-            # Apply list mapping to database
-            TrelloListMapper.apply_trello_list_to_db(rec, rec.trello_list_name, sync_op.operation_id)
-            
-            # Always create JobEvent for list moves - the webhook confirms the move happened
-            # Use to_list_name as the stage name to match frontend format
-            stage = to_list_name
-            # Use from_list_name from webhook for "from" value (more reliable than DB stage)
-            # Fall back to old_stage_before_list_move if from_list_name is not available
-            from_stage = from_list_name if from_list_name else (old_stage_before_list_move if old_stage_before_list_move else None)
-            
-            safe_log_sync_event(
-                sync_op.operation_id,
-                "INFO",
-                "Creating stage update event for list move",
-                job=rec.job,
-                release=rec.release,
-                from_list=from_list_name,
-                to_list=to_list_name,
-                old_stage=old_stage_before_list_move,
-                new_stage=stage
+
+            # Apply list mapping to database. Returns True only if the rank gate
+            # actually advanced rec.stage; False means the inbound was skipped
+            # (echo of our own push, backward Trello drag, or DB already at/ahead
+            # of the inbound list zone).
+            applied = TrelloListMapper.apply_trello_list_to_db(
+                rec, rec.trello_list_name, sync_op.operation_id
             )
-            
-            event = JobEventService.create(
-                job=rec.job,
-                release=rec.release,
-                action="update_stage",
-                source=trello_source,
-                payload={"from": from_stage, "to": stage},
-                external_user_id=trello_user_id,
-            )
-            if event:
-                created_events.append(event)
+
+            if applied:
+                # Use to_list_name as the stage name to match frontend format
+                stage = to_list_name
+                # Use from_list_name from webhook for "from" value (more reliable
+                # than DB stage); fall back to old DB stage if unavailable.
+                from_stage = (
+                    from_list_name
+                    if from_list_name
+                    else (old_stage_before_list_move if old_stage_before_list_move else None)
+                )
+
                 safe_log_sync_event(
                     sync_op.operation_id,
                     "INFO",
-                    "JobEvent created for stage update",
-                    job=rec.job,
-                    release=rec.release,
-                    from_list=from_list_name,
-                    to_stage=stage,
-                    event_id=event.id
-                )
-            else:
-                safe_log_sync_event(
-                    sync_op.operation_id,
-                    "WARNING",
-                    "Duplicate stage update event detected, skipping",
+                    "Creating stage update event for list move",
                     job=rec.job,
                     release=rec.release,
                     from_list=from_list_name,
                     to_list=to_list_name,
-                    payload_from=from_stage,
-                    payload_to=stage
+                    old_stage=old_stage_before_list_move,
+                    new_stage=stage,
+                )
+
+                event = JobEventService.create(
+                    job=rec.job,
+                    release=rec.release,
+                    action="update_stage",
+                    source=trello_source,
+                    payload={"from": from_stage, "to": stage},
+                    external_user_id=trello_user_id,
+                )
+                if event:
+                    created_events.append(event)
+                    safe_log_sync_event(
+                        sync_op.operation_id,
+                        "INFO",
+                        "JobEvent created for stage update",
+                        job=rec.job,
+                        release=rec.release,
+                        from_list=from_list_name,
+                        to_stage=stage,
+                        event_id=event.id,
+                    )
+                else:
+                    safe_log_sync_event(
+                        sync_op.operation_id,
+                        "WARNING",
+                        "Duplicate stage update event detected, skipping",
+                        job=rec.job,
+                        release=rec.release,
+                        from_list=from_list_name,
+                        to_list=to_list_name,
+                        payload_from=from_stage,
+                        payload_to=stage,
+                    )
+            else:
+                # Rank gate skipped the apply — DB stage was not advanced. No
+                # phantom update_stage event is recorded; the audit trail stays
+                # honest. The skip itself is logged inside apply_trello_list_to_db.
+                safe_log_sync_event(
+                    sync_op.operation_id,
+                    "INFO",
+                    "Skipping JobEvent — inbound Trello list move did not advance DB stage",
+                    job=rec.job,
+                    release=rec.release,
+                    from_list=from_list_name,
+                    to_list=to_list_name,
+                    db_stage=old_stage_before_list_move,
                 )
             
             destination_name = event_info.get("to")

--- a/tests/test_trello_stage_sync.py
+++ b/tests/test_trello_stage_sync.py
@@ -1,0 +1,362 @@
+"""
+Tests for the rank-gated Trello ↔ Job Log stage sync (#70).
+
+Two layers:
+- TestRankGate: pure unit tests of TrelloListMapper.apply_trello_list_to_db
+  using stub job objects. Verifies the rank gate skips echoes, blocks backward
+  drags, blocks Hold inbound, allows forward catch-up, etc.
+- TestUpdateStageCommandOutbound: integration tests of UpdateStageCommand
+  with the in-memory SQLite app fixture. Verifies the outbound milestone gate
+  has been replaced with target-list-differs, and that Hold transitions skip
+  the outbox entirely.
+"""
+import pytest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from app import create_app
+from app.models import Releases, db
+from app.api.helpers import STAGE_PROGRESSION_RANK
+from app.trello.list_mapper import TrelloListMapper
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret-key"
+
+    uri = app.config.get("SQLALCHEMY_DATABASE_URI") or ""
+    assert "sandbox" not in uri.lower() and "render.com" not in uri
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def mock_admin_user():
+    user = Mock()
+    user.id = 1
+    user.username = "test_admin"
+    user.is_admin = True
+    user.is_active = True
+    return user
+
+
+@pytest.fixture(autouse=True)
+def setup_auth(mock_admin_user):
+    with patch("app.auth.utils.get_current_user", return_value=mock_admin_user):
+        yield
+
+
+def make_release(
+    job, release, stage, stage_group, fab_order=5,
+    trello_card_id=None, trello_list_name=None, job_name="Test",
+):
+    r = Releases(
+        job=job,
+        release=release,
+        job_name=job_name,
+        stage=stage,
+        stage_group=stage_group,
+        fab_order=fab_order,
+        trello_card_id=trello_card_id,
+        trello_list_name=trello_list_name,
+    )
+    db.session.add(r)
+    db.session.flush()
+    return r
+
+
+def stub_job(stage, job_id=1):
+    """Lightweight stand-in for a Releases instance for pure rank-gate tests."""
+    return SimpleNamespace(id=job_id, stage=stage, stage_group=None)
+
+
+# ---------------------------------------------------------------------------
+# Unit: TrelloListMapper.apply_trello_list_to_db rank gate
+# ---------------------------------------------------------------------------
+
+class TestRankGate:
+    """The inbound rank gate — no DB required."""
+
+    def test_echo_of_outbound_push_is_skipped(self):
+        """DB at Welded QC (rank 9) + inbound 'Fit Up Complete.' (rank 4) → skip.
+
+        This is the literal echo case: setting Welded QC in Brain pushes the
+        card to 'Fit Up Complete.' (Welded QC's forward-mapped list); when the
+        webhook bounces back, the gate skips it because DB is already ahead.
+        """
+        job = stub_job("Welded QC")
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Fit Up Complete.", "op-1")
+        assert applied is False
+        assert job.stage == "Welded QC"
+
+    def test_complete_to_shipping_completed_echo_is_skipped(self):
+        """The literal #70 bug: DB Complete (15) + inbound 'Shipping completed' (14)."""
+        job = stub_job("Complete")
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Shipping completed", "op-1")
+        assert applied is False
+        assert job.stage == "Complete"
+
+    def test_exact_equal_rank_same_string_is_skipped(self):
+        """DB Released (0) + inbound 'Released' (0) → skip (>= rule)."""
+        job = stub_job("Released")
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Released", "op-1")
+        assert applied is False
+        assert job.stage == "Released"
+
+    def test_equal_rank_different_string_blocked(self):
+        """Variant rename via inbound is blocked: DB and Trello vocabularies stay separate.
+
+        DB 'Store at Shop' (rank 12) + inbound 'Store at MHMW for shipping'
+        (rank 12) → skip. DB keeps its job-log vocabulary.
+        """
+        job = stub_job("Store at Shop")
+        applied = TrelloListMapper.apply_trello_list_to_db(
+            job, "Store at MHMW for shipping", "op-1"
+        )
+        assert applied is False
+        assert job.stage == "Store at Shop"
+
+    def test_backward_drag_is_blocked(self):
+        """Trello drag from a higher-rank list to a lower-rank list is silently ignored.
+
+        Rollbacks must happen in Brain, not on Trello.
+        """
+        job = stub_job("Welded QC")
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Released", "op-1")
+        assert applied is False
+        assert job.stage == "Welded QC"
+
+    def test_forward_catch_up_applies(self):
+        """DB behind Trello → DB catches up to the canonical Trello list name."""
+        job = stub_job("Cut Complete")  # rank 3
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Fit Up Complete.", "op-1")
+        assert applied is True
+        assert job.stage == "Fit Up Complete."
+
+    def test_forward_catch_up_to_paint_complete(self):
+        """DB Welded QC (9) + inbound Paint complete (11) → apply."""
+        job = stub_job("Welded QC")
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Paint complete", "op-1")
+        assert applied is True
+        assert job.stage == "Paint complete"
+
+    def test_hold_is_sticky_against_inbound(self):
+        """DB Hold (rank 99) blocks every inbound, regardless of list."""
+        for inbound in TrelloListMapper.VALID_TRELLO_LISTS:
+            job = stub_job("Hold")
+            applied = TrelloListMapper.apply_trello_list_to_db(job, inbound, "op-1")
+            assert applied is False, f"Hold should block inbound '{inbound}'"
+            assert job.stage == "Hold"
+
+    def test_null_db_stage_seeds_from_inbound(self):
+        """A release with no stage (rank -1) accepts an inbound to seed the DB."""
+        job = stub_job(None)
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Released", "op-1")
+        assert applied is True
+        assert job.stage == "Released"
+
+    def test_unknown_inbound_list_rejected(self):
+        """Unknown Trello list name still produces no DB write."""
+        job = stub_job("Welded QC")
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Backlog", "op-1")
+        assert applied is False
+        assert job.stage == "Welded QC"
+
+    def test_finer_grained_substage_protected(self):
+        """All sub-stages mapping to 'Fit Up Complete.' are protected from clobber.
+
+        A bounce-back arriving as the literal list name 'Fit Up Complete.' must
+        not overwrite a finer-grained DB sub-stage.
+        """
+        substages = ["Fitup Start", "Weld Start", "Weld Complete", "Welded QC", "Paint Start"]
+        for stage in substages:
+            job = stub_job(stage)
+            applied = TrelloListMapper.apply_trello_list_to_db(
+                job, "Fit Up Complete.", f"op-{stage}"
+            )
+            # All substages have rank >= the list's floor (Fitup Start, rank 4),
+            # so the gate skips and DB stays at the finer-grained stage.
+            assert applied is False, f"Expected skip for sub-stage {stage}"
+            assert job.stage == stage
+
+    def test_stage_group_updated_on_apply(self):
+        """When the gate applies, stage_group is also synced."""
+        job = stub_job("Cut Complete")
+        applied = TrelloListMapper.apply_trello_list_to_db(job, "Paint complete", "op-1")
+        assert applied is True
+        assert job.stage == "Paint complete"
+        # Paint complete is in READY_TO_SHIP per STAGE_TO_GROUP
+        assert job.stage_group == "READY_TO_SHIP"
+
+
+class TestRankTableInvariants:
+    """Sanity checks on the rank tables themselves (catch drift early)."""
+
+    def test_every_forward_map_key_has_a_rank(self):
+        """The import-time assertion enforces this; this test pins the contract."""
+        forward_keys = set(TrelloListMapper.DB_STAGE_TO_TRELLO_LIST.keys()) - {"Hold"}
+        rank_keys = set(STAGE_PROGRESSION_RANK.keys())
+        missing = forward_keys - rank_keys
+        assert not missing, f"Missing rank entries: {missing}"
+
+    def test_every_trello_list_has_a_rank(self):
+        for list_name in TrelloListMapper.VALID_TRELLO_LISTS:
+            assert list_name in TrelloListMapper.TRELLO_LIST_RANK, (
+                f"Trello list {list_name!r} missing from TRELLO_LIST_RANK"
+            )
+
+    def test_hold_excluded_from_trello_list_floor(self):
+        """Hold's sentinel (99) must not raise the floor of 'Fit Up Complete.'."""
+        # Fitup Start is rank 4 and forward-maps to "Fit Up Complete.", so the
+        # floor of that list is 4 — not 99 (Hold).
+        assert TrelloListMapper.TRELLO_LIST_RANK["Fit Up Complete."] == 4
+
+    def test_hold_rank_is_above_all_real_stages(self):
+        max_real = max(
+            r for s, r in STAGE_PROGRESSION_RANK.items() if s != "Hold"
+        )
+        assert STAGE_PROGRESSION_RANK["Hold"] > max_real, (
+            "Hold sentinel must exceed every real stage rank to be sticky"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: UpdateStageCommand outbound gate (Hold + target-differs)
+# ---------------------------------------------------------------------------
+
+class TestUpdateStageCommandOutbound:
+    """The outbound milestone gate is now target-list-differs, plus Hold guard."""
+
+    def _patches(self):
+        """Common patches: OutboxService.add, scheduling cascade, list-id resolver."""
+        return [
+            patch("app.services.outbox_service.OutboxService.add"),
+            patch(
+                "app.brain.job_log.scheduling.service.recalculate_all_jobs_scheduling"
+            ),
+            patch(
+                "app.brain.job_log.routes.get_list_id_by_stage",
+                return_value="fake-list-id-123",
+            ),
+        ]
+
+    def test_set_to_complete_pushes_to_trello(self, app):
+        """Setting DB to Complete pushes the card; with the milestone gate fixed,
+        the forward-mapped list 'Shipping completed' differs from current list."""
+        with app.app_context():
+            make_release(
+                1, "A", "Welded QC", "READY_TO_SHIP",
+                trello_card_id="card-1", trello_list_name="Fit Up Complete.",
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = self._patches()
+            with patches[0] as m_add, patches[1], patches[2]:
+                cmd = UpdateStageCommand(job_id=1, release="A", stage="Complete")
+                cmd.execute()
+
+            assert m_add.called, "Expected outbox push for Complete transition"
+            kwargs = m_add.call_args.kwargs
+            assert kwargs.get("destination") == "trello"
+            assert kwargs.get("action") == "move_card"
+
+    def test_substage_within_same_zone_skips_outbox(self, app):
+        """DB Welded QC (list 'Fit Up Complete.') → Paint Start (also forward-maps
+        to 'Fit Up Complete.'). Target == current → no outbox push."""
+        with app.app_context():
+            make_release(
+                1, "A", "Welded QC", "READY_TO_SHIP",
+                trello_card_id="card-1", trello_list_name="Fit Up Complete.",
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = self._patches()
+            with patches[0] as m_add, patches[1], patches[2]:
+                cmd = UpdateStageCommand(job_id=1, release="A", stage="Paint Start")
+                cmd.execute()
+
+            assert not m_add.called, "Same-zone moves must not push to Trello"
+
+    def test_cross_zone_move_pushes(self, app):
+        """DB Welded QC (list 'Fit Up Complete.') → Paint complete (list 'Paint
+        complete'). Target != current → push fires."""
+        with app.app_context():
+            make_release(
+                1, "A", "Welded QC", "READY_TO_SHIP",
+                trello_card_id="card-1", trello_list_name="Fit Up Complete.",
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = self._patches()
+            with patches[0] as m_add, patches[1], patches[2]:
+                cmd = UpdateStageCommand(job_id=1, release="A", stage="Paint complete")
+                cmd.execute()
+
+            assert m_add.called, "Cross-zone moves must push to Trello"
+
+    def test_hold_transition_skips_outbox(self, app):
+        """Hold is a pause — the card stays where it is on Trello."""
+        with app.app_context():
+            make_release(
+                1, "A", "Welded QC", "READY_TO_SHIP",
+                trello_card_id="card-1", trello_list_name="Fit Up Complete.",
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = self._patches()
+            with patches[0] as m_add, patches[1], patches[2]:
+                cmd = UpdateStageCommand(job_id=1, release="A", stage="Hold")
+                cmd.execute()
+
+            assert not m_add.called, "Hold transition must not push to Trello"
+
+    def test_no_trello_card_id_skips_outbox(self, app):
+        """Releases without a Trello card never push regardless of stage."""
+        with app.app_context():
+            make_release(
+                1, "A", "Welded QC", "READY_TO_SHIP",
+                trello_card_id=None, trello_list_name=None,
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = self._patches()
+            with patches[0] as m_add, patches[1], patches[2]:
+                cmd = UpdateStageCommand(job_id=1, release="A", stage="Complete")
+                cmd.execute()
+
+            assert not m_add.called, "Releases without a Trello card must not push"
+
+    def test_store_at_shop_pushes_to_canonical_list(self, app):
+        """DB 'Store at Shop' forward-maps to 'Store at MHMW for shipping'.
+        With card on a different list, push fires (proves the fixed gate
+        catches non-VALID_TRELLO_LISTS DB stages too)."""
+        with app.app_context():
+            make_release(
+                1, "A", "Welded QC", "READY_TO_SHIP",
+                trello_card_id="card-1", trello_list_name="Fit Up Complete.",
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = self._patches()
+            with patches[0] as m_add, patches[1], patches[2]:
+                cmd = UpdateStageCommand(job_id=1, release="A", stage="Store at Shop")
+                cmd.execute()
+
+            assert m_add.called, "DB stage 'Store at Shop' must push to its canonical Trello list"


### PR DESCRIPTION
Trello webhooks were unconditionally rewriting job.stage from the literal list name, silently undoing Brain edits any time a finer-grained DB stage mapped to the same Trello list (e.g. Complete -> Shipping completed, Welded QC -> Fit Up Complete.).

Replace the unconditional clobber with a progression-rank gate: skip when rank(db.stage) >= rank(inbound_list). Echoes are mathematically caught by the same check (forward map satisfies rank(forward_map(s)) <= rank(s)). Hold gets sentinel rank 99 so it's sticky on both sides; outbound Hold transitions skip the Trello push entirely.

Also fix the outbound milestone gate in UpdateStageCommand: replace `stage in VALID_TRELLO_LISTS` with `target_list != current_list` so DB moves to Complete actually push to "Shipping completed".

apply_trello_list_to_db now returns bool; sync.py callers skip the update_stage event creation when the gate skipped, keeping the audit trail clean.