### PR TITLE
Release: staging → main

### DIFF
--- a/frontend/src/hooks/useJumpToHighlight.js
+++ b/frontend/src/hooks/useJumpToHighlight.js
@@ -22,7 +22,7 @@ export const JUMP_TO_HIGHLIGHT_MS = 3500;
 const TABLE_STICKY_HEADER_OFFSET = 44;
 
 /** Selectors for table scroll containers (Job Log, Drafting Work Load, etc.) — scroll only the container, not the page */
-const TABLE_SCROLL_CONTAINER_SELECTORS = '.job-log-table-scroll-hide-scrollbar, .dwl-table-scroll-hide-scrollbar';
+const TABLE_SCROLL_CONTAINER_SELECTORS = '.job-log-table-scroll, .dwl-table-scroll';
 
 /**
  * Scroll a row into view inside a table scroll container only (no page scroll).

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -109,15 +109,10 @@ body>#root>div>div {
   background: #64748b;
 }
 
-/* Hide vertical scrollbar on job log table; scrolling still works via wheel/trackpad */
-.job-log-table-scroll-hide-scrollbar {
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* IE / Edge */
+/* Scroll container for job log / archive tables */
+.job-log-table-scroll {
   overflow-anchor: none; /* Don't auto-scroll to follow rows when sort order changes */
   -webkit-overflow-scrolling: touch; /* Momentum scroll on iOS Safari */
-}
-.job-log-table-scroll-hide-scrollbar::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Edge */
 }
 
 /* Board slide-over animation */

--- a/frontend/src/pages/Archive.jsx
+++ b/frontend/src/pages/Archive.jsx
@@ -18,7 +18,7 @@ import { useJobsFilters } from '../hooks/useJobsFilters';
 import { JobsTableRow } from '../components/JobsTableRow';
 import { BananaCodeHeader } from '../components/StageIconRow';
 import { jobsApi } from '../services/jobsApi';
-import { checkAuth, userWantsVisibleScrollbars } from '../utils/auth';
+import { checkAuth } from '../utils/auth';
 import { HEADER_OVERRIDES } from '../constants/columnHeaders';
 import ViewToggle, { useViewMode } from '../components/ViewToggle';
 import JobLogCardGrid from '../components/JobLogCardGrid';
