### PR TITLE
Update CLAUDE.md to reflect current Releases/Projects models and seed nightly thesis

### DIFF
--- a/.claude/nightly-thesis.md
+++ b/.claude/nightly-thesis.md
@@ -1,0 +1,26 @@
+# Nightly Thesis — MHMW Brain
+
+Last updated: 2026-04-30 (first nightly run)
+
+## Direction
+
+**What the Brain does.** MHMW Brain is a Flask + React 19 app that mirrors three external systems (Trello, Procore submittals, OneDrive Excel) into one normalized job log so drafters and PMs can sequence fabrication, paint, and shipping for steel-fab releases. The hot paths are: (1) Trello card webhooks → in-process queue → ThreadPoolExecutor workers writing to `Releases` and `ReleaseEvents`; (2) Procore submittal webhooks → `Submittals`/`SubmittalEvents` with 15s burst dedup and outbound updates back to Procore; (3) APScheduler hourly Excel poll converting OneDrive rows to Trello cards; (4) the `outbox_retry_worker` daemon thread that drains `TrelloOutbox`/`ProcoreOutbox` with exponential backoff. The Job Log frontend reads `Releases` through `app/brain/job_log/routes.py` and applies a per-stage-group `fab_order` ordering scheme (fixed tiers 1–2, dynamic ≥3).
+
+**Where this should head.** Smooth, fast, accurate Brain means: (a) one source of truth for stage→group mapping (`STAGE_TO_GROUP` in `app/api/helpers.py`) — every consumer must derive groups from `stage`, never trust a stale `stage_group` column; (b) the duplicated `is_active`/`is_archived` filter that recurs across at least four call sites should collapse into one helper so a future change in semantics doesn't drift; (c) the new `app/brain/job_log/features/` layout (one folder per bounded behavior) is the right shape — Job Log routes should keep delegating rather than re-inlining; (d) the Job Log page component (1620 lines) is the next big simplification target — modal markup should move into per-feature components.
+
+## What's working
+
+- #167 — Renumber FABRICATION fab_orders. New admin button + dry-run preview + idempotent compress-to-3..N. Good shape: dedicated feature folder, full test file, sentinel-based tie handling. Baseline of how new Job Log behaviors should land.
+- #166 — Bug-tracker comment box now multiline + auto-grows. Tiny change, high-frequency improvement.
+- #165 — DWL "is this point inside a project?" lookup now reads `geofence_geojson` instead of the old `geometry` column. Includes migration to drop `geometry` and a Python-fallback test for the SQLite path.
+- #164 — Improved paint-department filter sort uses stage priority + `last_updated_at` ascending so the oldest waiting items surface first across Ready-to-Ship and Paint subsets.
+
+## What didn't work
+
+(First nightly run — no rejected/reverted moves to record yet.)
+
+## Open questions
+
+1. **Should `geofence_geojson` ever be NULL?** PR #165 added an `IS NOT NULL` guard to the PostGIS query but the Python fallback iterates all `is_active=True` Projects regardless. If NULL is "not a real project yet," the fallback could match that with an `is not None` check; if it's "uses lat/lng+radius circle," the fallback should fall back further. Need a one-line product call.
+2. **Should `_normalize_stage`/`_get_all_variants_for_stages` be the only path into stage filtering?** `app/brain/job_log/routes.py` still hand-rolls `Releases.stage.in_(...)` lists in places where `_get_all_variants_for_stages` would handle the spelling drift. Worth a sweep, but only after I confirm nobody is intentionally filtering one variant.
+3. **`Job` (legacy) vs `Releases`** — is the `Job` model dead enough to remove? It's still referenced in `app/trello/scripts/trello_cleanup.py` and `app/models.py` keeps the table. If yes, that's a meaningful simplification; if no, the docstring should be louder.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,10 @@ Models: `BoardItem` (status: open/in_progress/deployed/closed, priority: low/nor
 Comment creation auto-parses `@FirstName` mentions and creates `Notification` records. Frontend polls `/brain/notifications/unread-count` for the notification bell.
 
 ### Key models (`app/models.py`)
-- `Job` — job log entries (table: `jobs`)
-- `Jobs` — geofence/job site records (table: `job_sites`)
+- `Releases` — current job log entries (table: `releases`); the model the app reads/writes
+- `Job` — legacy job log model (table: `jobs`); kept for older code paths
+- `Projects` — geofence / job site records (table: `projects`); has `geofence_geojson` column (single canonical GeoJSON polygon, used by both the map renderer and the on-site location filter)
+- `ProjectManager` — PM display rows (color, name) used by the map and PM views
 - `Submittals` — Procore submittals (table: `submittals`; previously `procore_submittals`)
 - `ReleaseEvents` / `SubmittalEvents` — audit event streams with payload-hash dedup
 - `TrelloOutbox` / `ProcoreOutbox` — reliable outbound delivery queue
@@ -81,17 +83,23 @@ Comment creation auto-parses `@FirstName` mentions and creates `Notification` re
 - `User`, `SyncOperation`, `SyncLog`, `JobChangeLog`, `ProcoreToken`
 
 ### Naming conflicts to keep in mind
-- `Job` (main) is the job log. `Jobs` is geofences (table `job_sites`).
+- `Releases` (table `releases`) is the current job log. `Job` (table `jobs`) is the legacy model — most application code uses `Releases`.
+- `Projects` (table `projects`) holds geofence/job-site rows. There is no `Jobs` model anymore.
 - `Submittals` was renamed from `ProcoreSubmittal`; old scripts alias it: `from app.models import Submittals as ProcoreSubmittal`.
 - Integration code that bridges branches uses: `from app.models import Job as Releases`.
+- The Projects geofence is stored in a single column, `geofence_geojson` (the previous split with a `geometry` column was consolidated; both the on-site filter and the map renderer read from `geofence_geojson`).
 
 ### Migration order
 M1 (users) → M2 (rename submittals table) → M3 (release_events) → M4 (submittal_events) → M5 (procore_outbox) → M6 (webhook_receipts)
 
 ### Brain / services layer
 - `app/brain/` — query and transformation logic for job log, drafting work load (DWL), map views, and the board/bug tracker
+- `app/brain/job_log/features/` — feature folders that own one bounded behavior each (`fab_order/`, `notes/`, `stage/`, `start_install/`). Each folder typically contains `command.py` (write path), `events.py` (event-shape constants), `payloads.py`, `results.py`, plus any one-off migrations or helpers. The Job Log routes file delegates here rather than holding the logic inline.
+  - `fab_order/renumber_fabrication.py` — admin button on Job Log; compresses FABRICATION-group `fab_order` to a contiguous block starting at 3, preserves ties and the 80.555 placeholder, queues Trello sync only when `Config.FAB_ORDER_FIELD_ID` is set.
+  - `fab_order/migrate_unified.py` — one-time tier migration (Complete=NULL, tier 1 = 1, tier 2 = 2, dynamic stages 3+).
 - `app/services/` — `OutboxService` (retry), `JobEventService` (deduplication with time-bucketed hashing), `DatabaseMappingService` (field mappings)
 - `app/history/` — event audit trail queries
+- `scripts/` — operational scripts run from the CLI (e.g. `scripts/refresh_jobsites_from_procore.py` rebuilds `docs/jobsites.json` from Procore project data and upserts `ProjectManager` rows). Default is dry-run; pass `--apply` to write.
 
 ### Logging
 Structured logging via `structlog` (`app/logging_config.py`). Use `get_logger(__name__)` in every module. `SyncContext` context manager wraps sync operations with correlation IDs and timing. Output is JSON-structured; also writes to rotating file (`logs/app.log`, 10MB max, 5 backups).


### PR DESCRIPTION
## What
Refreshes `CLAUDE.md` so the agent guide matches the current code, and seeds `.claude/nightly-thesis.md` so future nightly runs have continuity.

CLAUDE.md changes:
- Replace stale `Job`/`Jobs` model references with the current `Releases` (job log) / `Job` (legacy) / `Projects` (geofences) split. There is no `Jobs` model anymore; the `job_sites` table is now `projects`.
- Document the geofence column consolidation from PR #165: `Projects.geometry` is gone; `geofence_geojson` is the single canonical column for both the map renderer and the on-site filter.
- Add the `app/brain/job_log/features/` folder layout (`fab_order`, `notes`, `stage`, `start_install`) and call out the new `fab_order/renumber_fabrication.py` admin behavior introduced by PR #167.
- Add the `scripts/` directory entry — `refresh_jobsites_from_procore.py` is now a real CLI surface (introduced alongside #165).

## Why
North star is a smooth/accurate Brain. Future agent edits start from CLAUDE.md, so misnamed models and missing module pointers cause exactly the kind of foot-guns that slow the codebase down. The thesis file gives subsequent nightly runs a starting context (direction, recent wins, open questions) instead of re-deriving them every night.

## Behavior preservation
Documentation-only — no code touched, so nothing to verify behaviorally. `pytest` was 434 passed on `main` before this PR; this PR doesn't change that.

## Risk
Low. Two markdown files; no code paths affected.

## Deferred
Bigger refactors not shipped tonight (called out in the thesis "Open questions" so the human can weigh in):
- Removing the legacy `Job` model — needs product confirmation it's truly dead.
- Routing all stage filters through `_get_all_variants_for_stages` to eliminate hand-rolled `Releases.stage.in_(...)` drift in `app/brain/job_log/routes.py`.
- Splitting the 1620-line `frontend/src/pages/JobLog.jsx` modal markup into per-feature components.

https://claude.ai/code/session_01QogwxYqLsUXmKoDzBbPuFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QogwxYqLsUXmKoDzBbPuFm)_