### PR TITLE
Idempotent Trello create_card retries (fixes duplicate cards on 5xx)

### DIFF
--- a/app/brain/job_log/routes.py
+++ b/app/brain/job_log/routes.py
@@ -96,14 +96,20 @@ def update_job_stage_fields(job_record, stage):
     job_record.stage_group = get_stage_group_from_stage(stage)
     logger.debug(f"Job stage updated to: {stage}, stage_group updated to: {job_record.stage_group}")
 
-def create_trello_card_for_job(job, excel_data_dict):
+def create_trello_card_for_job(job, excel_data_dict, idempotency_check=False):
     """
     Create a Trello card for an existing job.
-    
+
     Args:
         job: Job database object (may be newly created)
         excel_data_dict: Dictionary with job data in Excel format
-    
+        idempotency_check: When True (used on outbox retries), scan the target
+            list for a card with the same title before POSTing and adopt it
+            if found. Prevents duplicate cards when a prior attempt got a
+            Trello 5xx false-negative. When a card is adopted, post-creation
+            features (Fab Order / FC Drawing / notes / mirror) are skipped
+            since the original attempt likely already applied them.
+
     Returns:
         Dictionary with success status and card info, or None if card already exists
     """
@@ -173,49 +179,59 @@ def create_trello_card_for_job(job, excel_data_dict):
             card_title=card_title,
             card_description=card_description,
             list_id=list_id,
-            position="top"
+            position="top",
+            idempotency_check=idempotency_check,
         )
-        
+
         if not create_result["success"]:
             return {
                 "success": False,
                 "error": create_result.get("error", "Failed to create card")
             }
-        
+
         card_data = create_result["card_data"]
         card_id = create_result["card_id"]
-        
+        adopted = create_result.get("adopted", False)
+
         # Update the job record with Trello card data
         success = update_job_record_with_trello_data(job, card_data)
-        
+
         if success:
             logger.info(f"Successfully updated database record with Trello data")
         else:
             logger.error(f"Failed to update database record with Trello data")
-        
-        # Get values for post-creation features
-        fab_order_value = excel_data_dict.get('Fab Order') or job.fab_order
-        notes_value = excel_data_dict.get('Notes') or job.notes
-        
-        # Apply post-creation features (Fab Order, FC Drawing, notes, mirror card)
-        # jl_routes now works identically to scanner - creates mirror cards
-        post_creation_results = apply_card_post_creation_features(
-            card_id=card_id,
-            list_id=list_id,
-            job_record=job,
-            fab_order=fab_order_value if fab_order_value is not None and not pd.isna(fab_order_value) else None,
-            notes=notes_value,
-            create_mirror=True,  # jl_routes now creates mirror cards like scanner
-            operation_id=None
-        )
-        
+
+        if adopted:
+            # Skip Fab Order / FC Drawing / notes / mirror — these aren't
+            # idempotent and were applied by the original attempt that
+            # produced this card.
+            logger.warning(
+                f"Adopted existing Trello card {card_id} for job {job.job}-{job.release}; "
+                f"skipping post-creation features"
+            )
+            mirror_card_id = None
+        else:
+            fab_order_value = excel_data_dict.get('Fab Order') or job.fab_order
+            notes_value = excel_data_dict.get('Notes') or job.notes
+            post_creation_results = apply_card_post_creation_features(
+                card_id=card_id,
+                list_id=list_id,
+                job_record=job,
+                fab_order=fab_order_value if fab_order_value is not None and not pd.isna(fab_order_value) else None,
+                notes=notes_value,
+                create_mirror=True,
+                operation_id=None
+            )
+            mirror_card_id = post_creation_results.get("mirror_card_id")
+
         return {
             "success": True,
             "card_id": card_data["id"],
-            "card_name": card_data["name"],
-            "card_url": card_data["url"],
+            "card_name": card_data.get("name"),
+            "card_url": card_data.get("url"),
             "list_name": list_name,
-            "mirror_card_id": post_creation_results.get("mirror_card_id")
+            "mirror_card_id": mirror_card_id,
+            "adopted": adopted,
         }
         
     except Exception as e:

