### PR TITLE
Color Start install cells by schedule health on Job Log

### DIFF
--- a/frontend/src/components/JobsTableRow.jsx
+++ b/frontend/src/components/JobsTableRow.jsx
@@ -1158,9 +1158,21 @@ export function JobsTableRow({ row, columns, formatCellValue, formatDate, rowInd
                         // IMPORTANT: avoid conflicting bg-* utilities (Tailwind utility order, not class string order,
                         // determines the winner). If we include both rowBgClass and bg-red-500, the row bg can win,
                         // leaving white text on a light background (looks blank until hover).
-                        const startInstallBgClass = (isAsap || isHardDate)
-                            ? 'bg-red-500 text-white hover:bg-red-600 font-semibold'
-                            : `${rowBgClass} text-gray-900 dark:text-slate-100 hover:bg-accent-50 dark:hover:bg-slate-600`;
+                        // Hard dates compare to today's LOCAL date (toISOString would shift to UTC).
+                        const now = new Date();
+                        const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+                        const installDay = String(localStartInstall ?? '').split('T')[0];
+                        const isHardDatePast = isHardDate && installDay < todayStr;
+                        let startInstallBgClass;
+                        if (isAsap) {
+                            startInstallBgClass = 'bg-red-500 text-white hover:bg-red-600 font-semibold';
+                        } else if (isHardDatePast) {
+                            startInstallBgClass = 'bg-yellow-400 text-gray-900 hover:bg-yellow-500 font-semibold';
+                        } else if (isHardDate) {
+                            startInstallBgClass = 'bg-green-500 text-white hover:bg-green-600 font-semibold';
+                        } else {
+                            startInstallBgClass = `${rowBgClass} text-gray-900 dark:text-slate-100 hover:bg-accent-50 dark:hover:bg-slate-600`;
+                        }
 
                         const titleText = isAsap
                             ? 'ASAP — release will jump from Paint Complete to Shipping Planning. Click to edit.'


### PR DESCRIPTION
## Summary
- Recolors the **Start install** date cells on the Job Log to communicate scheduling health instead of a flat red.
- **ASAP** → red (unchanged), **hard date today or in the future** → green, **hard date one or more days in the past** → yellow.
- Formula-driven and empty cells are unchanged (default row background).
- Date comparison uses the browser's **local** date (not `toISOString()`, which would drift to UTC and could flip the today→yesterday boundary by a day), operating on the ISO `YYYY-MM-DD` strings the API already returns.

Single-file change: `frontend/src/components/JobsTableRow.jsx` (the `Start install` cell branch).

## Test plan
- [x] `npm run lint` — no new lint problems (pre-existing errors only, unrelated lines).
- [x] `npm run build` — compiles successfully.
- [x] In a browser, set a hard date to yesterday / today / tomorrow via the Start Install modal and confirm yellow / green / green respectively.
- [x] Confirm ASAP stays red, formula-driven and empty cells keep the default background.
- [x] Confirm dark-mode rows render correctly and text stays legible on green (white text) and yellow (dark text).

https://claude.ai/code/session_01UZwLxrt67e1E1Mayx2denH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZwLxrt67e1E1Mayx2denH)_