@@ -29,7 +29,6 @@ function Archive() {
     const { jobs, columns, loading, error: fetchError, refetch } = useArchiveDataFetching();
 
     const [isAdmin, setIsAdmin] = useState(false);
-    const [showScrollbars, setShowScrollbars] = useState(false);
     const [isFilterMinimized, setIsFilterMinimized] = useState(
         () => localStorage.getItem('ar_minimized') === 'true'
     );
@@ -44,10 +43,8 @@ function Archive() {
             try {
                 const user = await checkAuth();
                 setIsAdmin(user?.is_admin || false);
-                setShowScrollbars(userWantsVisibleScrollbars(user));
             } catch {
                 setIsAdmin(false);
-                setShowScrollbars(false);
             }
         };
         fetchUserInfo();
@@ -344,7 +341,7 @@ function Archive() {
 
                         {!loading && !fetchError && effectiveView === 'table' && (
                             <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-xl shadow-sm overflow-hidden flex-1 min-h-0 flex flex-col">
-                                <div className={`${showScrollbars ? '' : 'job-log-table-scroll-hide-scrollbar'} overflow-auto flex-1`.trim()}>
+                                <div className="job-log-table-scroll overflow-auto flex-1">
                                     <table className="w-full" style={{ borderCollapse: 'collapse', tableLayout: 'fixed', width: '100%' }}>
                                         <thead className="sticky top-0 z-10">
                                             <tr>

--- a/frontend/src/pages/DraftingWorkLoad.jsx
+++ b/frontend/src/pages/DraftingWorkLoad.jsx
@@ -25,7 +25,7 @@ import { AlertMessage } from '../components/AlertMessage';
 import { AddProjectModal } from '../components/AddProjectModal';
 import { generateDraftingWorkLoadPDF } from '../utils/pdfUtils';
 import { formatDate, formatCellValue } from '../utils/formatters';
-import { checkAuth, userWantsVisibleScrollbars } from '../utils/auth';
+import { checkAuth } from '../utils/auth';
 import { draftingWorkLoadApi } from '../services/draftingWorkLoadApi';
 import { fetchMentionableUsers } from '../services/notificationApi';
 import { useLocationContext } from '../context/LocationContext';
@@ -36,14 +36,6 @@ import { useBreakpoint, useIsTabletOrSmaller } from '../hooks/useBreakpoint';
 // Responsive column width styles for larger screens (2xl breakpoint: 1536px+)
 // Laptop sizes are kept as default (max-width only), only larger screens get adjusted max-widths
 const columnWidthStyles = `
-    /* Hide scrollbar on table scroll area; scrolling still works via wheel/trackpad */
-    .dwl-table-scroll-hide-scrollbar {
-        scrollbar-width: none; /* Firefox */
-        -ms-overflow-style: none; /* IE / Edge */
-    }
-    .dwl-table-scroll-hide-scrollbar::-webkit-scrollbar {
-        display: none; /* Chrome, Safari, Edge */
-    }
     @media (min-width: 1536px) {
         /* Reduce column max-widths on very large screens to prevent bloating */
         .dwl-col-name { max-width: 260px !important; }
@@ -103,7 +95,6 @@ function DraftingWorkLoad() {
     // User role status
     const [isAdmin, setIsAdmin] = useState(false);
     const [isDrafter, setIsDrafter] = useState(false);
-    const [showScrollbars, setShowScrollbars] = useState(false);
     const [userLoading, setUserLoading] = useState(true);
     const canEditDrafterFields = isAdmin || isDrafter;
 
@@ -114,12 +105,10 @@ function DraftingWorkLoad() {
                 const user = await checkAuth();
                 setIsAdmin(user?.is_admin || false);
                 setIsDrafter(user?.is_drafter || false);
-                setShowScrollbars(userWantsVisibleScrollbars(user));
             } catch (err) {
                 console.error('Error fetching user info:', err);
                 setIsAdmin(false);
                 setIsDrafter(false);
-                setShowScrollbars(false);
             } finally {
                 setUserLoading(false);
             }
@@ -491,10 +480,9 @@ function DraftingWorkLoad() {
 
                         {!loading && !fetchError && effectiveView === 'table' && (
                             <div className="flex-1 min-h-0 flex flex-col border border-gray-200 dark:border-slate-600 rounded-xl overflow-hidden bg-white dark:bg-slate-800 min-w-0">
-                                {/* Scrollbar hidden via CSS; scroll still works with wheel/trackpad */}
                                 <div
                                     ref={scrollContainerRef}
-                                    className={`${showScrollbars ? '' : 'dwl-table-scroll-hide-scrollbar'} flex-1 min-h-0 overflow-x-hidden`.trim()}
+                                    className="dwl-table-scroll flex-1 min-h-0 overflow-x-hidden"
                                     style={{ overflowY: 'auto' }}
                                 >
                                     <table className="w-full" style={{ borderCollapse: 'collapse', width: '100%', tableLayout: 'fixed' }}>

--- a/frontend/src/pages/JobLog.jsx
+++ b/frontend/src/pages/JobLog.jsx
@@ -22,7 +22,7 @@ import { useJobsDragAndDrop } from '../hooks/useJobsDragAndDrop';
 import { JobsTableRow } from '../components/JobsTableRow';
 import { BananaCodeHeader } from '../components/StageIconRow';
 import { jobsApi } from '../services/jobsApi';
-import { checkAuth, userWantsVisibleScrollbars } from '../utils/auth';
+import { checkAuth } from '../utils/auth';
 import { generateJobLogReviewPdf } from '../utils/jobLogPdf';
 import { isCompleteStage } from '../utils/stageProgress';
 import { formatDateShort, formatCellValue } from '../utils/formatters';
@@ -123,7 +123,6 @@ function JobLog() {
     );
     const [isAdmin, setIsAdmin] = useState(false);
     const [isDrafter, setIsDrafter] = useState(false);
-    const [showScrollbars, setShowScrollbars] = useState(false);
     const [isFilterMinimized, setIsFilterMinimized] = useState(
         () => localStorage.getItem('jl_minimized') === 'true'
     );
@@ -178,12 +177,10 @@ function JobLog() {
                 const user = await checkAuth();
                 setIsAdmin(user?.is_admin || false);
                 setIsDrafter(user?.is_drafter || false);
-                setShowScrollbars(userWantsVisibleScrollbars(user));
             } catch (err) {
                 console.error('Error fetching user info:', err);
                 setIsAdmin(false);
                 setIsDrafter(false);
-                setShowScrollbars(false);
             }
         };
         fetchUserInfo();
@@ -951,7 +948,7 @@ function JobLog() {
                                 <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-xl shadow-sm overflow-hidden flex-1 min-h-0 flex flex-col">
                                     <div
                                         ref={tableScrollRef}
-                                        className={`${showScrollbars ? '' : 'job-log-table-scroll-hide-scrollbar'} overflow-auto flex-1`.trim()}
+                                        className="job-log-table-scroll overflow-auto flex-1"
                                     >
                                         <table className="w-full" style={{ borderCollapse: 'collapse', tableLayout: 'fixed', width: '100%' }}>
                                             <thead className="sticky top-0 z-10">

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -40,13 +40,6 @@ export const logout = async () => {
     }
 };
 
-// Users opted in to native scrollbars on Job Log / DWL / Archive tables.
-// Usernames are stored lowercased server-side; compare lowercased.
-const USERS_WITH_VISIBLE_SCROLLBARS = new Set(['khearn@mhmw.com']);
-
-export const userWantsVisibleScrollbars = (user) =>
-    !!user?.username && USERS_WITH_VISIBLE_SCROLLBARS.has(user.username.toLowerCase());
-
 // Monthly invoicing report is visible to khearn plus any admin.
 export const userCanAccessInvoicing = (user) =>
     !!user && (user.is_admin || (user.username || '').toLowerCase() === 'khearn@mhmw.com');


### PR DESCRIPTION
## Summary

Promotes everything currently on `staging` to `main`. This is an accumulated release (~75 feature commits ahead of main), most recently including:

- **Show native scrollbars** on the Job Log, Drafting Workload, and Archive tables for all users (previously hidden behind a single-user allowlist).
- Job Log: removed the reschedule button, secondary search + `-` lookup, filter tooltips, admin CSV export, print improvements, banana urgency display.
- DWL: fab-order handling for off-status submittals, note @mentions, status-change/note admin gating.
- Job–release identifier collision detection and handling.
- Bug tracker card-ordering fix and drag-n-drop.
- Stage ordering changes (Material Ordered between Released and Cut Start), Review filter improvements, calendar entry modal on the hard-date picker.
- Various scheduling/config fixes, archive scripts, and dev webhook tooling.

## Test plan

- [ ] CI passes on the merge commit
- [ ] Smoke-test Job Log, Drafting Workload, and Archive in staging: tables scroll with a visible scrollbar and sticky headers stay pinned
- [ ] Verify jump-to-row deep links (`?highlight=...`) still scroll/highlight correctly
- [ ] Confirm no regressions in the recently changed Job Log / DWL flows above

https://claude.ai/code/session_01J6X27be3JaThy1bTaTUYbo

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6X27be3JaThy1bTaTUYbo)_