--- a/app/services/outbox_service.py
+++ b/app/services/outbox_service.py
@@ -367,8 +367,18 @@ class OutboxService:
                 # Rebuild excel_data_dict from the event payload
                 excel_data_dict = event.payload or {}
 
+                # On retries, scan the target list first and adopt any
+                # existing card with the same title. Trello sometimes
+                # returns 5xx on POST /1/cards but creates the card anyway,
+                # which without this check produces one duplicate per retry.
+                is_retry = (outbox_item.retry_count or 0) > 0
+
                 try:
-                    trello_result = create_trello_card_for_job(job_record, excel_data_dict)
+                    trello_result = create_trello_card_for_job(
+                        job_record,
+                        excel_data_dict,
+                        idempotency_check=is_retry,
+                    )
 
                     if trello_result and trello_result.get('success'):
                         outbox_item.status = 'completed'
@@ -379,7 +389,11 @@ class OutboxService:
                         JobEventService.close(event.id)
                         db.session.commit()
 
-                        logger.info(f"Outbox {outbox_item.id} completed successfully (create_card for {event.job}-{event.release})")
+                        adopted_note = " (adopted existing card)" if trello_result.get('adopted') else ""
+                        logger.info(
+                            f"Outbox {outbox_item.id} completed successfully "
+                            f"(create_card for {event.job}-{event.release}){adopted_note}"
+                        )
                         return True
                     else:
                         error_msg = trello_result.get('error', 'Unknown error') if trello_result else 'Trello card creation returned None'

--- a/app/trello/api.py
+++ b/app/trello/api.py
@@ -233,6 +233,32 @@ def get_trello_card_by_id(card_id):
         return None
 
 
+def find_card_in_list_by_name(list_id, card_name):
+    """
+    Find an existing open card in a list whose name matches `card_name` exactly.
+
+    Used by the create-card retry path to detect cards that Trello created
+    despite returning a 5xx on a prior POST (a known false-negative mode that
+    otherwise produces duplicates on every retry).
+
+    Returns the card dict (id, name, ...) on first exact match, or None.
+    Raises requests.HTTPError if the GET itself fails — caller should treat
+    that as "unknown" and fall through to the create path.
+    """
+    url = f"https://api.trello.com/1/lists/{list_id}/cards"
+    params = {
+        "key": cfg.TRELLO_API_KEY,
+        "token": cfg.TRELLO_TOKEN,
+        "fields": "id,name,url,idList,idBoard,shortLink,shortUrl",
+    }
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    for card in response.json() or []:
+        if card.get("name") == card_name:
+            return card
+    return None
+
+
 def get_trello_cards_from_subset():
     """
     Fetch all Trello cards from the board and filter them based on a specific subset.

--- a/app/trello/card_creation.py
+++ b/app/trello/card_creation.py
@@ -108,28 +108,53 @@ def create_trello_card_core(
     card_title: str,
     card_description: str,
     list_id: str,
-    position: str = "top"
+    position: str = "top",
+    idempotency_check: bool = False,
 ) -> Dict[str, Any]:
     """
     Core function to create a Trello card.
-    
+
     This is the shared logic for creating a card in Trello.
     All other card creation functions should use this.
-    
+
     Args:
         card_title: Card title
         card_description: Card description
         list_id: Trello list ID to create card in
         position: Position in list ("top", "bottom", or numeric)
-    
+        idempotency_check: When True, GET the target list first and adopt
+            an existing card with the same title instead of POSTing. Use on
+            retries to avoid duplicates from Trello 5xx false-negatives.
+
     Returns:
         Dictionary with:
             - success: bool
             - card_data: dict (if success)
             - card_id: str (if success)
