### PR TITLE
Refactor: extract active_releases_filter helper to dedupe is_active/is_archived clause

### DIFF
--- a/app/api/helpers.py
+++ b/app/api/helpers.py
@@ -160,6 +160,24 @@ def _get_all_variants_for_stages(canonical_stages: List[str]) -> List[str]:
     return result
 
 
+def active_releases_filter():
+    """SQLAlchemy boolean expression matching active, non-archived releases.
+
+    Active means: ``is_archived`` is False AND ``is_active`` is True or NULL.
+    NULL ``is_active`` is treated as active because legacy rows pre-date the
+    column. Use as the first arg to ``Releases.query.filter(...)``:
+
+        Releases.query.filter(active_releases_filter(), Releases.stage.in_(...))
+
+    Centralized so the "active" semantics live in one place; if the policy
+    ever shifts, every consumer changes together.
+    """
+    return (
+        (Releases.is_archived == False)  # noqa: E712
+        & ((Releases.is_active == True) | (Releases.is_active.is_(None)))  # noqa: E712
+    )
+
+
 def get_stage_position(stage: Optional[str]) -> Optional[int]:
     """Return 0-based index of a stage in DYNAMIC_STAGE_ORDER, or None if exempt/fixed-tier."""
     normalized = _normalize_stage(stage)

--- a/app/brain/job_log/features/fab_order/migrate_unified.py
+++ b/app/brain/job_log/features/fab_order/migrate_unified.py
@@ -32,7 +32,12 @@ Ordering:
 """
 
 from app.models import Releases, db
-from app.api.helpers import DYNAMIC_STAGE_ORDER, FIXED_TIER_STAGES, _get_all_variants_for_stages
+from app.api.helpers import (
+    DYNAMIC_STAGE_ORDER,
+    FIXED_TIER_STAGES,
+    _get_all_variants_for_stages,
+    active_releases_filter,
+)
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -50,10 +55,7 @@ def renumber_fab_orders(dry_run=False):
     stats = {'complete_cleared': 0, 'fixed_tier_1': 0, 'fixed_tier_2': 0, 'dynamic': 0, 'total': 0}
 
     # Only renumber active, non-archived releases
-    active_filter = (
-        (Releases.is_archived == False) &  # noqa: E712
-        ((Releases.is_active == True) | (Releases.is_active.is_(None)))  # noqa: E712
-    )
+    active_filter = active_releases_filter()
 
     # Step 0: Clear fab_order for Complete releases. Complete is terminal — no
     # ordering applies — and is intentionally not in FIXED_TIER_STAGES, so

--- a/app/brain/job_log/features/fab_order/renumber_fabrication.py
+++ b/app/brain/job_log/features/fab_order/renumber_fabrication.py
@@ -18,7 +18,7 @@ updated_by_agent: 2026-04-29T00:00:00Z
 from datetime import datetime
 
 from app.models import Releases, db
-from app.api.helpers import DEFAULT_FAB_ORDER, STAGE_TO_GROUP
+from app.api.helpers import DEFAULT_FAB_ORDER, STAGE_TO_GROUP, active_releases_filter
 from app.services.job_event_service import JobEventService
 from app.services.outbox_service import OutboxService
 from app.config import Config
@@ -49,11 +49,6 @@ def renumber_fabrication_fab_orders(dry_run=False):
             'changes': [{'job', 'release', 'stage', 'from', 'to'}, ...]  # capped
         }
     """
-    active_filter = (
-        (Releases.is_archived == False) &  # noqa: E712
-        ((Releases.is_active == True) | (Releases.is_active.is_(None)))  # noqa: E712
-    )
-
     # Match the frontend Fab filter: it derives Stage Group from `stage` via
     # STAGE_TO_GROUP at serialization time (see routes.py /get-all-jobs), not
     # from the `stage_group` column. Some rows have stale or NULL stage_group
@@ -61,7 +56,7 @@ def renumber_fabrication_fab_orders(dry_run=False):
     fab_stage_variants = [s for s, g in STAGE_TO_GROUP.items() if g == 'FABRICATION']
     all_fab_releases = (
         Releases.query
-        .filter(active_filter, Releases.stage.in_(fab_stage_variants))
+        .filter(active_releases_filter(), Releases.stage.in_(fab_stage_variants))
         .order_by(
             Releases.fab_order.asc().nullslast(),
             Releases.job.asc(),


### PR DESCRIPTION
## What
Both `app/brain/job_log/features/fab_order/migrate_unified.py` and `app/brain/job_log/features/fab_order/renumber_fabrication.py` (the latter just landed in #167) hand-rolled the same "active, non-archived release" SQLAlchemy clause:

```python
(Releases.is_archived == False) &
((Releases.is_active == True) | (Releases.is_active.is_(None)))
```

This PR extracts that clause into `active_releases_filter()` in `app/api/helpers.py` and updates both call sites to use it.

## Why
North star: smooth, accurate Brain. The "active" semantics — including the legacy-row decision to treat NULL `is_active` as active — is a rule the codebase will likely revisit. Right now the rule lives in two places (today) with at least two more candidates in `app/brain/job_log/routes.py`. Centralizing keeps every consumer aligned when the rule shifts.

## Behavior preservation
- `active_releases_filter()` returns the identical SQLAlchemy boolean expression that both files were building inline.
- `Releases` is already imported at module scope in `app/api/helpers.py` (used by `get_fab_order_bounds`, `transform_job_for_display`, etc.), so the helper imposes no new import burden or circular risk.
- Full pytest suite: **434 passed before, 434 passed after** — including `tests/test_renumber_fabrication.py` (10 tests covering the affected file) and the integration paths in `tests/brain/`.

## Risk
Low. Pure rename / extraction. No test changes. No SQL-level change — same expression, just produced by a function call.

https://claude.ai/code/session_01QogwxYqLsUXmKoDzBbPuFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QogwxYqLsUXmKoDzBbPuFm)_