### PR TITLE
Promote clear_hard_date_cascade to module-level imports

### DIFF
--- a/app/brain/job_log/features/stage/command.py
+++ b/app/brain/job_log/features/stage/command.py
@@ -5,7 +5,7 @@ purpose: Encapsulate the full stage update workflow (DB write, stage_group sync,
 exports:
   UpdateStageCommand: Dataclass command that executes a stage update with all side effects
   StageUpdateResult: Dataclass result with event_id, job_comp/fab_order extras
-imports_from: [app.models, app.services.outbox_service, app.services.job_event_service, app.api.helpers, app.brain.job_log.scheduling.service]
+imports_from: [app.models, app.services.outbox_service, app.services.job_event_service, app.api.helpers, app.brain.job_log.scheduling.service, app.brain.job_log.features.start_install.clear_hard_date_cascade]
 imported_by: [app/brain/job_log/routes.py]
 invariants:
   - Fixed-tier stages (Ready-to-Ship / Complete groups) auto-assign fab_order via get_fixed_tier
@@ -22,6 +22,7 @@ from app.models import Releases, db
 from app.services.job_event_service import JobEventService
 from app.services.outbox_service import OutboxService
 from app.logging_config import get_logger
+from app.brain.job_log.features.start_install.clear_hard_date_cascade import clear_hard_date_cascade
 
 logger = get_logger(__name__)
 
@@ -192,9 +193,6 @@ class UpdateStageCommand:
         # Red-date auto-clear: a hard start_install date is meaningless once the
         # release is complete. Helper is a no-op when no hard date is present.
         if self.stage == 'Complete':
-            from app.brain.job_log.features.start_install.clear_hard_date_cascade import (
-                clear_hard_date_cascade,
-            )
             if clear_hard_date_cascade(
                 job_record,
                 parent_event_id=event.id,

--- a/app/brain/job_log/routes.py
+++ b/app/brain/job_log/routes.py
@@ -29,6 +29,7 @@ from app.models import Releases, db, ReleaseEvents, Submittals, User
 from app.auth.utils import login_required, get_current_user, admin_required
 from app.route_utils import handle_errors, require_json, get_or_404
 from app.api.helpers import DEFAULT_FAB_ORDER
+from app.brain.job_log.features.start_install.clear_hard_date_cascade import clear_hard_date_cascade
 from datetime import datetime
 import json
 import hashlib
@@ -1183,9 +1184,6 @@ def update_job_comp(job, release):
             response_extras['fab_order'] = None
 
     if new_is_x and not old_was_x and primary_event is not None:
-        from app.brain.job_log.features.start_install.clear_hard_date_cascade import (
-            clear_hard_date_cascade,
-        )
         if clear_hard_date_cascade(
             job_record,
             parent_event_id=primary_event.id,
@@ -1240,9 +1238,6 @@ def update_invoiced(job, release):
     old_was_x = old_invoiced and old_invoiced.strip().upper() == 'X'
     new_is_x = invoiced_str and invoiced_str.upper() == 'X'
     if new_is_x and not old_was_x and primary_event is not None:
-        from app.brain.job_log.features.start_install.clear_hard_date_cascade import (
-            clear_hard_date_cascade,
-        )
         if clear_hard_date_cascade(
             job_record,
             parent_event_id=primary_event.id,


### PR DESCRIPTION
## What
Move the three `from ... import clear_hard_date_cascade` blocks from inside conditional branches to module-level imports in `stage/command.py` and `routes.py` (two sites).

## Why
The inline imports were introduced in #175 with no circular-import justification — `clear_hard_date_cascade` only imports from `app.models`, `app.services.job_event_service`, and `app.logging_config`, none of which import back into `stage/command.py` or `routes.py`. Inline imports inside conditionals imply "I couldn't import this at the top for a reason," which distracts readers and invites future authors to copy the pattern. Moving them to module-level removes that false signal and follows standard Python conventions. Smoothness — cleaner code is easier to reason about.

## Behavior preservation
Pure import location change. Python caches modules in `sys.modules`, so behavior is identical whether the import happens at module load or at first call. 445 tests pass before and after.

## Risk
Low — no logic changed, no new imports introduced.

https://claude.ai/code/session_01S2DY1E4MgbdUb2FoM4cdrt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2DY1E4MgbdUb2FoM4cdrt)_