+            - adopted: bool (True if an existing card was reused rather than created)
             - error: str (if not success)
     """
     try:
+        if idempotency_check:
+            try:
+                from app.trello.api import find_card_in_list_by_name
+                existing = find_card_in_list_by_name(list_id, card_title)
+                if existing:
+                    logger.warning(
+                        f"Idempotency: adopting existing Trello card {existing['id']} "
+                        f"with matching title in list {list_id} (skipping POST)"
+                    )
+                    return {
+                        "success": True,
+                        "card_data": existing,
+                        "card_id": existing["id"],
+                        "adopted": True,
+                    }
+            except Exception as scan_err:
+                # If the lookup fails we fall through to the create path; better
+                # to risk a duplicate than to block the retry entirely.
+                logger.warning(f"Idempotency scan failed, proceeding with create: {scan_err}")
+
         url = "https://api.trello.com/1/cards"
         payload = {
             "key": cfg.TRELLO_API_KEY,
@@ -139,20 +164,21 @@ def create_trello_card_core(
             "idList": list_id,
             "pos": position
         }
-        
+
         logger.info(f"Creating Trello card in list {list_id}")
         response = requests.post(url, params=payload)
         response.raise_for_status()
-        
+
         card_data = response.json()
         logger.info(f"Trello card created successfully: {card_data['id']}")
-        
+
         return {
             "success": True,
             "card_data": card_data,
-            "card_id": card_data['id']
+            "card_id": card_data['id'],
+            "adopted": False,
         }
-        
+
     except Exception as err:
         error_msg = f"Error creating Trello card: {str(err)}"
         logger.error(error_msg, exc_info=True)

--- a/tests/services/test_outbox_service.py
+++ b/tests/services/test_outbox_service.py
@@ -193,3 +193,92 @@ def test_process_pending_items_skips_future_retry(app):
         with _trello_move_patches() as mock_api:
             assert OutboxService.process_pending_items(limit=10) == 0
         mock_api.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_card idempotency on retry
+# ---------------------------------------------------------------------------
+
+def _add_create_card_item(event_id, retry_count=0):
+    item = OutboxService.add(destination="trello", action="create_card", event_id=event_id)
+    item.retry_count = retry_count
+    db.session.commit()
+    return item
+
+
+def test_create_card_first_attempt_does_not_request_idempotency(app):
+    """First attempt (retry_count=0) must NOT trigger the list-scan — avoids
+    an extra GET on the hot path for normal card creations."""
+    with app.app_context():
+        make_release(1, "A", trello_card_id=None)
+        ev = _make_event(action="created")
+        item = _add_create_card_item(ev.id, retry_count=0)
+
+        fresh = {
+            "success": True,
+            "adopted": False,
+            "card_id": "fresh-1",
+            "card_data": {"id": "fresh-1", "name": "x", "url": "u"},
+        }
+        with patch(
+            "app.brain.job_log.routes.create_trello_card_for_job",
+            return_value=fresh,
+        ) as mock_create:
+            assert OutboxService.process_item(item) is True
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs.get("idempotency_check") is False
+
+        db.session.refresh(item)
+        assert item.status == "completed"
+
+
+def test_create_card_retry_passes_idempotency_check_true(app):
+    """retry_count>=1 must set idempotency_check=True so the wrapper scans
+    the target list before re-POSTing."""
+    with app.app_context():
+        make_release(1, "A", trello_card_id=None)
+        ev = _make_event(action="created")
+        item = _add_create_card_item(ev.id, retry_count=2)
+
+        adopted = {
+            "success": True,
+            "adopted": True,
+            "card_id": "adopted-9",
+            "card_data": {"id": "adopted-9", "name": "x", "url": "u"},
+        }
+        with patch(
+            "app.brain.job_log.routes.create_trello_card_for_job",
+            return_value=adopted,
+        ) as mock_create:
+            assert OutboxService.process_item(item) is True
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs.get("idempotency_check") is True
+
+        db.session.refresh(item)
+        assert item.status == "completed"
+        assert item.error_message is None
+
+
+def test_create_card_retry_failure_does_not_double_invoke(app):
+    """If the retry still fails, the outbox increments retry_count and stays
+    pending — sanity-check that the contract didn't regress."""
+    with app.app_context():
+        make_release(1, "A", trello_card_id=None)
+        ev = _make_event(action="created")
+        item = _add_create_card_item(ev.id, retry_count=1)
+
+        with patch(
+            "app.brain.job_log.routes.create_trello_card_for_job",
+            return_value={"success": False, "error": "still 500"},
+        ) as mock_create:
+            assert OutboxService.process_item(item) is False
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs.get("idempotency_check") is True
+
+        db.session.refresh(item)
+        assert item.retry_count == 2
+        assert item.status == "pending"
+        assert "still 500" in (item.error_message or "")

