### PR TITLE
Remove dead code from pdf_markup feature

### DIFF
--- a/app/brain/job_log/features/pdf_markup/payloads.py
+++ b/app/brain/job_log/features/pdf_markup/payloads.py
@@ -1,18 +1,5 @@
 """Request/response shapes for the PDF markup feature."""
 
-from dataclasses import dataclass
-from typing import Optional
-
-
-@dataclass
-class UploadDrawingRequest:
-    file_bytes: bytes
-    filename: Optional[str]
-    mime_type: str
-    note: Optional[str] = None
-    source_version_id: Optional[int] = None
-
-
 PDF_MAGIC = b'%PDF-'
 
 

--- a/app/brain/job_log/pdf_markup_routes.py
+++ b/app/brain/job_log/pdf_markup_routes.py
@@ -18,7 +18,6 @@ from app.auth.utils import (
 from app.models import (
     Releases,
     ReleaseDrawingVersion,
-    User,
     db,
 )
 from app.services.job_event_service import JobEventService
@@ -32,14 +31,6 @@ from app.brain.job_log.features.pdf_markup.payloads import is_pdf_bytes
 from app.brain.job_log.features.pdf_markup.storage import absolute_path
 
 logger = get_logger(__name__)
-
-
-def _resolve_user_display_name(user: User) -> str:
-    if not user:
-        return None
-    first = (user.first_name or '').strip()
-    last = (user.last_name or '').strip()
-    return (f"{first} {last}".strip()) or user.username
 
 
 @brain_bp.route('/releases/<int:release_id>/drawing', methods=['POST'])


### PR DESCRIPTION
## What
Delete two never-called definitions added in #182:
- `_resolve_user_display_name` in `pdf_markup_routes.py` — defined but never imported or called anywhere. Removes the now-unused `User` import along with it.
- `UploadDrawingRequest` dataclass in `pdf_markup/payloads.py` — defined but never imported or instantiated; `upload_release_drawing` reads request fields directly. Removes the unused `dataclass`/`Optional` imports.

## Why
Dead functions in a new module are the highest-cost form of dead code — they look like active contracts to future readers, implying "something calls this." Both definitions were shipped with #182 but never wired to a caller. Removing them keeps the pdf_markup surface exactly as large as what the routes actually use. Smoothness: a module that does exactly what it says is easier to reason about.

## Behavior preservation
No callers exist. `grep -rn "_resolve_user_display_name\|UploadDrawingRequest"` returns only the definition sites. 460 tests pass before and after, including the full `tests/brain/test_pdf_markup.py` suite.

## Risk
Low — pure deletion of unreachable code.

https://claude.ai/code/session_01HGhXYXkvHN8Gem3WV7BazH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGhXYXkvHN8Gem3WV7BazH)_