### PR TITLE
Promote User import to module level in pdf_markup/command.py

### DIFF
--- a/app/brain/job_log/features/pdf_markup/command.py
+++ b/app/brain/job_log/features/pdf_markup/command.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from sqlalchemy import func
 
-from app.models import Releases, ReleaseDrawingVersion, db
+from app.models import Releases, ReleaseDrawingVersion, User, db
 from app.services.job_event_service import JobEventService
 from app.logging_config import get_logger
 
@@ -24,7 +24,6 @@ logger = get_logger(__name__)
 def _username_suffix(user_id: Optional[int]) -> str:
     if not user_id:
         return "Brain"
-    from app.models import User
     user = db.session.get(User, user_id)
     if not user:
         return "Brain"


### PR DESCRIPTION
## What
Move `from app.models import User` from inside `_username_suffix` to the module-level `from app.models import` line in `app/brain/job_log/features/pdf_markup/command.py`.

## Why
The inline import signals "I couldn't import this at the top for a reason" — but `User` lives in `app.models`, which has no back-reference to this feature module. There is no circular-import justification. This is the same class of cleanup as #177, #178, #180, #192. Removing the false signal makes the module's dependency graph read correctly. Smoothness.

## Behavior preservation
Pure import location change; Python caches modules in `sys.modules`. 15 pdf_markup tests and all 460 suite tests pass before and after.

## Risk
Low — import location change only. Same as prior series.

https://claude.ai/code/session_01HGhXYXkvHN8Gem3WV7BazH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGhXYXkvHN8Gem3WV7BazH)_