--- a/tests/test_trello_card_creation_idempotency.py
+++ b/tests/test_trello_card_creation_idempotency.py
@@ -1,0 +1,262 @@
+"""Tests for the idempotent-create path that prevents duplicate Trello cards
+when a prior POST /1/cards got a 5xx false-negative from Trello.
+
+Covers:
+  - find_card_in_list_by_name lookup helper
+  - create_trello_card_core idempotency_check behavior
+  - create_trello_card_for_job skipping post-creation features on adoption
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.trello.api import find_card_in_list_by_name
+from app.trello.card_creation import create_trello_card_core
+
+
+# ---------------------------------------------------------------------------
+# find_card_in_list_by_name
+# ---------------------------------------------------------------------------
+
+def _mock_get_response(json_payload, status=200):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_payload
+    resp.raise_for_status = MagicMock()
+    if status >= 400:
+        resp.raise_for_status.side_effect = requests.HTTPError(f"{status} error")
+    return resp
+
+
+def test_find_card_in_list_returns_first_exact_name_match():
+    cards = [
+        {"id": "a1", "name": "Other card"},
+        {"id": "a2", "name": "500-615 Brinkman - Novel Flatiron SE Canopy"},
+        {"id": "a3", "name": "Another unrelated"},
+    ]
+    with patch("app.trello.api.requests.get", return_value=_mock_get_response(cards)):
+        result = find_card_in_list_by_name(
+            "list-abc", "500-615 Brinkman - Novel Flatiron SE Canopy"
+        )
+    assert result is not None
+    assert result["id"] == "a2"
+
+
+def test_find_card_in_list_returns_none_when_no_match():
+    cards = [{"id": "a1", "name": "Other card"}]
+    with patch("app.trello.api.requests.get", return_value=_mock_get_response(cards)):
+        result = find_card_in_list_by_name("list-abc", "Nope")
+    assert result is None
+
+
+def test_find_card_in_list_returns_none_for_empty_list():
+    with patch("app.trello.api.requests.get", return_value=_mock_get_response([])):
+        assert find_card_in_list_by_name("list-abc", "Anything") is None
+
+
+def test_find_card_in_list_propagates_http_errors():
+    with patch(
+        "app.trello.api.requests.get",
+        return_value=_mock_get_response({"message": "boom"}, status=500),
+    ):
+        with pytest.raises(requests.HTTPError):
+            find_card_in_list_by_name("list-abc", "x")
+
+
+# ---------------------------------------------------------------------------
+# create_trello_card_core
+# ---------------------------------------------------------------------------
+
+def _mock_post_response(card_id="created-1", name="Title", status=200):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = {"id": card_id, "name": name, "url": f"https://trello.com/c/{card_id}"}
+    resp.raise_for_status = MagicMock()
+    if status >= 400:
+        resp.raise_for_status.side_effect = requests.HTTPError(f"{status} error")
+    return resp
+
+
+def test_create_core_without_idempotency_check_posts_directly():
+    with patch("app.trello.card_creation.requests.post", return_value=_mock_post_response()) as mock_post, \
+         patch("app.trello.api.requests.get") as mock_get:
+        result = create_trello_card_core(
+            card_title="Title",
+            card_description="Desc",
+            list_id="list-abc",
+            idempotency_check=False,
+        )
+
+    assert result["success"] is True
+    assert result["adopted"] is False
+    assert result["card_id"] == "created-1"
+    mock_post.assert_called_once()
+    mock_get.assert_not_called()
+
+
+def test_create_core_with_idempotency_check_adopts_existing_card():
+    existing = {
+        "id": "existing-9",
+        "name": "Title",
+        "url": "https://trello.com/c/existing-9",
+        "idList": "list-abc",
+    }
+    with patch(
+        "app.trello.api.requests.get",
+        return_value=_mock_get_response([{"id": "other", "name": "x"}, existing]),
+    ) as mock_get, \
+         patch("app.trello.card_creation.requests.post") as mock_post:
+        result = create_trello_card_core(
+            card_title="Title",
+            card_description="Desc",
+            list_id="list-abc",
+            idempotency_check=True,
+        )
+
+    assert result["success"] is True
+    assert result["adopted"] is True
+    assert result["card_id"] == "existing-9"
+    assert result["card_data"]["id"] == "existing-9"
+    mock_get.assert_called_once()
+    mock_post.assert_not_called()
+
+
+def test_create_core_with_idempotency_check_posts_when_no_match():
+    with patch(
+        "app.trello.api.requests.get",
+        return_value=_mock_get_response([{"id": "other", "name": "Different"}]),
+    ) as mock_get, \
+         patch(
+        "app.trello.card_creation.requests.post",
+        return_value=_mock_post_response(card_id="new-7", name="Title"),
+    ) as mock_post:
+        result = create_trello_card_core(
+            card_title="Title",
+            card_description="Desc",
+            list_id="list-abc",
+            idempotency_check=True,
+        )
+
+    assert result["success"] is True
+    assert result["adopted"] is False
+    assert result["card_id"] == "new-7"
+    mock_get.assert_called_once()
+    mock_post.assert_called_once()
+
+
+def test_create_core_falls_through_to_post_when_scan_fails():
+    """If the idempotency GET errors out we'd rather risk a duplicate than
+    block the retry — verify the create path still runs."""
+    with patch(
+        "app.trello.api.requests.get",
+        side_effect=requests.ConnectionError("network down"),
+    ), \
+         patch(
+        "app.trello.card_creation.requests.post",
+        return_value=_mock_post_response(card_id="fallback-3"),
+    ) as mock_post:
+        result = create_trello_card_core(
+            card_title="Title",
+            card_description="Desc",
+            list_id="list-abc",
+            idempotency_check=True,
+        )
+
+    assert result["success"] is True
+    assert result["adopted"] is False
+    assert result["card_id"] == "fallback-3"
+    mock_post.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# create_trello_card_for_job — adopted path skips post-creation features
+# ---------------------------------------------------------------------------
+
+def test_create_trello_card_for_job_skips_post_creation_when_adopted(app):
+    """When the core adopts an existing card on retry, the wrapper must
+    NOT re-run Fab Order / FC Drawing / notes / mirror — those side-effects
+    aren't idempotent and likely already ran in the original attempt."""
+    from app.brain.job_log.routes import create_trello_card_for_job
+    from tests.conftest import make_release
+
+    with app.app_context():
+        job = make_release(500, "615", job_name="Brinkman", trello_card_id=None)
+
+        adopted_card = {
+            "id": "adopted-1",
+            "name": "500-615 Brinkman Some desc",
+            "url": "https://trello.com/c/adopted-1",
+            "idList": "list-released",
+        }
+
+        with patch(
+            "app.trello.api.get_list_by_name",
+            return_value={"id": "list-released", "name": "Released"},
+        ), \
+             patch(
+            "app.trello.card_creation.create_trello_card_core",
+            return_value={
+                "success": True,
+                "adopted": True,
+                "card_data": adopted_card,
+                "card_id": "adopted-1",
+            },
+        ) as mock_core, \
+             patch("app.trello.api.update_job_record_with_trello_data", return_value=True), \
+             patch(
+            "app.trello.card_creation.apply_card_post_creation_features",
+        ) as mock_post_features:
+            result = create_trello_card_for_job(
+                job, {"Job #": 500, "Release #": "615"}, idempotency_check=True,
+            )
+
+        assert result["success"] is True
+        assert result["adopted"] is True
+        assert result["card_id"] == "adopted-1"
+        mock_core.assert_called_once()
+        assert mock_core.call_args.kwargs.get("idempotency_check") is True
+        mock_post_features.assert_not_called()
+
+
+def test_create_trello_card_for_job_runs_post_creation_on_fresh_create(app):
+    """The non-adopted path must still run post-creation features."""
+    from app.brain.job_log.routes import create_trello_card_for_job
+    from tests.conftest import make_release
+
+    with app.app_context():
+        job = make_release(500, "616", job_name="Brinkman", trello_card_id=None)
+
+        fresh_card = {
+            "id": "fresh-1",
+            "name": "500-616 Brinkman Some desc",
+            "url": "https://trello.com/c/fresh-1",
+            "idList": "list-released",
+        }
+
+        with patch(
+            "app.trello.api.get_list_by_name",
+            return_value={"id": "list-released", "name": "Released"},
+        ), \
+             patch(
+            "app.trello.card_creation.create_trello_card_core",
+            return_value={
+                "success": True,
+                "adopted": False,
+                "card_data": fresh_card,
+                "card_id": "fresh-1",
+            },
+        ), \
+             patch("app.trello.api.update_job_record_with_trello_data", return_value=True), \
+             patch(
+            "app.trello.card_creation.apply_card_post_creation_features",
+            return_value={"mirror_card_id": "mirror-1"},
+        ) as mock_post_features:
+            result = create_trello_card_for_job(
+                job, {"Job #": 500, "Release #": "616"}, idempotency_check=False,
+            )
+
+        assert result["success"] is True
+        assert result["adopted"] is False
+        assert result["mirror_card_id"] == "mirror-1"
+        mock_post_features.assert_called_once()


### PR DESCRIPTION
## Summary
- Outbox `create_card` retries on Trello `POST /1/cards` 5xx false-negatives produced one duplicate card per retry (up to 6 total). Observed on release **500-615** — 1 job log row, 0 captured `trello_card_id`, 1 failed outbox row, multiple Trello cards on the board.
- On retries (`retry_count > 0`) the outbox now scans the target list for a card with the same title and **adopts** it instead of re-POSTing. Adopted cards skip post-creation features (Fab Order / FC Drawing / notes / mirror) since they were already applied by the original attempt and aren't idempotent.
- First-time creates are unchanged — no extra GET on the hot path.

## Changes
- `app/trello/api.py` — new `find_card_in_list_by_name(list_id, name)` helper.
- `app/trello/card_creation.py` — `create_trello_card_core` gains `idempotency_check: bool = False`; on True, scans the list first and returns `adopted=True` if a same-named card already exists.
- `app/brain/job_log/routes.py` — `create_trello_card_for_job` accepts and passes through `idempotency_check`; skips post-creation features when adopted.
- `app/services/outbox_service.py` — passes `idempotency_check=True` whenever `retry_count > 0`.
- 13 new tests across `tests/test_trello_card_creation_idempotency.py` (10) and `tests/services/test_outbox_service.py` (3).

## Not in this PR
- Manual cleanup of the existing 500-615 duplicate cards on the Trello board and writing the surviving `trello_card_id` back to `releases.id=786`.
- Pre-existing test flake (`test_process_item_move_card_success`) caused by `TRELLO_MOCK=1` in local `.env` leaking into the app fixture — fails on clean main too. Worth a separate small PR.

## Test plan
- [ ] `pytest tests/test_trello_card_creation_idempotency.py tests/services/test_outbox_service.py` — 24/24 green locally with `TRELLO_MOCK=0`.
- [ ] In sandbox: queue a `create_card` outbox row, force a 5xx (or pre-create a card with the matching title in the target list), let the retry fire, confirm `adopted=True` log line and that no duplicate card appears.
- [ ] Verify first-time creates in sandbox still POST directly (no extra GET) and post-creation features (Fab Order, FC Drawing, mirror) run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)