### PR TITLE
Meeting → checklist → to-do/notify (MVP) + HITL demo

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -117,6 +117,28 @@ def init_scheduler(app):
         replace_existing=True,
     )
 
+    # --- Checklist deadline notifications (daily 6:00 AM Mountain Time) ---
+    # Pings the owner of each accepted post-meeting to-do whose due date is near
+    # or overdue (deduped via ChecklistItem.last_notified_at).
+    def checklist_due_scan():
+        from app.brain.meetings.service import notify_due_items
+        with app.app_context():
+            try:
+                notify_due_items()
+            except Exception as e:
+                logger.error("Checklist due scan failed", error=str(e), exc_info=True)
+
+    scheduler.add_job(
+        func=checklist_due_scan,
+        trigger="cron",
+        hour=6,
+        minute=0,
+        timezone="America/Denver",
+        id="checklist_due_scan",
+        name="Checklist Deadline Notifications",
+        replace_existing=True,
+    )
+
     scheduler.start()
     atexit.register(lambda: scheduler.shutdown(wait=False))
 
@@ -138,6 +160,12 @@ def init_scheduler(app):
             "name": "FC PDF Pack Retry",
             "schedule": "Daily at 02:00 America/Denver",
             "description": "Retry Procore FC viewer_url for releases missing it (last 7 days)",
+        },
+        {
+            "id": "checklist_due_scan",
+            "name": "Checklist Deadline Notifications",
+            "schedule": "Daily at 06:00 America/Denver",
+            "description": "Notify owners of accepted post-meeting to-dos that are due soon/overdue",
         },
     ]
 

--- a/app/brain/__init__.py
+++ b/app/brain/__init__.py
@@ -32,4 +32,5 @@ from app.brain.job_log import pdf_markup_routes  # noqa: F401  (registers /relea
 from app.brain.drafting_work_load import routes as dwl_routes
 from app.brain.map import routes as map_routes
 from app.brain.board import routes as board_routes
+from app.brain.meetings import routes as meetings_routes
 from app.brain import notification_routes

--- a/app/brain/job_log/features/stage/command.py
+++ b/app/brain/job_log/features/stage/command.py
@@ -171,9 +171,11 @@ class UpdateStageCommand:
 
         extras: dict = {}
 
-        # job_comp cascade. Linked events get `parent_event_id` so the undo
-        # endpoint can find them and bundle their reverts with the parent's.
-        if self.stage == 'Complete':
+        # job_comp cascade. 'Install Complete' is the install-progress completion
+        # marker (job_comp='X'); 'Complete' is inert toward Install Prog. Linked
+        # events get `parent_event_id` so the undo endpoint can find them and
+        # bundle their reverts with the parent's.
+        if self.stage == 'Install Complete':
             current_job_comp = (job_record.job_comp or '').strip().upper()
             if current_job_comp != 'X':
                 old_jc = job_record.job_comp
@@ -185,12 +187,12 @@ class UpdateStageCommand:
                         'field': 'job_comp',
                         'old_value': old_jc,
                         'new_value': 'X',
-                        'reason': 'stage_set_to_complete',
+                        'reason': 'stage_set_to_install_complete',
                         'parent_event_id': event.id,
                     },
                 )
                 extras['job_comp'] = 'X'
-        elif old_stage == 'Complete' and self.stage != 'Complete':
+        elif old_stage == 'Install Complete' and self.stage != 'Install Complete':
             current_job_comp = (job_record.job_comp or '').strip().upper()
             if current_job_comp == 'X':
                 old_jc = job_record.job_comp
@@ -202,19 +204,25 @@ class UpdateStageCommand:
                         'field': 'job_comp',
                         'old_value': old_jc,
                         'new_value': None,
-                        'reason': 'stage_changed_from_complete',
+                        'reason': 'stage_changed_from_install_complete',
                         'parent_event_id': event.id,
                     },
                 )
                 extras['job_comp'] = None
 
         # Red-date auto-clear: a hard start_install date is meaningless once the
-        # release is complete. Helper is a no-op when no hard date is present.
-        if self.stage == 'Complete':
+        # release is installed/complete. Helper is a no-op when no hard date is
+        # present. Fires for both terminal stages (Install Complete is the new
+        # completion marker; Complete stays for safety).
+        if self.stage in ('Complete', 'Install Complete'):
             if clear_hard_date_cascade(
                 job_record,
                 parent_event_id=event.id,
-                reason='stage_set_to_complete',
+                reason=(
+                    'stage_set_to_install_complete'
+                    if self.stage == 'Install Complete'
+                    else 'stage_set_to_complete'
+                ),
                 source=self.source,
             ):
                 extras['hard_date_cleared'] = True

--- a/app/brain/job_log/features/start_install/clear_hard_date_cascade.py
+++ b/app/brain/job_log/features/start_install/clear_hard_date_cascade.py
@@ -1,7 +1,7 @@
 """
 @milehigh-header
 schema_version: 1
-purpose: Idempotently clear a hard start_install date as a cascade from a completion-marking action (stage='Complete', job_comp='X', invoiced='X'), emitting a child audit event linked by parent_event_id.
+purpose: Idempotently clear a hard start_install date as a cascade from a completion-marking action (stage='Complete', stage='Install Complete', job_comp='X', invoiced='X'), emitting a child audit event linked by parent_event_id.
 exports:
   clear_hard_date_cascade: Function that clears the hard-date flag and emits a child event when a hard date is present
 imports_from: [app.models, app.services.job_event_service]
@@ -22,6 +22,7 @@ logger = get_logger(__name__)
 
 CascadeReason = Literal[
     'stage_set_to_complete',
+    'stage_set_to_install_complete',
     'job_comp_set_to_x',
     'invoiced_set_to_x',
 ]

--- a/app/brain/job_log/routes.py
+++ b/app/brain/job_log/routes.py
@@ -1238,10 +1238,12 @@ def update_job_comp(job, release):
     """
     raw = request.json.get("job_comp")
     job_comp_str = _normalize_short_field(raw)
+    new_is_pct = False  # True only for an actual numeric install-progress value
     if job_comp_str and job_comp_str.upper() != 'X':
         try:
             num = float(job_comp_str.rstrip('%'))
             job_comp_str = f"{num:g}%"
+            new_is_pct = True
         except ValueError:
             pass
 
@@ -1262,46 +1264,40 @@ def update_job_comp(job, release):
         payload={'field': 'job_comp', 'old_value': old_job_comp, 'new_value': job_comp_str},
     )
 
-    # If job_comp cleared from 'X', revert stage to what it was before Complete
+    # Install Prog drives the install stages. Clearing the cell leaves the
+    # stage untouched (the user manages stage separately from there).
     response_extras = {}
     old_was_x = old_job_comp and old_job_comp.strip().upper() == 'X'
     new_is_x = job_comp_str and job_comp_str.upper() == 'X'
-    if old_was_x and not new_is_x:
+
+    if new_is_pct:
+        # Entering a percentage moves the release to 'Install Start'. Does NOT
+        # clear the hard start-install date or fab_order — install has begun,
+        # not finished.
         current_stage = job_record.stage or 'Released'
-        if current_stage == 'Complete':
-            from app.models import ReleaseEvents
-            recent_stage_events = ReleaseEvents.query.filter_by(
-                job=job, release=release, action='update_stage'
-            ).order_by(ReleaseEvents.created_at.desc()).limit(20).all()
-
-            revert_stage = 'Released'
-            for evt in recent_stage_events:
-                if evt.payload.get('to') == 'Complete' and evt.payload.get('from'):
-                    revert_stage = evt.payload['from']
-                    break
-
-            update_job_stage_fields(job_record, revert_stage)
+        if current_stage != 'Install Start':
+            update_job_stage_fields(job_record, 'Install Start')
             JobEventService.create_and_close(
                 job=job, release=release,
                 action='update_stage', source='Brain',
-                payload={'from': 'Complete', 'to': revert_stage, 'reason': 'job_comp_cleared'},
+                payload={'from': current_stage, 'to': 'Install Start', 'reason': 'job_comp_pct_set'},
             )
-            response_extras['stage'] = revert_stage
+            response_extras['stage'] = 'Install Start'
             from app.api.helpers import get_stage_group_from_stage
-            response_extras['stage_group'] = get_stage_group_from_stage(revert_stage)
+            response_extras['stage_group'] = get_stage_group_from_stage('Install Start')
 
     if new_is_x:
         current_stage = job_record.stage or 'Released'
-        if current_stage != 'Complete':
-            update_job_stage_fields(job_record, 'Complete')
+        if current_stage != 'Install Complete':
+            update_job_stage_fields(job_record, 'Install Complete')
             JobEventService.create_and_close(
                 job=job, release=release,
                 action='update_stage', source='Brain',
-                payload={'from': current_stage, 'to': 'Complete', 'reason': 'job_comp_set_to_x'},
+                payload={'from': current_stage, 'to': 'Install Complete', 'reason': 'job_comp_set_to_x'},
             )
-            response_extras['stage'] = 'Complete'
+            response_extras['stage'] = 'Install Complete'
             from app.api.helpers import get_stage_group_from_stage
-            response_extras['stage_group'] = get_stage_group_from_stage('Complete')
+            response_extras['stage_group'] = get_stage_group_from_stage('Install Complete')
 
         if job_record.fab_order is not None:
             old_fab = job_record.fab_order

--- a/app/brain/meetings/__init__.py
+++ b/app/brain/meetings/__init__.py
@@ -1,0 +1,10 @@
+"""Meeting ingestion (stubbed) + post-meeting checklist → to-do/notify.
+
+MVP of the Hive Mind "meeting → checklist → to-do/notify" flow:
+  transcript in → extractor proposes checklist items → reviewer (Bill) curates
+  (yes/no/edit, owner + due date editable) → accepted items notify their owner
+  as the due date approaches.
+
+Ingestion is stubbed (transcript pasted via the API); the Recall.ai/Teams adapters
+land here later behind the same boundary.
+"""

--- a/app/brain/meetings/extract.py
+++ b/app/brain/meetings/extract.py
@@ -1,0 +1,110 @@
+"""Extract proposed checklist items from a meeting transcript.
+
+Uses the Anthropic Messages API when ANTHROPIC_API_KEY is set; on a missing key or
+ANY failure (bad model, network, malformed JSON) it falls back to a deterministic
+keyword stub so the feature always works without a key — and tests stay hermetic.
+Mirrors how Trello/Procore wrap raw `requests`.
+"""
+import json
+import os
+import re
+from datetime import date
+
+import requests
+
+from app.config import Config as cfg
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+EXTRACT_MODEL = os.environ.get("CHECKLIST_EXTRACT_MODEL", "claude-sonnet-4-6")
+VALID_TYPES = {"action", "needs_gc_update", "decision", "risk", "fyi"}
+
+_ACTION_HINTS = (
+    "need", "redo", "today", "follow up", "follow-up", "asap", "by ", "send",
+    "order", "confirm", "update", "fix", "schedule", "call", "make sure",
+    "fab", "install", "submit", "release", "expedite", "deadline",
+)
+
+
+def _system_prompt(today: date) -> str:
+    return (
+        "You extract action items from a steel-fabrication company's internal or GC "
+        "meeting transcript. Return STRICT JSON only — no prose, no markdown. "
+        f"Today is {today.isoformat()}. Schema: "
+        '{"items":[{"title":str,"detail":str|null,'
+        '"item_type":"action|needs_gc_update|decision|risk|fyi",'
+        '"owner_name":str|null,"due_date":"YYYY-MM-DD"|null,"gc_facing":bool,'
+        '"release_ref":str|null,"submittal_ref":str|null,"confidence":number}]}. '
+        "owner_name = first name of the responsible person if stated. "
+        "due_date = resolve relative dates (today, Thursday, EOW) to absolute. "
+        "release_ref = a job-release token like '480-146' if mentioned. "
+        "Only include real action items / decisions / risks — skip chit-chat."
+    )
+
+
+def _call_anthropic(transcript: str, today: date) -> list:
+    key = cfg.ANTHROPIC_API_KEY
+    if not key:
+        raise RuntimeError("no ANTHROPIC_API_KEY")
+    resp = requests.post(
+        ANTHROPIC_URL,
+        headers={
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        json={
+            "model": EXTRACT_MODEL,
+            "max_tokens": 2000,
+            "system": _system_prompt(today),
+            "messages": [{"role": "user", "content": transcript[:100000]}],
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+    text = "".join(b.get("text", "") for b in resp.json().get("content", []))
+    m = re.search(r"\{.*\}", text, re.DOTALL)
+    data = json.loads(m.group(0) if m else text)
+    items = data.get("items", [])
+    if not isinstance(items, list):
+        raise ValueError("items is not a list")
+    return items
+
+
+def _stub_extract(transcript: str) -> list:
+    """Deterministic fallback: one item per line that looks like an action."""
+    items = []
+    for line in (transcript or "").splitlines():
+        s = line.strip().lstrip("-*•").strip()
+        if len(s) < 6:
+            continue
+        low = s.lower()
+        if any(h in low for h in _ACTION_HINTS):
+            mref = re.search(r"\b(\d{2,4})-(\w+)\b", s)
+            items.append({
+                "title": s[:200],
+                "detail": None,
+                "item_type": "action",
+                "owner_name": None,
+                "due_date": None,
+                "gc_facing": ("gc" in low or "client" in low),
+                "release_ref": mref.group(0) if mref else None,
+                "submittal_ref": None,
+                "confidence": None,
+            })
+    return items
+
+
+def extract_items(transcript: str, today: date = None) -> list:
+    """Return a list of proposed-item dicts. Never raises — falls back to the stub."""
+    today = today or date.today()
+    try:
+        items = _call_anthropic(transcript, today)
+        if items:
+            return items
+        logger.info("checklist_extract_empty_llm_result")
+    except Exception as e:  # noqa: BLE001 — any failure → deterministic stub
+        logger.info("checklist_extract_fallback", error=str(e))
+    return _stub_extract(transcript)

--- a/app/brain/meetings/routes.py
+++ b/app/brain/meetings/routes.py
@@ -1,0 +1,113 @@
+"""Meeting ingestion (stubbed) + checklist review routes. Registered on brain_bp.
+
+Admin-only, matching the board's posture. Endpoints:
+  POST   /brain/meetings                     ingest a transcript -> proposed checklist
+  GET    /brain/meetings                      recent meetings
+  GET    /brain/meetings/<id>                 meeting + its checklist items
+  GET    /brain/meetings/checklist/pending    proposed items awaiting review
+  GET    /brain/meetings/assignable-users     active users for the owner picker
+  PATCH  /brain/checklist-items/<id>          accept / reject / done / edit (owner+date)
+  POST   /brain/checklist-items/scan-due      manual deadline-notification scan
+"""
+from datetime import datetime
+
+from flask import request, jsonify
+
+from app.brain import brain_bp
+from app.auth.utils import admin_required, get_current_user
+from app.models import db, Meeting, ChecklistItem, User
+from app.brain.meetings import service
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@brain_bp.route('/meetings/assignable-users', methods=['GET'])
+@admin_required
+def list_assignable_users():
+    """Active users for the owner dropdown in the review UI."""
+    users = User.query.filter_by(is_active=True).order_by(User.first_name).all()
+    return jsonify({'users': [
+        {'id': u.id, 'first_name': u.first_name or u.username, 'last_name': u.last_name or ''}
+        for u in users
+    ]})
+
+
+@brain_bp.route('/meetings', methods=['POST'])
+@admin_required
+def create_meeting():
+    """Ingest a transcript (stubbed ingestion) and surface a proposed checklist."""
+    data = request.get_json(silent=True) or {}
+    transcript = (data.get('transcript') or '').strip()
+    if not transcript:
+        return jsonify({'error': 'transcript is required'}), 400
+
+    occurred_at = None
+    if data.get('occurred_at'):
+        try:
+            occurred_at = datetime.fromisoformat(str(data['occurred_at'])[:19])
+        except ValueError:
+            occurred_at = None
+
+    user = get_current_user()
+    meeting = service.create_meeting_with_extraction(
+        title=data.get('title'),
+        meeting_type=data.get('meeting_type'),
+        transcript=transcript,
+        project_number=data.get('project_number'),
+        occurred_at=occurred_at,
+        created_by_id=user.id if user else None,
+    )
+    return jsonify(meeting.to_dict(include_items=True)), 201
+
+
+@brain_bp.route('/meetings', methods=['GET'])
+@admin_required
+def list_meetings():
+    rows = Meeting.query.order_by(Meeting.created_at.desc()).limit(100).all()
+    return jsonify({'meetings': [m.to_dict() for m in rows]})
+
+
+@brain_bp.route('/meetings/<int:meeting_id>', methods=['GET'])
+@admin_required
+def get_meeting(meeting_id):
+    m = db.session.get(Meeting, meeting_id)
+    if not m:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(m.to_dict(include_items=True))
+
+
+@brain_bp.route('/meetings/checklist/pending', methods=['GET'])
+@admin_required
+def pending_checklist():
+    """Proposed (un-reviewed) items awaiting the reviewer, newest meeting first."""
+    rows = (ChecklistItem.query
+            .filter(ChecklistItem.status == 'proposed')
+            .order_by(ChecklistItem.meeting_id.desc(), ChecklistItem.id)
+            .all())
+    return jsonify({'items': [i.to_dict() for i in rows]})
+
+
+@brain_bp.route('/checklist-items/<int:item_id>', methods=['PATCH'])
+@admin_required
+def review_checklist_item(item_id):
+    """Curate an item: action in {accept, reject, done} and/or edit `fields`
+    (owner_user_id, due_date, title, detail, item_type, gc_facing, links)."""
+    data = request.get_json(silent=True) or {}
+    action = data.get('action')
+    if action and action not in ('accept', 'reject', 'done'):
+        return jsonify({'error': 'invalid action'}), 400
+    item = service.review_item(
+        item_id, action=action, fields=data.get('fields') or {},
+        reviewer=get_current_user(),
+    )
+    if not item:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(item.to_dict())
+
+
+@brain_bp.route('/checklist-items/scan-due', methods=['POST'])
+@admin_required
+def scan_due_items():
+    """Manually run the deadline-notification scan (also runs on a schedule)."""
+    return jsonify({'notified': service.notify_due_items()})

--- a/app/brain/meetings/service.py
+++ b/app/brain/meetings/service.py
@@ -1,0 +1,200 @@
+"""Meeting → checklist service: create+extract, review (yes/no/edit), notify owners.
+
+Kept as plain service functions (the routes delegate here), mirroring the brain
+feature-command split without the event/outbox machinery — checklist items are not
+release-scoped and have no async external push.
+"""
+import re
+from datetime import date, datetime, timedelta
+
+from app.config import Config as cfg
+from app.logging_config import get_logger
+from app.models import (
+    db, Meeting, ChecklistItem, Releases, Submittals, User, Notification,
+)
+from app.brain.meetings.extract import extract_items, VALID_TYPES
+
+logger = get_logger(__name__)
+
+NOTIFY_LEAD_DAYS = 2       # ping when the due date is within this many days
+NOTIFY_DEDUP_HOURS = 20    # don't re-ping the same item within this window
+_EDITABLE = ("title", "detail", "item_type", "gc_facing", "owner_user_id",
+             "due_date", "release_id", "submittal_id")
+
+
+def get_reviewer():
+    """The user who reviews post-meeting checklists (MVP: Bill, by config)."""
+    return User.query.filter_by(username=cfg.CHECKLIST_REVIEWER_USERNAME).first()
+
+
+def _resolve_owner_id(owner_name):
+    if not owner_name:
+        return None
+    u = User.query.filter(
+        db.func.lower(User.first_name) == str(owner_name).strip().lower(),
+        User.is_active.is_(True),
+    ).first()
+    return u.id if u else None
+
+
+def _parse_due(value):
+    if not value or isinstance(value, date):
+        return value or None
+    try:
+        return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _resolve_release(ref):
+    """'480-146' -> (Releases.id, job_number_str); best-effort."""
+    if not ref:
+        return None, None
+    m = re.match(r"\s*(\d+)\s*-\s*(\w+)\s*$", str(ref))
+    if not m:
+        return None, None
+    job, rel = int(m.group(1)), m.group(2)
+    row = Releases.query.filter_by(job=job, release=rel).first()
+    return (row.id, str(job)) if row else (None, None)
+
+
+def _resolve_submittal(ref):
+    if not ref:
+        return None
+    row = Submittals.query.filter_by(submittal_id=str(ref)).first()
+    return row.submittal_id if row else None
+
+
+def create_meeting_with_extraction(*, title, meeting_type, transcript,
+                                   project_number=None, occurred_at=None,
+                                   created_by_id=None):
+    """Create a Meeting, mine the transcript into proposed ChecklistItems, and
+    notify the reviewer. Returns the Meeting."""
+    # Run the (slow, external) extraction BEFORE opening the write transaction —
+    # holding a DB transaction across the LLM HTTP call resets the connection and
+    # corrupts the unit of work.
+    raw_items = extract_items(transcript)
+
+    meeting = Meeting(
+        title=(title or "Untitled meeting")[:255],
+        meeting_type=meeting_type or "other",
+        source="stub",
+        project_number=project_number,
+        occurred_at=occurred_at,
+        transcript=transcript,
+        created_by=created_by_id,
+    )
+    db.session.add(meeting)
+    db.session.flush()  # assign meeting.id
+
+    created = 0
+    for it in raw_items:
+        itype = it.get("item_type") if it.get("item_type") in VALID_TYPES else "action"
+        rel_id, rel_proj = _resolve_release(it.get("release_ref"))
+        db.session.add(ChecklistItem(
+            meeting_id=meeting.id,
+            title=((it.get("title") or "").strip()[:1000]) or "(untitled)",
+            detail=it.get("detail"),
+            item_type=itype,
+            gc_facing=bool(it.get("gc_facing")),
+            proposed_owner_user_id=_resolve_owner_id(it.get("owner_name")),
+            proposed_due_date=_parse_due(it.get("due_date")),
+            confidence=it.get("confidence"),
+            release_id=rel_id,
+            submittal_id=_resolve_submittal(it.get("submittal_ref")),
+        ))
+        created += 1
+        if rel_proj and not meeting.project_number:
+            meeting.project_number = rel_proj
+
+    meeting.extracted_at = datetime.utcnow()
+    db.session.commit()
+
+    _notify_reviewer(meeting, created)
+    logger.info("meeting_ingested", meeting_id=meeting.id, items=created,
+                meeting_type=meeting.meeting_type)
+    return meeting
+
+
+def _notify_reviewer(meeting, n_items):
+    reviewer = get_reviewer()
+    if not reviewer:
+        logger.warning("checklist_reviewer_unresolved",
+                       username=cfg.CHECKLIST_REVIEWER_USERNAME)
+        return
+    db.session.add(Notification(
+        user_id=reviewer.id,
+        type="checklist_ready",
+        message=f'Post-meeting checklist ready: {n_items} item(s) from "{meeting.title}"',
+    ))
+    db.session.commit()
+
+
+def review_item(item_id, *, action=None, fields=None, reviewer=None):
+    """Apply edits and/or an action (accept/reject/done) to a checklist item.
+
+    On accept, owner + due default to the agent's proposal when the reviewer didn't
+    override them — but the reviewer always has final say via `fields`.
+    """
+    item = db.session.get(ChecklistItem, item_id)
+    if not item:
+        return None
+    fields = fields or {}
+
+    for f in _EDITABLE:
+        if f in fields:
+            val = fields[f]
+            if f == "due_date":
+                val = _parse_due(val)
+            setattr(item, f, val)
+
+    if action == "accept":
+        if item.owner_user_id is None:
+            item.owner_user_id = item.proposed_owner_user_id
+        if item.due_date is None:
+            item.due_date = item.proposed_due_date
+        item.status = "accepted"
+    elif action == "reject":
+        item.status = "rejected"
+    elif action == "done":
+        item.status = "done"
+
+    if action:
+        item.reviewed_by = reviewer.id if reviewer else None
+        item.reviewed_at = datetime.utcnow()
+
+    db.session.commit()
+    return item
+
+
+def notify_due_items(today=None):
+    """Ping owners of accepted items whose due date is near/overdue (deduped).
+    Returns the number of notifications sent. Safe to run on a schedule."""
+    today = today or date.today()
+    cutoff = today + timedelta(days=NOTIFY_LEAD_DAYS)
+    dedup_before = datetime.utcnow() - timedelta(hours=NOTIFY_DEDUP_HOURS)
+
+    items = ChecklistItem.query.filter(
+        ChecklistItem.status == "accepted",
+        ChecklistItem.owner_user_id.isnot(None),
+        ChecklistItem.due_date.isnot(None),
+        ChecklistItem.due_date <= cutoff,
+    ).all()
+
+    sent = 0
+    for item in items:
+        if item.last_notified_at and item.last_notified_at > dedup_before:
+            continue
+        when = "overdue" if item.due_date < today else f"due {item.due_date.isoformat()}"
+        db.session.add(Notification(
+            user_id=item.owner_user_id,
+            type="checklist_due",
+            message=f"To-do {when}: {item.title[:160]}",
+            checklist_item_id=item.id,
+        ))
+        item.last_notified_at = datetime.utcnow()
+        sent += 1
+    if sent:
+        db.session.commit()
+    logger.info("checklist_due_scan", sent=sent, candidates=len(items))
+    return sent

--- a/app/config.py
+++ b/app/config.py
@@ -89,6 +89,23 @@ class Config:
     # Admin PIN for health scan admin page
     ADMIN_PIN = os.environ.get("ADMIN_PIN", "1234")
 
+    # Anthropic — used to extract checklist items from meeting transcripts.
+    # Falls back to a deterministic stub extractor when unset (tests / no key).
+    ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+
+    # Meeting → checklist reviewer. MVP: every post-meeting checklist surfaces to
+    # this user (resolved by username, which is the user's email here).
+    # Future distribution order on the admin side: Bill > David > Katie > Luis;
+    # for a project meeting the assigned PM takes precedence. The dev admin
+    # (mcgareyconsulting@gmail.com) is excluded from ranking.
+    CHECKLIST_REVIEWER_USERNAME = os.environ.get("CHECKLIST_REVIEWER_USERNAME", "boneill@mhmw.com")
+    CHECKLIST_ADMIN_RANKING = [
+        "boneill@mhmw.com",   # Bill
+        "dservold@mhmw.com",  # David
+        "khearn@mhmw.com",    # Katie
+        "lsolano@mhmw.com",   # Luis
+    ]
+
 
 class LocalConfig(Config):
     """Configuration for local development."""

--- a/app/models.py
+++ b/app/models.py
@@ -706,6 +706,7 @@ class Notification(db.Model):
     board_item_id = db.Column(db.Integer, db.ForeignKey('board_items.id', ondelete='CASCADE'), nullable=True)
     board_activity_id = db.Column(db.Integer, db.ForeignKey('board_activity.id', ondelete='CASCADE'), nullable=True)
     submittal_id = db.Column(db.String(255), db.ForeignKey('submittals.submittal_id', ondelete='CASCADE'), nullable=True, index=True)
+    checklist_item_id = db.Column(db.Integer, db.ForeignKey('checklist_items.id', ondelete='CASCADE'), nullable=True, index=True)
     is_read = db.Column(db.Boolean, default=False, nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
@@ -713,6 +714,7 @@ class Notification(db.Model):
     board_item = db.relationship('BoardItem', lazy='select')
     board_activity = db.relationship('BoardActivity', lazy='select')
     submittal = db.relationship('Submittals', lazy='select')
+    checklist_item = db.relationship('ChecklistItem', lazy='select')
 
     def to_dict(self):
         return {
@@ -723,6 +725,7 @@ class Notification(db.Model):
             'board_item_id': self.board_item_id,
             'board_activity_id': self.board_activity_id,
             'submittal_id': self.submittal_id,
+            'checklist_item_id': self.checklist_item_id,
             'is_read': self.is_read,
             'created_at': _dt(self.created_at),
             'board_item_title': self.board_item.title if self.board_item else None,
@@ -883,3 +886,124 @@ class FcCollectionRun(db.Model):
         d = self.to_summary_dict()
         d['details'] = self.details or {}
         return d
+
+
+class Meeting(db.Model):
+    """A captured meeting whose transcript is mined for checklist items.
+
+    MVP: ingestion is stubbed — a transcript is pasted/uploaded via the API rather
+    than pulled from Recall.ai/Teams. Maps to the future data-lake
+    `core_communication(kind='meeting')`; the Recall/Graph adapters land here later.
+    """
+    __tablename__ = "meetings"
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    # internal_draft | internal_shop | gc_pm | other
+    meeting_type = db.Column(db.String(40), nullable=False, default='other')
+    source = db.Column(db.String(30), nullable=False, default='stub')  # stub | recall | graph
+    project_number = db.Column(db.String(100), nullable=True, index=True)
+    occurred_at = db.Column(db.DateTime, nullable=True)
+    transcript = db.Column(db.Text, nullable=True)
+    created_by = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+    extracted_at = db.Column(db.DateTime, nullable=True)  # when checklist items were generated
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    items = db.relationship(
+        'ChecklistItem', backref='meeting', lazy='dynamic',
+        cascade='all, delete-orphan',
+    )
+    created_by_user = db.relationship('User', foreign_keys=[created_by])
+
+    def to_dict(self, include_items=False):
+        d = {
+            'id': self.id,
+            'title': self.title,
+            'meeting_type': self.meeting_type,
+            'source': self.source,
+            'project_number': self.project_number,
+            'occurred_at': _dt(self.occurred_at),
+            'extracted_at': _dt(self.extracted_at),
+            'created_at': _dt(self.created_at),
+        }
+        if include_items:
+            items = self.items.order_by(ChecklistItem.id).all()
+            d['items'] = [i.to_dict() for i in items]
+            d['item_count'] = len(items)
+        else:
+            d['item_count'] = self.items.count()
+        return d
+
+
+class ChecklistItem(db.Model):
+    """An agent-proposed to-do surfaced from a meeting transcript.
+
+    Lifecycle: the extractor creates rows as `status='proposed'` with an inferred
+    owner + due date. The reviewer (MVP: Bill) curates each via yes/no/edit — accept
+    sets the final owner_user_id + due_date and flips status to 'accepted'; the
+    notification worker then pings the owner as the due date approaches.
+    """
+    __tablename__ = "checklist_items"
+    id = db.Column(db.Integer, primary_key=True)
+    meeting_id = db.Column(
+        db.Integer, db.ForeignKey('meetings.id', ondelete='CASCADE'),
+        nullable=False, index=True,
+    )
+    title = db.Column(db.Text, nullable=False)
+    detail = db.Column(db.Text, nullable=True)
+    # action | needs_gc_update | decision | risk | fyi
+    item_type = db.Column(db.String(30), nullable=False, default='action')
+    gc_facing = db.Column(db.Boolean, nullable=False, default=False)
+
+    # Agent inference — immutable record of what was proposed
+    proposed_owner_user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+    proposed_due_date = db.Column(db.Date, nullable=True)
+    confidence = db.Column(db.Float, nullable=True)
+
+    # Final, human-curated values (set on accept/edit; owner + date editable)
+    owner_user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+    due_date = db.Column(db.Date, nullable=True)
+
+    # Optional links to internal records (expands to the lake reference spine later)
+    release_id = db.Column(db.Integer, db.ForeignKey('releases.id'), nullable=True)
+    submittal_id = db.Column(db.String(255), db.ForeignKey('submittals.submittal_id'), nullable=True)
+
+    # proposed | accepted | rejected | done
+    status = db.Column(db.String(20), nullable=False, default='proposed', index=True)
+    reviewed_by = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+    reviewed_at = db.Column(db.DateTime, nullable=True)
+    last_notified_at = db.Column(db.DateTime, nullable=True)  # dedup deadline pings
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    # joined eager-load avoids an N+1 on owner-name lookups when serializing item lists
+    owner = db.relationship('User', foreign_keys=[owner_user_id], lazy='joined')
+    proposed_owner = db.relationship('User', foreign_keys=[proposed_owner_user_id], lazy='joined')
+    reviewer = db.relationship('User', foreign_keys=[reviewed_by])
+
+    @staticmethod
+    def _name(u):
+        if not u:
+            return None
+        full = f"{(u.first_name or '').strip()} {(u.last_name or '').strip()}".strip()
+        return full or u.username
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'meeting_id': self.meeting_id,
+            'title': self.title,
+            'detail': self.detail,
+            'item_type': self.item_type,
+            'gc_facing': self.gc_facing,
+            'proposed_owner_user_id': self.proposed_owner_user_id,
+            'proposed_owner_name': self._name(self.proposed_owner),
+            'proposed_due_date': _dt(self.proposed_due_date),
+            'owner_user_id': self.owner_user_id,
+            'owner_name': self._name(self.owner),
+            'due_date': _dt(self.due_date),
+            'release_id': self.release_id,
+            'submittal_id': self.submittal_id,
+            'status': self.status,
+            'confidence': self.confidence,
+            'reviewed_at': _dt(self.reviewed_at),
+            'created_at': _dt(self.created_at),
+        }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import PMBoard from './pages/PMBoard';
 import Login from './pages/Login';
 import JobsiteMap from './pages/maps/JobsiteMap';
 import Board from './pages/Board';
+import Meetings from './pages/Meetings';
 import FcCollection from './pages/FcCollection';
 import InvoicingReport from './pages/InvoicingReport';
 import { checkAuth } from './utils/auth';
@@ -69,6 +70,7 @@ function AppContent() {
               <Route path="pm-board" element={<PMBoard />} />
               <Route path="jobsite-map" element={<JobsiteMap />} />
               <Route path="board" element={<Board />} />
+              <Route path="meetings" element={<Meetings />} />
               <Route path="invoicing-report" element={<InvoicingReport />} />
               <Route path="admin/fc-collection" element={<FcCollection />} />
               <Route path="*" element={<Navigate to="/job-log" replace />} />

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -122,6 +122,7 @@ function AppShellInner({ isAuthenticated }) {
             {navBtn('/drafting-work-load', 'Drafting WL')}
             {navBtn('/events', 'Events')}
             {canSeeReport && navBtn('/invoicing-report', 'Invoicing')}
+            {isAdmin && navBtn('/meetings', 'Meetings')}
             {isAdmin && navBtn('/board', 'Bug Tracker')}
           </div>
 

--- a/frontend/src/components/ColumnHeaderFilter.jsx
+++ b/frontend/src/components/ColumnHeaderFilter.jsx
@@ -17,9 +17,22 @@ import { useState, useEffect, useRef, useMemo, useLayoutEffect, useCallback } fr
 import { createPortal } from 'react-dom';
 
 const BLANKS = '(Blanks)';
-const POPOVER_WIDTH = 224;        // matches w-56
+const POPOVER_WIDTH = 224;        // matches w-56; also the minimum when autoWidth is on
 const POPOVER_MAX_HEIGHT = 360;   // approximate; just used for vertical clamp
 const VIEWPORT_PAD = 8;
+// Chrome around a value label: checkbox + gap + label padding + list padding + scrollbar slack.
+const AUTOWIDTH_CHROME = 64;
+const AUTOWIDTH_FONT = '12px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif';
+
+// Lazily reused canvas for measuring label widths (only used when autoWidth is on).
+let _measureCanvas = null;
+function measureTextWidth(text) {
+    if (typeof document === 'undefined') return String(text).length * 7;
+    if (!_measureCanvas) _measureCanvas = document.createElement('canvas');
+    const ctx = _measureCanvas.getContext('2d');
+    ctx.font = AUTOWIDTH_FONT;
+    return ctx.measureText(String(text)).width;
+}
 
 export default function ColumnHeaderFilter({
     column,
@@ -31,11 +44,12 @@ export default function ColumnHeaderFilter({
     onSort,
     isActive,
     children,
+    autoWidth = false,
 }) {
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState('');
     const [draft, setDraft] = useState(selected);
-    const [coords, setCoords] = useState({ top: 0, left: 0 });
+    const [coords, setCoords] = useState({ top: 0, left: 0, width: POPOVER_WIDTH });
     const triggerRef = useRef(null);
     const popoverRef = useRef(null);
 
@@ -44,17 +58,32 @@ export default function ColumnHeaderFilter({
         if (open) setDraft(new Set(selected));
     }, [open, selected]);
 
+    // When autoWidth is on, the popover grows to fit the longest value label
+    // (clamped to the viewport in updatePosition); otherwise it stays at the fixed width.
+    const contentWidth = useMemo(() => {
+        if (!autoWidth) return POPOVER_WIDTH;
+        let maxText = 0;
+        for (const v of values) {
+            const w = measureTextWidth(v);
+            if (w > maxText) maxText = w;
+        }
+        if (hasBlanks) maxText = Math.max(maxText, measureTextWidth(BLANKS));
+        return Math.max(POPOVER_WIDTH, Math.ceil(maxText + AUTOWIDTH_CHROME));
+    }, [autoWidth, values, hasBlanks]);
+
     const updatePosition = useCallback(() => {
         const el = triggerRef.current;
         if (!el) return;
         const rect = el.getBoundingClientRect();
         const vw = window.innerWidth;
         const vh = window.innerHeight;
+        // Resolve width, clamped so the popover always fits inside the viewport.
+        const width = Math.min(contentWidth, vw - 2 * VIEWPORT_PAD);
         // Prefer right-aligning to the trigger so the dropdown opens "from" the header,
         // but clamp to viewport on both sides.
-        let left = rect.right - POPOVER_WIDTH;
+        let left = rect.right - width;
         if (left < VIEWPORT_PAD) left = VIEWPORT_PAD;
-        if (left + POPOVER_WIDTH > vw - VIEWPORT_PAD) left = vw - VIEWPORT_PAD - POPOVER_WIDTH;
+        if (left + width > vw - VIEWPORT_PAD) left = vw - VIEWPORT_PAD - width;
         // Prefer below; flip above if it would overflow.
         let top = rect.bottom + 4;
         if (top + POPOVER_MAX_HEIGHT > vh - VIEWPORT_PAD) {
@@ -62,8 +91,8 @@ export default function ColumnHeaderFilter({
             if (above >= VIEWPORT_PAD) top = rect.top - 4 - POPOVER_MAX_HEIGHT;
             else top = Math.max(VIEWPORT_PAD, vh - VIEWPORT_PAD - POPOVER_MAX_HEIGHT);
         }
-        setCoords({ top, left });
-    }, []);
+        setCoords({ top, left, width });
+    }, [contentWidth]);
 
     // Position on open + keep in sync with scroll/resize while open
     useLayoutEffect(() => {
@@ -177,7 +206,7 @@ export default function ColumnHeaderFilter({
             {open && createPortal(
                 <div
                     ref={popoverRef}
-                    style={{ position: 'fixed', top: coords.top, left: coords.left, width: POPOVER_WIDTH }}
+                    style={{ position: 'fixed', top: coords.top, left: coords.left, width: coords.width }}
                     className="z-[1000] bg-white dark:bg-slate-800 border-2 border-gray-300 dark:border-slate-500 rounded-md shadow-lg text-left normal-case tracking-normal font-normal text-gray-800 dark:text-slate-100"
                     onClick={(e) => e.stopPropagation()}
                     onMouseDown={(e) => e.stopPropagation()}
@@ -246,7 +275,7 @@ export default function ColumnHeaderFilter({
                                             onChange={() => toggleValue(v)}
                                             className="accent-blue-600"
                                         />
-                                        <span className="truncate" title={v}>{v}</span>
+                                        <span className={autoWidth ? 'whitespace-nowrap' : 'truncate'} title={v}>{v}</span>
                                     </label>
                                 ))}
                             </>

--- a/frontend/src/components/JobsTableRow.jsx
+++ b/frontend/src/components/JobsTableRow.jsx
@@ -440,15 +440,15 @@ export function JobsTableRow({ row, columns, formatCellValue, formatDate, rowInd
         const oldJobComp = localJobComp;
         const oldFabOrder = localFabOrder;
         setLocalStage(newStage); // Optimistic update
-        // If setting to Complete, optimistically update job_comp and fab_order
-        if (newStage === 'Complete') {
+        // If setting to Install Complete, optimistically update job_comp and fab_order
+        if (newStage === 'Install Complete') {
             setLocalJobComp('X');
             setJobCompInputValue('X');
             setLocalFabOrder(null);
             setFabOrderInputValue('');
         }
-        // If changing away from Complete, clear job_comp 'X'
-        if (oldStage === 'Complete' && newStage !== 'Complete') {
+        // If changing away from Install Complete, clear job_comp 'X'
+        if (oldStage === 'Install Complete' && newStage !== 'Install Complete') {
             if ((localJobComp || '').trim().toUpperCase() === 'X') {
                 setLocalJobComp('');
                 setJobCompInputValue('');
@@ -557,23 +557,19 @@ export function JobsTableRow({ row, columns, formatCellValue, formatDate, rowInd
         const oldStage = localStage;
         const oldFabOrder = localFabOrder;
         setLocalJobComp(newValue);
-        // If setting to 'X', optimistically update stage and fab_order
-        if (newValue.trim().toUpperCase() === 'X') {
-            setLocalStage('Complete');
+        const trimmed = newValue.trim();
+        // 'X' marks install complete; a percentage means install has started.
+        // Clearing the cell leaves the stage unchanged (backend does the same).
+        if (trimmed.toUpperCase() === 'X') {
+            setLocalStage('Install Complete');
             setLocalFabOrder(null);
             setFabOrderInputValue('');
+        } else if (trimmed !== '' && !Number.isNaN(parseFloat(trimmed.replace('%', '')))) {
+            setLocalStage('Install Start');
         }
-        // If clearing 'X', optimistically show stage reverting (actual stage comes from API)
-        const oldWasX = (oldValue || '').trim().toUpperCase() === 'X';
-        const newIsX = newValue.trim().toUpperCase() === 'X';
-        const clearingX = oldWasX && !newIsX && localStage === 'Complete';
         setUpdatingJobComp(true);
         try {
-            const result = await jobsApi.updateJobComp(row['Job #'], row['Release #'], newValue);
-            // Apply the reverted stage from the backend (looked up from release_events)
-            if (clearingX && result?.stage) {
-                setLocalStage(result.stage);
-            }
+            await jobsApi.updateJobComp(row['Job #'], row['Release #'], newValue);
             if (onUpdate) onUpdate();
         } catch (err) {
             setLocalJobComp(oldValue);

--- a/frontend/src/components/MobileNavDrawer.jsx
+++ b/frontend/src/components/MobileNavDrawer.jsx
@@ -22,6 +22,7 @@ const NAV_ITEMS = [
 ];
 
 const ADMIN_ITEMS = [
+    { label: 'Meetings', path: '/meetings' },
     { label: 'Bug Tracker', path: '/board' },
 ];
 

--- a/frontend/src/components/PdfMarkupModal.jsx
+++ b/frontend/src/components/PdfMarkupModal.jsx
@@ -1,10 +1,16 @@
 /**
  * Fullscreen PDF markup modal — renders a release's drawing version with
- * pdf.js's built-in AnnotationEditor (pen + text), and saves the result as
- * the next version via POST /brain/releases/<id>/drawing.
+ * pdf.js's built-in AnnotationEditor (pen + text) plus shape tools
+ * (line/arrow/box/circle) and a stroke-thickness control, and saves the result
+ * as the next version via POST /brain/releases/<id>/drawing.
  *
- * Tablet-friendly: native pointer events, large toolbar hit targets,
- * touch-action: none on the canvas wrapper to suppress scroll/pinch hijack.
+ * Shapes have no native pdf.js editor: a transparent overlay captures the drag
+ * and the result is injected as an Ink annotation (built from point paths) so
+ * it persists via saveDocument() and behaves like any other annotation.
+ *
+ * Tablet-friendly: native pointer events, large toolbar hit targets. The scroll
+ * container allows one-finger pan in Hand mode and suppresses touch while a
+ * drawing tool is active; two-finger pinch-to-zoom is handled explicitly.
  */
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -46,7 +52,85 @@ const TOOL = {
     HAND: pdfjsLib.AnnotationEditorType.NONE,
     INK: pdfjsLib.AnnotationEditorType.INK,
     FREETEXT: pdfjsLib.AnnotationEditorType.FREETEXT,
+    // Shape tools have no native pdf.js editor — they are drawn through an
+    // input overlay and committed as Ink annotations (see commitShape). String
+    // sentinels keep them distinct from the numeric AnnotationEditorType values.
+    LINE: 'line',
+    ARROW: 'arrow',
+    SQUARE: 'square',
+    CIRCLE: 'circle',
 };
+
+const SHAPE_TOOLS = new Set([TOOL.LINE, TOOL.ARROW, TOOL.SQUARE, TOOL.CIRCLE]);
+const isShapeTool = (t) => SHAPE_TOOLS.has(t);
+
+// Stroke-width presets shared by the pen and shapes (pdf.js "thickness" units).
+const THICKNESS = { Thin: 2, Medium: 6, Thick: 12 };
+
+function hexToRgbArray(hex) {
+    const h = hex.replace('#', '');
+    return [
+        parseInt(h.slice(0, 2), 16),
+        parseInt(h.slice(2, 4), 16),
+        parseInt(h.slice(4, 6), 16),
+    ];
+}
+
+// Two arrowhead barbs for an arrow from s -> e (page-space points).
+function arrowHeadPoints(s, e) {
+    const ang = Math.atan2(e.y - s.y, e.x - s.x);
+    const len = 18;
+    const spread = Math.PI / 7;
+    return {
+        a: { x: e.x - len * Math.cos(ang - spread), y: e.y - len * Math.sin(ang - spread) },
+        b: { x: e.x - len * Math.cos(ang + spread), y: e.y - len * Math.sin(ang + spread) },
+    };
+}
+
+// Build a shape as a list of polylines (each an array of {x,y}) in page space.
+// Rect/arrow use separate 2-point segments so corners stay crisp (pdf.js
+// bezier-smooths long polylines); the circle uses one sampled polyline.
+function buildShapeCssPaths(shape, s, e) {
+    switch (shape) {
+        case TOOL.LINE:
+            return [[s, e]];
+        case TOOL.ARROW: {
+            const { a, b } = arrowHeadPoints(s, e);
+            return [[s, e], [a, e], [b, e]];
+        }
+        case TOOL.SQUARE: {
+            const p1 = { x: s.x, y: s.y };
+            const p2 = { x: e.x, y: s.y };
+            const p3 = { x: e.x, y: e.y };
+            const p4 = { x: s.x, y: e.y };
+            return [[p1, p2], [p2, p3], [p3, p4], [p4, p1]];
+        }
+        case TOOL.CIRCLE: {
+            const cx = (s.x + e.x) / 2;
+            const cy = (s.y + e.y) / 2;
+            const rx = Math.abs(e.x - s.x) / 2;
+            const ry = Math.abs(e.y - s.y) / 2;
+            const N = 64;
+            const pts = [];
+            for (let i = 0; i <= N; i++) {
+                const a = (i / N) * 2 * Math.PI;
+                pts.push({ x: cx + rx * Math.cos(a), y: cy + ry * Math.sin(a) });
+            }
+            // Emit consecutive points as separate straight chords rather than one
+            // closed polyline: pdf.js bezier-smooths long polylines, and the seam
+            // of a closed loop produces control-point overshoot that inflates the
+            // bounding box. 64 short chords read as a smooth ellipse but give an
+            // exact bbox (same approach as the square's edges).
+            const segments = [];
+            for (let i = 0; i < pts.length - 1; i++) {
+                segments.push([pts[i], pts[i + 1]]);
+            }
+            return segments;
+        }
+        default:
+            return [];
+    }
+}
 
 export function PdfMarkupModal({
     isOpen,
@@ -57,11 +141,14 @@ export function PdfMarkupModal({
     onSaved,
 }) {
     const containerRef = useRef(null);
+    const overlayRef = useRef(null);
+    const shapeStartRef = useRef(null);  // { x, y } client coords of the in-progress shape
     const viewerStateRef = useRef({
         pdfDocument: null,
         pdfViewer: null,
         eventBus: null,
         loadingTask: null,
+        uiManager: null,
     });
 
     const [loading, setLoading] = useState(true);
@@ -70,9 +157,12 @@ export function PdfMarkupModal({
     const [tool, setTool] = useState(TOOL.HAND);
     const [color, setColor] = useState(COLORS[0]);
     const [fontSize, setFontSize] = useState(16);
+    const [thickness, setThickness] = useState(THICKNESS.Medium);
     const [note, setNote] = useState('');
     const [dirty, setDirty] = useState(false);
     const [ticks, setTicks] = useState([]);  // scrollbar ticks for each annotation
+    const [shapeDraft, setShapeDraft] = useState(null);  // { sx, sy, ex, ey } overlay-relative preview
+    const [hasSelection, setHasSelection] = useState(false);  // an editor is currently selected
 
     const isEdit = mode === 'edit';
 
@@ -88,6 +178,9 @@ export function PdfMarkupModal({
         setDirty(false);
         setTool(TOOL.HAND);
         setTicks([]);
+        setShapeDraft(null);
+        shapeStartRef.current = null;
+        setHasSelection(false);
         setNote('');  // optional save-note resets every time the editor opens
 
         const init = async () => {
@@ -116,8 +209,18 @@ export function PdfMarkupModal({
                     // over-zoom wide FC drawings on big screens.
                     pdfViewer.currentScaleValue = 'page-fit';
                 });
-                eventBus.on('annotationeditorstateschanged', () => {
+                eventBus.on('annotationeditorstateschanged', (e) => {
                     setDirty(true);
+                    const details = e?.details;
+                    if (details && 'hasSelectedEditor' in details) {
+                        setHasSelection(!!details.hasSelectedEditor);
+                    }
+                });
+                // The UIManager is created during setDocument (NONE mode still
+                // creates it); capture it so shape tools can inject Ink editors
+                // via uiManager.getLayer(pageIndex).deserialize/add.
+                eventBus.on('annotationeditoruimanager', ({ uiManager }) => {
+                    viewerStateRef.current.uiManager = uiManager;
                 });
 
                 const refreshTicks = async () => {
@@ -139,7 +242,7 @@ export function PdfMarkupModal({
                         const currentVer = viewerStateRef.current.currentVersionNumber;
                         for (const ann of annots) {
                             if (!['FreeText', 'Ink', 'Stamp'].includes(ann.subtype)) continue;
-                            const [x1, y1, x2, y2] = viewport.convertToViewportRectangle(ann.rect);
+                            const [x1, y1, , y2] = viewport.convertToViewportRectangle(ann.rect);
                             const top = Math.min(y1, y2);
                             const fp = fingerprintAnnotation(ann, pageNum);
                             const versionNumber = originMap.has(fp) ? originMap.get(fp) : currentVer;
@@ -253,7 +356,7 @@ export function PdfMarkupModal({
             try { state.loadingTask?.destroy?.(); } catch { /* noop */ }
             try { state.pdfViewer?.cleanup?.(); } catch { /* noop */ }
             try { state.pdfDocument?.destroy?.(); } catch { /* noop */ }
-            viewerStateRef.current = { pdfDocument: null, pdfViewer: null, eventBus: null, loadingTask: null };
+            viewerStateRef.current = { pdfDocument: null, pdfViewer: null, eventBus: null, loadingTask: null, uiManager: null };
         };
     }, [isOpen, releaseId, versionId]);
 
@@ -262,7 +365,10 @@ export function PdfMarkupModal({
         const pdfViewer = viewerStateRef.current.pdfViewer;
         if (!pdfViewer || !isEdit) return;
         try {
-            pdfViewer.annotationEditorMode = { mode: tool };
+            // Shape tools ride on the INK editor layer (which provides the page
+            // layers we inject into); the shape input overlay handles drawing.
+            const mode = isShapeTool(tool) ? TOOL.INK : tool;
+            pdfViewer.annotationEditorMode = { mode };
         } catch {
             // pdfViewer not yet ready — ignored, will retry on next state change.
         }
@@ -297,6 +403,55 @@ export function PdfMarkupModal({
         } catch { /* swallow */ }
     }, [fontSize, tool, isEdit]);
 
+    // Apply stroke-thickness changes to the pen. Shapes read `thickness`
+    // directly when committed, so only the live INK editor needs the dispatch.
+    useEffect(() => {
+        const eventBus = viewerStateRef.current.eventBus;
+        if (!eventBus || !isEdit || tool !== TOOL.INK) return;
+        const params = pdfjsLib.AnnotationEditorParamsType;
+        try {
+            if (params?.INK_THICKNESS != null) {
+                eventBus.dispatch('switchannotationeditorparams', { type: params.INK_THICKNESS, value: thickness });
+            }
+        } catch { /* swallow */ }
+    }, [thickness, tool, isEdit]);
+
+    // Two-finger pinch-to-zoom. pdf.js's own TouchManager only resizes the
+    // selected editor, so page zoom is handled here: adjust currentScale by the
+    // change in finger distance. Single-finger touches fall through to native
+    // pan-scroll (touch-action on the container).
+    useEffect(() => {
+        if (!isOpen) return;
+        const container = containerRef.current;
+        if (!container) return;
+        let lastDist = null;
+        const dist = (t) => Math.hypot(t[0].clientX - t[1].clientX, t[0].clientY - t[1].clientY);
+        const onTouchMove = (e) => {
+            if (e.touches.length !== 2) return;
+            e.preventDefault();
+            const d = dist(e.touches);
+            if (lastDist != null && d > 0) {
+                const pdfViewer = viewerStateRef.current.pdfViewer;
+                if (pdfViewer) {
+                    const current = pdfViewer.currentScale || 1;
+                    pdfViewer.currentScale = Math.min(8, Math.max(0.25, current * (d / lastDist)));
+                }
+            }
+            lastDist = d;
+        };
+        const onTouchEnd = (e) => {
+            if (e.touches.length < 2) lastDist = null;
+        };
+        container.addEventListener('touchmove', onTouchMove, { passive: false });
+        container.addEventListener('touchend', onTouchEnd);
+        container.addEventListener('touchcancel', onTouchEnd);
+        return () => {
+            container.removeEventListener('touchmove', onTouchMove);
+            container.removeEventListener('touchend', onTouchEnd);
+            container.removeEventListener('touchcancel', onTouchEnd);
+        };
+    }, [isOpen]);
+
     // Esc-to-close
     useEffect(() => {
         if (!isOpen) return;
@@ -326,6 +481,123 @@ export function PdfMarkupModal({
         const pdfViewer = viewerStateRef.current.pdfViewer;
         if (!pdfViewer) return;
         pdfViewer.currentScaleValue = 'page-width';
+    };
+
+    // Which rendered page is under a screen point, plus its scaled viewport and
+    // on-screen rect (used to map the gesture into PDF page coordinates).
+    const getPageAtClientPoint = (clientX, clientY) => {
+        const pdfViewer = viewerStateRef.current.pdfViewer;
+        const doc = viewerStateRef.current.pdfDocument;
+        if (!pdfViewer || !doc) return null;
+        for (let i = 0; i < doc.numPages; i++) {
+            const pv = pdfViewer.getPageView(i);
+            if (!pv || !pv.div || !pv.viewport) continue;
+            const r = pv.div.getBoundingClientRect();
+            if (clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom) {
+                return { pageIndex: i, viewport: pv.viewport, rect: r };
+            }
+        }
+        return null;
+    };
+
+    // Convert a drag (start -> end, client coords) into an Ink annotation on the
+    // page under the start point and inject it via the editor layer so it
+    // persists through saveDocument() and behaves like any other annotation.
+    const commitShape = async (startClient, endClient) => {
+        const uiManager = viewerStateRef.current.uiManager;
+        if (!uiManager) return;
+        const page = getPageAtClientPoint(startClient.x, startClient.y);
+        if (!page) return;
+        const { pageIndex, viewport, rect } = page;
+        const s = { x: startClient.x - rect.left, y: startClient.y - rect.top };
+        const e = { x: endClient.x - rect.left, y: endClient.y - rect.top };
+        if (Math.hypot(e.x - s.x, e.y - s.y) < 4) return;  // ignore taps/tiny drags
+
+        const cssPaths = buildShapeCssPaths(tool, s, e);
+        if (!cssPaths.length) return;
+
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        const points = cssPaths.map((path) => {
+            const flat = [];
+            for (const p of path) {
+                const [px, py] = viewport.convertToPdfPoint(p.x, p.y);
+                flat.push(px, py);
+                if (px < minX) minX = px;
+                if (px > maxX) maxX = px;
+                if (py < minY) minY = py;
+                if (py > maxY) maxY = py;
+            }
+            return Float32Array.from(flat);
+        });
+
+        const pad = thickness / 2 + 1;
+        const obj = {
+            annotationType: pdfjsLib.AnnotationEditorType.INK,
+            color: hexToRgbArray(color),
+            opacity: 1,
+            thickness,
+            paths: { points },
+            pageIndex,
+            rect: [minX - pad, minY - pad, maxX + pad, maxY + pad],
+            // pdf.js initializes every editor's rotation to the page's view
+            // rotation (architectural PDFs are often stored rotated). The points
+            // are in unrotated PDF space (convertToPdfPoint), so deserialize maps
+            // them through the rotation-matched rescale and the selection box
+            // lands on the right axes. Hardcoding 0 here put the box on swapped
+            // axes for rotated pages.
+            rotation: viewport.rotation || 0,
+        };
+
+        try {
+            const layer = uiManager.getLayer(pageIndex);
+            if (!layer) return;
+            const editor = await layer.deserialize(obj);
+            if (editor) {
+                layer.add(editor);
+                setDirty(true);
+            }
+        } catch (err) {
+            console.error('Failed to add shape:', err);
+        }
+    };
+
+    const onShapePointerDown = (e) => {
+        if (!isShapeTool(tool)) return;
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+        const r = overlayRef.current?.getBoundingClientRect();
+        if (!r) return;
+        shapeStartRef.current = { x: e.clientX, y: e.clientY };
+        const ox = e.clientX - r.left;
+        const oy = e.clientY - r.top;
+        setShapeDraft({ sx: ox, sy: oy, ex: ox, ey: oy });
+    };
+
+    const onShapePointerMove = (e) => {
+        if (!shapeStartRef.current) return;
+        const r = overlayRef.current?.getBoundingClientRect();
+        if (!r) return;
+        const ex = e.clientX - r.left;
+        const ey = e.clientY - r.top;
+        setShapeDraft((d) => (d ? { ...d, ex, ey } : d));
+    };
+
+    const onShapePointerUp = (e) => {
+        const start = shapeStartRef.current;
+        shapeStartRef.current = null;
+        setShapeDraft(null);
+        if (!start) return;
+        commitShape(start, { x: e.clientX, y: e.clientY });
+    };
+
+    // Delete the currently-selected annotation(s). pdf.js's delete() is
+    // undoable and works for both saved and not-yet-saved editors; this is the
+    // touch equivalent of pressing Delete/Backspace.
+    const deleteSelected = () => {
+        const uiManager = viewerStateRef.current.uiManager;
+        if (!uiManager) return;
+        uiManager.delete();
+        setHasSelection(false);
+        setDirty(true);
     };
 
     const tryClose = () => {
@@ -400,10 +672,21 @@ export function PdfMarkupModal({
                 .annotationEditorLayer .freeTextEditor { cursor: move !important; }
                 .annotationEditorLayer .freeTextEditor > .internal { cursor: text !important; }
 
-                /* Hand mode: existing annotations stay visible but become
-                   non-interactive (no select/drag/edit). Pen/Text re-enable. */
+                /* Hand mode = move/select. pdf.js disables editor-layer pointer
+                   events in NONE mode (adds .disabled); we re-enable them so
+                   existing annotations — pen strokes, shapes, text — can be
+                   selected and dragged. NONE mode binds no create-on-click
+                   handler, so empty-space clicks create nothing, and the
+                   container's touch-action still allows one-finger pan-scroll. */
                 [data-tool="hand"] .annotationEditorLayer,
-                [data-tool="hand"] .annotationEditorLayer * {
+                [data-tool="hand"] .annotationEditorLayer.disabled {
+                    pointer-events: auto !important;
+                }
+
+                /* Shape mode: suppress the editor layer so the shape input
+                   overlay — not the native ink pen — handles drawing. */
+                [data-tool="shape"] .annotationEditorLayer,
+                [data-tool="shape"] .annotationEditorLayer * {
                     pointer-events: none !important;
                 }
 
@@ -452,6 +735,30 @@ export function PdfMarkupModal({
                         {toolBtn('Hand', TOOL.HAND, 'Move/select')}
                         {toolBtn('Pen', TOOL.INK)}
                         {toolBtn('Text', TOOL.FREETEXT)}
+                        {toolBtn('Line', TOOL.LINE)}
+                        {toolBtn('Arrow', TOOL.ARROW)}
+                        {toolBtn('Box', TOOL.SQUARE, 'Square')}
+                        {toolBtn('Circle', TOOL.CIRCLE)}
+                        {(tool === TOOL.INK || isShapeTool(tool)) && (
+                            <div className="flex items-center gap-1 ml-2">
+                                {Object.entries(THICKNESS).map(([label, value]) => (
+                                    <button
+                                        key={label}
+                                        type="button"
+                                        onClick={() => setThickness(value)}
+                                        className={`px-3 py-3 min-h-[44px] rounded-md text-sm font-semibold border ${
+                                            thickness === value
+                                                ? 'bg-accent-600 text-white border-accent-600'
+                                                : 'bg-white text-gray-800 border-gray-300 hover:bg-gray-100'
+                                        }`}
+                                        title={`${label} stroke`}
+                                        aria-label={`${label} stroke width`}
+                                    >
+                                        {label}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
                         {tool === TOOL.FREETEXT && (
                             <div className="flex items-center gap-1 ml-2">
                                 <button
@@ -483,6 +790,16 @@ export function PdfMarkupModal({
                                 />
                             ))}
                         </div>
+                        <button
+                            type="button"
+                            onClick={deleteSelected}
+                            disabled={!hasSelection}
+                            className="ml-2 px-4 py-3 min-h-[44px] rounded-md font-semibold border border-red-300 text-red-700 bg-white hover:bg-red-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                            title="Delete selected annotation (or press Delete)"
+                            aria-label="Delete selected annotation"
+                        >
+                            Delete
+                        </button>
                         <input
                             type="text"
                             value={note}
@@ -519,11 +836,57 @@ export function PdfMarkupModal({
                 <div
                     ref={containerRef}
                     className="absolute inset-0 overflow-auto"
-                    style={{ touchAction: 'none', position: 'absolute' }}
-                    data-tool={tool === TOOL.HAND ? 'hand' : tool === TOOL.INK ? 'pen' : 'text'}
+                    // Hand mode allows one-finger pan-scroll; drawing tools
+                    // suppress it so finger/stylus drags become strokes.
+                    style={{ touchAction: tool === TOOL.HAND ? 'pan-x pan-y' : 'none', position: 'absolute' }}
+                    data-tool={
+                        tool === TOOL.HAND ? 'hand'
+                            : tool === TOOL.INK ? 'pen'
+                                : tool === TOOL.FREETEXT ? 'text'
+                                    : 'shape'
+                    }
                 >
                     <div className="pdfViewer" />
                 </div>
+
+                {/* Shape input overlay: captures the drag for line/arrow/box/circle,
+                    shows a live preview, and commits the result as an Ink annotation
+                    on pointer-up. Only mounted while a shape tool is active. */}
+                {isEdit && isShapeTool(tool) && (
+                    <div
+                        ref={overlayRef}
+                        className="absolute inset-0 z-10"
+                        style={{ touchAction: 'none', cursor: 'crosshair' }}
+                        onPointerDown={onShapePointerDown}
+                        onPointerMove={onShapePointerMove}
+                        onPointerUp={onShapePointerUp}
+                        onPointerCancel={onShapePointerUp}
+                        onWheel={(e) => {
+                            const c = containerRef.current;
+                            if (c) { c.scrollTop += e.deltaY; c.scrollLeft += e.deltaX; }
+                        }}
+                    >
+                        {shapeDraft && (
+                            <svg className="absolute inset-0 w-full h-full pointer-events-none">
+                                {buildShapeCssPaths(
+                                    tool,
+                                    { x: shapeDraft.sx, y: shapeDraft.sy },
+                                    { x: shapeDraft.ex, y: shapeDraft.ey },
+                                ).map((path, idx) => (
+                                    <polyline
+                                        key={idx}
+                                        points={path.map((p) => `${p.x},${p.y}`).join(' ')}
+                                        fill="none"
+                                        stroke={color}
+                                        strokeWidth={thickness}
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                    />
+                                ))}
+                            </svg>
+                        )}
+                    </div>
+                )}
 
                 {/* Annotation ticks overlaid on the right edge of the scroll track.
                     Click jumps the scroll container to that annotation. */}

--- a/frontend/src/hooks/useFilters.js
+++ b/frontend/src/hooks/useFilters.js
@@ -3,18 +3,23 @@
  * schema_version: 1
  * purpose: Centralizes all DWL filter, search, and column-sort logic so DraftingWorkLoad only handles rendering.
  * exports:
- *   useFilters: Hook returning filter state, dropdown options, displayRows, and sort/reset handlers for DWL
+ *   useFilters: Hook returning column-filter state, reachable values, displayRows, and sort/reset handlers for DWL
  * imports_from: [react]
  * imported_by: [../pages/DraftingWorkLoad.jsx]
  * invariants:
  *   - Rows with type 'For Construction' are always excluded before any user filter is applied
+ *   - Filtering is per-column (Excel-style): columnFilters maps a display column name to an allowed-value list
+ *   - '(Blanks)' is the sentinel for null/empty values; an empty/absent list means "no filter on that column"
+ *   - BIC is comma-split: a row matches if ANY of its individual ball-in-court names is allowed
  *   - Default sort groups by BIC then order_number; column sort overrides but preserves multi-assignee-last rule for NAME
- *   - Ball-in-court filter splits comma-separated values so individual names are matchable
- * updated_by_agent: 2026-04-14T00:00:00Z (commit e133a47)
  */
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 
 const ALL_OPTION_VALUE = '__ALL__';
+const BLANKS = '(Blanks)';
+
+// Display columns that get an Excel-style header dropdown filter.
+const FILTER_COLUMNS = ['PROJ. #', 'NAME', 'TITLE', 'BIC', 'SUB MANAGER', 'PROCORE STATUS'];
 
 /**
  * Get value from row by column name (handles both database field names and display names)
@@ -38,9 +43,28 @@ const getColumnValue = (row, column) => {
     };
 
     const fieldName = columnMap[column] || column.toLowerCase().replace(/\s+/g, '_');
-    
+
     // Try both the mapped field name and the display column name
     return row[fieldName] ?? row[column] ?? null;
+};
+
+/**
+ * Does a row pass the allowed-value list for one column?
+ * - Empty/missing allowed list means no constraint (true).
+ * - BIC splits comma-separated names and matches if ANY name is allowed.
+ * - '(Blanks)' matches null/empty values.
+ */
+const rowPassesColumn = (row, col, allowed) => {
+    if (!allowed || allowed.length === 0) return true;
+    if (col === 'BIC') {
+        const raw = (row.ball_in_court ?? row['BIC'] ?? '').toString().trim();
+        if (raw === '') return allowed.includes(BLANKS);
+        const names = raw.split(',').map((n) => n.trim()).filter(Boolean);
+        return names.some((n) => allowed.includes(n));
+    }
+    const v = getColumnValue(row, col);
+    const blank = v === null || v === undefined || String(v).trim() === '';
+    return blank ? allowed.includes(BLANKS) : allowed.includes(String(v).trim());
 };
 
 /**
@@ -55,7 +79,7 @@ const compareValues = (a, b, direction = 'asc') => {
     // Try to parse as number
     const numA = typeof a === 'number' ? a : parseFloat(a);
     const numB = typeof b === 'number' ? b : parseFloat(b);
-    
+
     if (!isNaN(numA) && !isNaN(numB)) {
         // Both are numbers
         const result = numA - numB;
@@ -84,72 +108,75 @@ const compareValues = (a, b, direction = 'asc') => {
  * @returns {Object} Filter state, options, handlers, and filtered/sorted rows
  */
 export function useFilters(rows = []) {
-    // Filter state
-    const [selectedBallInCourt, setSelectedBallInCourt] = useState(ALL_OPTION_VALUE);
-    const [selectedSubmittalManager, setSelectedSubmittalManager] = useState(ALL_OPTION_VALUE);
-    const [selectedProjectName, setSelectedProjectName] = useState(ALL_OPTION_VALUE);
-    const [selectedProcoreStatus, setSelectedProcoreStatus] = useState(ALL_OPTION_VALUE);
-    
+    // Per-column dropdown filters: { [displayCol]: string[] of allowed values; '(Blanks)' represents null/empty }
+    const [columnFilters, setColumnFiltersState] = useState(() => {
+        try {
+            const raw = localStorage.getItem('dwl_column_filters');
+            return raw ? JSON.parse(raw) : {};
+        } catch {
+            return {};
+        }
+    });
+
     // Text search state
     const [search, setSearch] = useState('');
 
-    // General column sorting: { column: 'Project Name', direction: 'asc' | 'desc' | null }
-    // For Project Name, we maintain backward compatibility with the existing 'normal' mode
+    // General column sorting: { column: 'TITLE', direction: 'asc' | 'desc' | null }
     const [columnSort, setColumnSort] = useState({ column: null, direction: null });
 
+    // Persist column filters across reloads (drop the key entirely when empty)
+    useEffect(() => {
+        if (Object.keys(columnFilters).length === 0) {
+            localStorage.removeItem('dwl_column_filters');
+        } else {
+            localStorage.setItem('dwl_column_filters', JSON.stringify(columnFilters));
+        }
+    }, [columnFilters]);
+
+    const setColumnFilter = useCallback((column, values) => {
+        setColumnFiltersState((prev) => {
+            const next = { ...prev };
+            if (!values || values.length === 0) {
+                delete next[column];
+            } else {
+                next[column] = [...values];
+            }
+            return next;
+        });
+    }, []);
+
     /**
-     * Check if a row matches all selected filters
+     * Text search across all six filterable columns: project #, project name,
+     * title, ball in court, submittal manager, and Procore status.
      */
-    const matchesSelectedFilter = useCallback((row) => {
-        // Check Ball In Court filter (handles comma-separated values for multiple assignees)
-        if (selectedBallInCourt !== ALL_OPTION_VALUE) {
-            const ballInCourtValue = (row.ball_in_court ?? '').toString().trim();
-            // Check if selected value matches exactly OR appears in comma-separated list
-            const ballInCourtNames = ballInCourtValue.split(',').map(name => name.trim());
-            if (!ballInCourtNames.includes(selectedBallInCourt)) {
-                return false;
-            }
-        }
+    const matchesSearch = useCallback((row) => {
+        if (search.trim() === '') return true;
+        const keywords = search.trim().toLowerCase().split(/\s+/);
+        const haystack = [
+            String(row.project_number ?? row['PROJ. #'] ?? ''),
+            String(row.project_name ?? row['NAME'] ?? ''),
+            String(row.title ?? row['TITLE'] ?? ''),
+            String(row.ball_in_court ?? row['BIC'] ?? ''),
+            String(row.submittal_manager ?? row['SUB MANAGER'] ?? ''),
+            String(row.status ?? row['PROCORE STATUS'] ?? ''),
+        ].join(' ').toLowerCase();
+        return keywords.every((kw) => haystack.includes(kw));
+    }, [search]);
 
-        // Check Submittal Manager filter
-        if (selectedSubmittalManager !== ALL_OPTION_VALUE) {
-            const managerValue = row.submittal_manager ?? row['SUB MANAGER'];
-            if ((managerValue ?? '').toString().trim() !== selectedSubmittalManager) {
-                return false;
-            }
+    /**
+     * Check if a row passes every active per-column dropdown filter.
+     */
+    const matchesColumnFilters = useCallback((row) => {
+        for (const col in columnFilters) {
+            if (!rowPassesColumn(row, col, columnFilters[col])) return false;
         }
-
-        // Check Project Name filter
-        if (selectedProjectName !== ALL_OPTION_VALUE) {
-            const projectNameValue = row.project_name ?? row['NAME'];
-            if ((projectNameValue ?? '').toString().trim() !== selectedProjectName) {
-                return false;
-            }
-        }
-
-        // Check Procore Status filter
-        if (selectedProcoreStatus !== ALL_OPTION_VALUE) {
-            const statusValue = row.status ?? row['PROCORE STATUS'] ?? '';
-            if ((statusValue ?? '').toString().trim() !== selectedProcoreStatus) {
-                return false;
-            }
-        }
-
-        // Text search across project name, title, and ball in court
-        if (search.trim() !== '') {
-            const keywords = search.trim().toLowerCase().split(/\s+/);
-            const haystack = [
-                String(row.project_name ?? row['NAME'] ?? ''),
-                String(row.title ?? row['TITLE'] ?? ''),
-                String(row.ball_in_court ?? row['BIC'] ?? ''),
-            ].join(' ').toLowerCase();
-            if (!keywords.every(kw => haystack.includes(kw))) {
-                return false;
-            }
-        }
-
         return true;
-    }, [selectedBallInCourt, selectedSubmittalManager, selectedProjectName, selectedProcoreStatus, search]);
+    }, [columnFilters]);
+
+    const matchesSelectedFilter = useCallback(
+        (row) => matchesColumnFilters(row) && matchesSearch(row),
+        [matchesColumnFilters, matchesSearch]
+    );
 
     /**
      * Sort rows based on columnSort state
@@ -261,169 +288,125 @@ export function useFilters(rows = []) {
     }, [columnSort]);
 
     /**
+     * Rows after the always-on 'For Construction' exclusion (the base set every
+     * filter and reachable-value calculation starts from).
+     */
+    const baseRows = useMemo(
+        () => rows.filter((row) => (row.type ?? row['Type'] ?? '') !== 'For Construction'),
+        [rows]
+    );
+
+    /**
      * Filtered and sorted rows for display
      */
     const displayRows = useMemo(() => {
-        // First, filter out rows where type is 'For Construction'
-        const withoutForConstruction = rows.filter((row) => {
-            const type = row.type ?? row['Type'] ?? '';
-            return type !== 'For Construction';
-        });
-        // Then apply user-selected filters
-        const filtered = withoutForConstruction.filter(matchesSelectedFilter);
-        return sortRows([...filtered]); // Create a copy to avoid mutating the filtered array
-    }, [rows, matchesSelectedFilter, sortRows]);
+        const filtered = baseRows.filter(matchesSelectedFilter);
+        return sortRows([...filtered]); // copy to avoid mutating the filtered array
+    }, [baseRows, matchesSelectedFilter, sortRows]);
 
     /**
-     * Extract unique ball in court options from rows
-     * Handles comma-separated values by extracting individual names
-     * Excludes rows where type is 'For Construction'
+     * Per-column reachable values: for each filterable column C, the distinct non-blank
+     * values present in rows that pass search + every active column filter EXCEPT C's own
+     * (Excel-style narrowing). BIC is exploded into individual comma-split names.
      */
-    const ballInCourtOptions = useMemo(() => {
-        const values = new Set();
-        rows.forEach((row) => {
-            const type = row.type ?? row['Type'] ?? '';
-            if (type === 'For Construction') return;
+    const uniqueValuesByColumn = useMemo(() => {
+        const out = {};
+        FILTER_COLUMNS.forEach((col) => {
+            const set = new Set();
+            let hasBlanks = false;
+            for (const row of baseRows) {
+                if (!matchesSearch(row)) continue;
+                let ok = true;
+                for (const k in columnFilters) {
+                    if (k === col) continue;
+                    if (!rowPassesColumn(row, k, columnFilters[k])) {
+                        ok = false;
+                        break;
+                    }
+                }
+                if (!ok) continue;
 
-            const value = row.ball_in_court;
-            if (value !== null && value !== undefined && String(value).trim() !== '') {
-                const names = String(value).split(',').map(name => name.trim()).filter(name => name !== '');
-                names.forEach(name => values.add(name));
+                if (col === 'BIC') {
+                    const raw = (row.ball_in_court ?? row['BIC'] ?? '').toString().trim();
+                    if (raw === '') hasBlanks = true;
+                    else raw.split(',').map((n) => n.trim()).filter(Boolean).forEach((n) => set.add(n));
+                } else {
+                    const v = getColumnValue(row, col);
+                    if (v === null || v === undefined || String(v).trim() === '') hasBlanks = true;
+                    else set.add(String(v).trim());
+                }
             }
+            out[col] = {
+                values: [...set].sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })),
+                hasBlanks,
+            };
         });
-        return Array.from(values).sort((a, b) => a.localeCompare(b));
-    }, [rows]);
+        return out;
+    }, [baseRows, columnFilters, matchesSearch]);
 
     /**
-     * Extract unique submittal manager options from rows
-     * Excludes rows where type is 'For Construction'
+     * The lone selected Ball-In-Court drafter, when exactly one non-blank name is
+     * checked in the BIC column filter — drives the admin Resort button. Null otherwise.
      */
-    const submittalManagerOptions = useMemo(() => {
-        const values = new Set();
-        rows.forEach((row) => {
-            const type = row.type ?? row['Type'] ?? '';
-            if (type === 'For Construction') return;
-
-            const value = row.submittal_manager ?? row['Submittal Manager'];
-            if (value !== null && value !== undefined && String(value).trim() !== '') {
-                values.add(String(value).trim());
-            }
-        });
-        return Array.from(values).sort((a, b) => a.localeCompare(b));
-    }, [rows]);
-
-    /**
-     * Extract unique project name options from rows
-     * Excludes rows where type is 'For Construction'
-     */
-    const projectNameOptions = useMemo(() => {
-        const values = new Set();
-        rows.forEach((row) => {
-            const type = row.type ?? row['Type'] ?? '';
-            if (type === 'For Construction') return;
-
-            const value = row.project_name ?? row['NAME'];
-            if (value !== null && value !== undefined && String(value).trim() !== '') {
-                values.add(String(value).trim());
-            }
-        });
-        return Array.from(values).sort((a, b) => a.localeCompare(b));
-    }, [rows]);
-
-    /**
-     * Extract unique Procore status options from rows (subset of statuses present in current data)
-     * Excludes rows where type is 'For Construction'
-     */
-    const procoreStatusOptions = useMemo(() => {
-        const values = new Set();
-        rows.forEach((row) => {
-            const type = row.type ?? row['Type'] ?? '';
-            if (type === 'For Construction') return;
-
-            const value = row.status ?? row['PROCORE STATUS'];
-            if (value !== null && value !== undefined && String(value).trim() !== '') {
-                values.add(String(value).trim());
-            }
-        });
-        return Array.from(values).sort((a, b) => a.localeCompare(b));
-    }, [rows]);
+    const singleSelectedBallInCourt = useMemo(() => {
+        const sel = (columnFilters['BIC'] || []).filter((v) => v !== BLANKS);
+        return sel.length === 1 ? sel[0] : null;
+    }, [columnFilters]);
 
     /**
      * Reset all filters to default values
      */
     const resetFilters = useCallback(() => {
-        setSelectedBallInCourt(ALL_OPTION_VALUE);
-        setSelectedSubmittalManager(ALL_OPTION_VALUE);
-        setSelectedProjectName(ALL_OPTION_VALUE);
-        setSelectedProcoreStatus(ALL_OPTION_VALUE);
+        setColumnFiltersState({});
         setSearch('');
         setColumnSort({ column: null, direction: null });
     }, []);
 
     /**
-     * Handle column sort toggle: null -> asc -> desc -> null (cycle)
+     * Cycle column sort: null -> asc -> desc -> null. Used by the plain (non-dropdown)
+     * sortable headers (TITLE, LAST BIC, TYPE, DUE DATE, LIFESPAN, PROJ. #).
      */
     const handleColumnSort = useCallback((column) => {
         setColumnSort((current) => {
-            // If clicking the same column, cycle: null -> asc -> desc -> null
             if (current.column === column) {
-                if (current.direction === null) {
-                    return { column, direction: 'asc' };
-                } else if (current.direction === 'asc') {
-                    return { column, direction: 'desc' };
-                } else {
-                    return { column: null, direction: null };
-                }
+                if (current.direction === null) return { column, direction: 'asc' };
+                if (current.direction === 'asc') return { column, direction: 'desc' };
+                return { column: null, direction: null };
             }
-            // If clicking a different column, start with asc
             return { column, direction: 'asc' };
         });
     }, []);
 
-    // handleProjectNameSortToggle for NAME column
-    // Maps 'normal' -> null, 'a-z' -> asc, 'z-a' -> desc
-    const handleProjectNameSortToggle = useCallback(() => {
-        handleColumnSort('NAME');
-    }, [handleColumnSort]);
-
-    // Get current sort state for NAME column
-    const projectNameSortMode = useMemo(() => {
-        if (columnSort.column !== 'NAME') return 'normal';
-        if (columnSort.direction === 'asc') return 'a-z';
-        if (columnSort.direction === 'desc') return 'z-a';
-        return 'normal';
-    }, [columnSort]);
+    /**
+     * Direct sort setter for the column-header dropdowns, which pass an explicit
+     * 'asc' | 'desc' | null rather than cycling.
+     */
+    const setColumnSortDirect = useCallback((column, direction) => {
+        if (!direction) setColumnSort({ column: null, direction: null });
+        else setColumnSort({ column, direction });
+    }, []);
 
     return {
         // Filter state
         search,
-        selectedBallInCourt,
-        selectedSubmittalManager,
-        selectedProjectName,
-        selectedProcoreStatus,
-        columnSort, // New general column sort state
-        projectNameSortMode, // Backward compatibility
+        columnFilters,
+        columnSort,
 
-        // Filter setters
+        // Setters / handlers
         setSearch,
-        setSelectedBallInCourt,
-        setSelectedSubmittalManager,
-        setSelectedProjectName,
-        setSelectedProcoreStatus,
+        setColumnFilter,
+        handleColumnSort,
+        setColumnSortDirect,
+        resetFilters,
 
-        // Filter options
-        ballInCourtOptions,
-        submittalManagerOptions,
-        projectNameOptions,
-        procoreStatusOptions,
+        // Reachable per-column values for the header dropdowns
+        uniqueValuesByColumn,
+
+        // Derived
+        singleSelectedBallInCourt,
 
         // Filtered and sorted rows
         displayRows,
-
-        // Actions
-        resetFilters,
-        handleColumnSort, // New general column sort handler
-        handleProjectNameSortToggle, // Backward compatibility
 
         // Constants
         ALL_OPTION_VALUE,

--- a/frontend/src/pages/DraftingWorkLoad.jsx
+++ b/frontend/src/pages/DraftingWorkLoad.jsx
@@ -20,7 +20,7 @@ import { useMutations } from '../hooks/useMutations';
 import { useFilters } from '../hooks/useFilters';
 import { useDWLDragAndDrop } from '../hooks/useDWLDragAndDrop';
 import { TableRow } from '../components/TableRow';
-import { FilterButtonGroup } from '../components/FilterButtonGroup';
+import ColumnHeaderFilter from '../components/ColumnHeaderFilter';
 import { AlertMessage } from '../components/AlertMessage';
 import { AddProjectModal } from '../components/AddProjectModal';
 import { generateDraftingWorkLoadPDF } from '../utils/pdfUtils';
@@ -49,13 +49,23 @@ const columnWidthStyles = `
     }
 `;
 
+// Friendly labels + display order for the active-filter chips (keys match useFilters' columnFilters).
+const FILTER_LABELS = {
+    'PROJ. #': 'Project #',
+    'NAME': 'Project Name',
+    'TITLE': 'Title',
+    'BIC': 'Ball in Court',
+    'SUB MANAGER': 'Sub Manager',
+    'PROCORE STATUS': 'Procore Status',
+};
+const FILTER_CHIP_ORDER = ['PROJ. #', 'NAME', 'TITLE', 'BIC', 'SUB MANAGER', 'PROCORE STATUS'];
+
 function DraftingWorkLoad() {
     const [searchParams] = useSearchParams();
     const { locationFilter } = useLocationContext();
     const [resorting, setResorting] = useState(false);
     const [resortError, setResortError] = useState(null);
     const [addProjectOpen, setAddProjectOpen] = useState(false);
-    const [isFilterMinimized, setIsFilterMinimized] = useState(false);
     const [viewMode, setViewMode] = useViewMode('dwl_view', 'auto');
     const isTabletOrSmaller = useIsTabletOrSmaller();
     const { is3xl } = useBreakpoint();
@@ -125,26 +135,16 @@ function DraftingWorkLoad() {
     // Use the filters hook
     const {
         search,
-        selectedBallInCourt,
-        selectedSubmittalManager,
-        selectedProjectName,
-        selectedProcoreStatus,
-        projectNameSortMode,
+        columnFilters,
         columnSort,
         setSearch,
-        setSelectedBallInCourt,
-        setSelectedSubmittalManager,
-        setSelectedProjectName,
-        setSelectedProcoreStatus,
-        ballInCourtOptions,
-        submittalManagerOptions,
-        projectNameOptions,
-        procoreStatusOptions,
-        displayRows,
-        resetFilters,
-        handleProjectNameSortToggle,
+        setColumnFilter,
         handleColumnSort,
-        ALL_OPTION_VALUE,
+        setColumnSortDirect,
+        resetFilters,
+        uniqueValuesByColumn,
+        singleSelectedBallInCourt,
+        displayRows,
     } = useFilters(rows);
 
     // Use the drag-and-drop hook
@@ -166,18 +166,18 @@ function DraftingWorkLoad() {
     });
 
     const handleResort = useCallback(async () => {
-        if (selectedBallInCourt === ALL_OPTION_VALUE) return;
+        if (!singleSelectedBallInCourt) return;
         setResorting(true);
         setResortError(null);
         try {
-            await draftingWorkLoadApi.resortDrafter(selectedBallInCourt);
+            await draftingWorkLoadApi.resortDrafter(singleSelectedBallInCourt);
             await refetch();
         } catch (err) {
             setResortError(err.message);
         } finally {
             setResorting(false);
         }
-    }, [selectedBallInCourt, ALL_OPTION_VALUE, refetch]);
+    }, [singleSelectedBallInCourt, refetch]);
 
     const handleGeneratePDF = useCallback(() => {
         generateDraftingWorkLoadPDF(displayRows, columns, lastUpdated);
@@ -197,6 +197,20 @@ function DraftingWorkLoad() {
     const formattedLastUpdated = useMemo(
         () => lastUpdated ? new Date(lastUpdated).toLocaleString() : 'Unknown',
         [lastUpdated]
+    );
+
+    // Active per-column filters, as removable chips — one chip per selected value
+    // so multiple selections in the same column (e.g. two BICs) each show and can
+    // be removed individually.
+    const activeFilterChips = useMemo(
+        () => FILTER_CHIP_ORDER
+            .filter((col) => (columnFilters[col]?.length ?? 0) > 0)
+            .flatMap((col) => columnFilters[col].map((value) => ({
+                column: col,
+                value,
+                label: FILTER_LABELS[col] ?? col,
+            }))),
+        [columnFilters]
     );
 
     const hasData = displayRows.length > 0;
@@ -219,18 +233,17 @@ function DraftingWorkLoad() {
             >
                 <div className="flex-1 min-h-0 max-w-full mx-auto w-full py-2 px-2 flex flex-col" style={{ width: '100%' }}>
                     <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl overflow-hidden flex flex-col flex-1 min-h-0">
-                        {/* Title bar - fixed, does not scroll */}
-                        <div className={`flex-shrink-0 px-4 py-3 ${selectedTab === 'draft' ? 'bg-gradient-to-r from-green-500 to-green-600' : 'bg-gradient-to-r from-accent-500 to-accent-600'}`}>
-                            <div className="flex items-center justify-between gap-2 flex-wrap">
-                                <div>
-                                    <h1 className="text-xl md:text-2xl 3xl:text-3xl font-bold text-white">Drafting Work Load</h1>
-                                </div>
-                                <div className="flex items-center gap-2 md:gap-3 flex-wrap">
-                                    <ViewToggle value={viewMode} onChange={setViewMode} className="bg-white/95" />
+                        {/* Actions + Filters - fixed, do not scroll */}
+                        <div className="flex-shrink-0 p-2">
+                            <div className="bg-gray-100 dark:bg-slate-700 rounded-lg px-3 py-2.5 border border-gray-200 dark:border-slate-600 space-y-2.5">
+                                {/* Actions row */}
+                                <div className="flex items-center gap-2.5 flex-wrap">
+                                    <ViewToggle value={viewMode} onChange={setViewMode} />
+                                    {isAdmin && <span className="hidden sm:block h-5 w-px bg-gray-300 dark:bg-slate-500" aria-hidden="true" />}
                                     {isAdmin && (
                                     <button
                                         onClick={() => setAddProjectOpen(true)}
-                                        className="inline-flex items-center px-4 py-2 rounded-lg font-medium shadow-sm transition-all bg-white dark:bg-slate-700 text-accent-600 dark:text-accent-300 hover:bg-accent-50 dark:hover:bg-slate-600 cursor-pointer"
+                                        className="px-3 py-1.5 rounded-md text-xs font-semibold transition-all whitespace-nowrap bg-amber-50 dark:bg-amber-900/30 border border-amber-400 dark:border-amber-600 text-amber-700 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900/50 cursor-pointer"
                                         title="Add a new Procore project to the system"
                                     >
                                         + Add Project
@@ -239,15 +252,15 @@ function DraftingWorkLoad() {
                                     {isAdmin && (
                                     <button
                                         onClick={handleResort}
-                                        disabled={selectedBallInCourt === ALL_OPTION_VALUE || resorting}
-                                        className={`inline-flex items-center px-4 py-2 rounded-lg font-medium shadow-sm transition-all ${
-                                            selectedBallInCourt === ALL_OPTION_VALUE || resorting
-                                                ? 'bg-gray-300 dark:bg-slate-600 text-gray-500 dark:text-slate-400 cursor-not-allowed'
-                                                : 'bg-white dark:bg-slate-700 text-accent-600 dark:text-accent-300 hover:bg-accent-50 dark:hover:bg-slate-600 cursor-pointer'
+                                        disabled={!singleSelectedBallInCourt || resorting}
+                                        className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-all whitespace-nowrap ${
+                                            !singleSelectedBallInCourt || resorting
+                                                ? 'bg-gray-200 dark:bg-slate-600 border border-gray-300 dark:border-slate-500 text-gray-400 dark:text-slate-400 cursor-not-allowed'
+                                                : 'bg-amber-50 dark:bg-amber-900/30 border border-amber-400 dark:border-amber-600 text-amber-700 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900/50 cursor-pointer'
                                         }`}
-                                        title={selectedBallInCourt === ALL_OPTION_VALUE
-                                            ? 'Select a single drafter to enable resort'
-                                            : `Compress ${selectedBallInCourt}'s ordered submittals to sequential numbers`}
+                                        title={!singleSelectedBallInCourt
+                                            ? 'Filter the BIC column to a single drafter to enable resort'
+                                            : `Compress ${singleSelectedBallInCourt}'s ordered submittals to sequential numbers`}
                                     >
                                         {resorting ? 'Resorting\u2026' : '\u2195 Resort'}
                                     </button>
@@ -255,194 +268,95 @@ function DraftingWorkLoad() {
                                     <button
                                         onClick={handleGeneratePDF}
                                         disabled={!hasData || loading}
-                                        className={`inline-flex items-center px-4 py-2 rounded-lg font-medium shadow-sm transition-all ${!hasData || loading
-                                            ? 'bg-gray-300 dark:bg-slate-600 text-gray-500 dark:text-slate-400 cursor-not-allowed'
-                                            : 'bg-white dark:bg-slate-700 text-accent-600 dark:text-accent-300 hover:bg-accent-50 dark:hover:bg-slate-600 cursor-pointer'
+                                        className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-all whitespace-nowrap ${!hasData || loading
+                                            ? 'bg-gray-200 dark:bg-slate-600 border border-gray-300 dark:border-slate-500 text-gray-400 dark:text-slate-400 cursor-not-allowed'
+                                            : 'bg-white dark:bg-slate-600 border border-gray-400 dark:border-slate-500 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-500 cursor-pointer'
                                             }`}
                                         title="Generate PDF"
                                     >
                                         🖨️ Print/PDF
                                     </button>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Tabs + Filters - fixed, do not scroll */}
-                        <div className="flex-shrink-0 p-2 space-y-2">
-                            {/* Tab Selection */}
-                            <div className="bg-white dark:bg-slate-800 rounded-xl p-2 border border-gray-200 dark:border-slate-600 shadow-sm">
-                                <div className="flex gap-2">
-                                    <button
-                                        onClick={() => setSelectedTab('open')}
-                                        className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${selectedTab === 'open'
-                                            ? 'bg-gradient-to-r from-accent-500 to-accent-600 text-white shadow-md'
-                                            : 'bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-slate-200 hover:bg-gray-200 dark:hover:bg-slate-600'
-                                            }`}
-                                    >
-                                        Open
-                                    </button>
-                                    <button
-                                        onClick={() => setSelectedTab('draft')}
-                                        className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${selectedTab === 'draft'
-                                            ? 'bg-gradient-to-r from-green-500 to-green-600 text-white shadow-md'
-                                            : 'bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-slate-200 hover:bg-gray-200 dark:hover:bg-slate-600'
-                                            }`}
-                                    >
-                                        Draft
-                                    </button>
-                                </div>
-                            </div>
-                            <div className={`rounded-xl p-2 border border-gray-200 dark:border-slate-600 shadow-sm ${selectedTab === 'draft' ? 'bg-gradient-to-r from-gray-50 to-green-50 dark:from-slate-700 dark:to-slate-700' : 'bg-gradient-to-r from-gray-50 to-accent-50 dark:from-slate-700 dark:to-slate-700'}`}>
-                                {/* Filter header with chevron toggle */}
-                                <div className="flex items-center justify-between mb-2 px-1">
-                                    <span className="text-xs font-semibold text-gray-500 dark:text-slate-400">Filters</span>
-                                    <button
-                                        onClick={() => setIsFilterMinimized(v => !v)}
-                                        className="p-1.5 rounded-lg hover:bg-gray-300 dark:hover:bg-slate-600 transition-colors"
-                                        title={isFilterMinimized ? 'Expand filters' : 'Collapse filters'}
-                                    >
-                                        <span className="text-xl leading-none text-gray-600 dark:text-slate-300">
-                                            {isFilterMinimized ? '▾' : '▴'}
-                                        </span>
-                                    </button>
+                                    <div className="ml-auto text-xs text-gray-500 dark:text-slate-400 whitespace-nowrap">
+                                        Last updated <span className="font-semibold text-gray-700 dark:text-slate-200">{formattedLastUpdated}</span>
+                                    </div>
                                 </div>
 
-                                <div className="flex flex-col gap-3">
-                                    {/* Show full filter panel when expanded */}
-                                    {!isFilterMinimized && (
-                                        <div className="grid grid-cols-2 gap-3">
-                                            <div className="flex flex-col gap-3">
-                                                <FilterButtonGroup
-                                                    label="🎯 Ball In Court"
-                                                    options={ballInCourtOptions}
-                                                    selectedValue={selectedBallInCourt}
-                                                    onSelect={setSelectedBallInCourt}
-                                                    allOptionValue={ALL_OPTION_VALUE}
-                                                    minimized={false}
-                                                />
-                                                <FilterButtonGroup
-                                                    label="👤 Submittal Manager"
-                                                    options={submittalManagerOptions}
-                                                    selectedValue={selectedSubmittalManager}
-                                                    onSelect={setSelectedSubmittalManager}
-                                                    allOptionValue={ALL_OPTION_VALUE}
-                                                    minimized={false}
-                                                />
-                                            </div>
-                                            <div>
-                                                <FilterButtonGroup
-                                                    label="📁 Project Name"
-                                                    options={projectNameOptions}
-                                                    selectedValue={selectedProjectName}
-                                                    onSelect={setSelectedProjectName}
-                                                    allOptionValue={ALL_OPTION_VALUE}
-                                                    minimized={false}
-                                                />
-                                                <FilterButtonGroup
-                                                    label="📋 Procore Status"
-                                                    options={procoreStatusOptions}
-                                                    selectedValue={selectedProcoreStatus}
-                                                    onSelect={setSelectedProcoreStatus}
-                                                    allOptionValue={ALL_OPTION_VALUE}
-                                                    minimized={false}
-                                                />
-                                            </div>
-                                        </div>
-                                    )}
+                                {/* Divider between actions and filters */}
+                                <div className="border-t border-gray-200 dark:border-slate-600" />
 
-                                    {/* Show minimized filter labels with inline badges */}
-                                    {isFilterMinimized && (
-                                        <div className="flex items-center gap-4 flex-wrap text-xs">
-                                            {/* Ball In Court */}
-                                            <div className="flex items-center gap-1.5">
-                                                <span className="font-semibold text-gray-600 dark:text-slate-300">🎯 Ball In Court</span>
-                                                {selectedBallInCourt !== ALL_OPTION_VALUE && (
-                                                    <span className="px-2 py-0.5 bg-accent-100 dark:bg-accent-900 text-accent-700 dark:text-accent-300 rounded-full font-medium">
-                                                        {selectedBallInCourt}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {/* Submittal Manager */}
-                                            <div className="flex items-center gap-1.5">
-                                                <span className="font-semibold text-gray-600 dark:text-slate-300">👤 Submittal Manager</span>
-                                                {selectedSubmittalManager !== ALL_OPTION_VALUE && (
-                                                    <span className="px-2 py-0.5 bg-accent-100 dark:bg-accent-900 text-accent-700 dark:text-accent-300 rounded-full font-medium">
-                                                        {selectedSubmittalManager}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {/* Project Name */}
-                                            <div className="flex items-center gap-1.5">
-                                                <span className="font-semibold text-gray-600 dark:text-slate-300">📁 Project Name</span>
-                                                {selectedProjectName !== ALL_OPTION_VALUE && (
-                                                    <span className="px-2 py-0.5 bg-accent-100 dark:bg-accent-900 text-accent-700 dark:text-accent-300 rounded-full font-medium">
-                                                        {selectedProjectName}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {/* Procore Status */}
-                                            <div className="flex items-center gap-1.5">
-                                                <span className="font-semibold text-gray-600 dark:text-slate-300">📋 Procore Status</span>
-                                                {selectedProcoreStatus !== ALL_OPTION_VALUE && (
-                                                    <span className="px-2 py-0.5 bg-accent-100 dark:bg-accent-900 text-accent-700 dark:text-accent-300 rounded-full font-medium">
-                                                        {selectedProcoreStatus}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {/* Search */}
-                                            <div className="flex items-center gap-1.5">
-                                                <label className="text-xs font-semibold text-gray-600 dark:text-slate-300 whitespace-nowrap">Search:</label>
-                                                <input
-                                                    type="text"
-                                                    value={search}
-                                                    onChange={(e) => setSearch(e.target.value)}
-                                                    placeholder="Name, title, BIC..."
-                                                    className="w-48 px-2 py-0.5 text-xs border border-gray-300 dark:border-slate-500 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-slate-600 text-gray-900 dark:text-slate-100"
-                                                />
-                                            </div>
-                                            <button
-                                                onClick={resetFilters}
-                                                className="px-2 py-1 bg-white dark:bg-slate-600 border border-accent-300 dark:border-accent-600 text-accent-700 dark:text-accent-300 rounded text-xs font-medium shadow-sm hover:bg-accent-50 dark:hover:bg-slate-500 transition-all"
+                                {/* Filters row */}
+                                <div className="flex items-center gap-2.5 flex-wrap">
+                                    {/* Open / Draft segmented toggle */}
+                                    <div className="inline-flex rounded-md border border-gray-400 dark:border-slate-500 overflow-hidden shadow-sm">
+                                        <button
+                                            onClick={() => setSelectedTab('open')}
+                                            className={`px-3.5 py-1.5 text-xs font-semibold transition-all whitespace-nowrap ${selectedTab === 'open'
+                                                ? 'bg-blue-700 text-white'
+                                                : 'bg-white dark:bg-slate-600 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-500'
+                                                }`}
+                                        >
+                                            Open
+                                        </button>
+                                        <button
+                                            onClick={() => setSelectedTab('draft')}
+                                            className={`px-3.5 py-1.5 text-xs font-semibold transition-all whitespace-nowrap border-l border-gray-400 dark:border-slate-500 ${selectedTab === 'draft'
+                                                ? 'bg-blue-700 text-white'
+                                                : 'bg-white dark:bg-slate-600 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-500'
+                                                }`}
+                                        >
+                                            Draft
+                                        </button>
+                                    </div>
+
+                                    <span className="hidden sm:block h-5 w-px bg-gray-300 dark:bg-slate-500" aria-hidden="true" />
+
+                                    {/* Search */}
+                                    <div className="flex items-center gap-2">
+                                        <label className="text-xs font-semibold text-gray-700 dark:text-slate-200 whitespace-nowrap">Search</label>
+                                        <input
+                                            type="text"
+                                            value={search}
+                                            onChange={(e) => setSearch(e.target.value)}
+                                            placeholder="Project, title, BIC, manager…"
+                                            className="w-48 sm:w-72 px-3 py-1.5 text-xs border border-gray-300 dark:border-slate-500 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-slate-600 text-gray-900 dark:text-slate-100"
+                                        />
+                                    </div>
+
+                                    <button
+                                        onClick={resetFilters}
+                                        className="px-3 py-1.5 bg-white dark:bg-slate-600 border border-accent-300 dark:border-accent-600 text-accent-700 dark:text-accent-300 rounded-md text-xs font-semibold shadow-sm hover:bg-accent-50 dark:hover:bg-slate-500 transition-all whitespace-nowrap"
+                                    >
+                                        Reset Filters
+                                    </button>
+
+                                    <div className="ml-auto text-xs text-gray-500 dark:text-slate-400 whitespace-nowrap">
+                                        Total <span className="font-semibold text-gray-900 dark:text-slate-100">{displayRows.length}</span> records
+                                    </div>
+                                </div>
+
+                                {/* Active filter chips */}
+                                {activeFilterChips.length > 0 && (
+                                    <div className="flex items-center gap-1.5 flex-wrap border-t border-gray-200 dark:border-slate-600 pt-2">
+                                        <span className="text-xs font-semibold text-gray-500 dark:text-slate-400 whitespace-nowrap">Active filters:</span>
+                                        {activeFilterChips.map((chip) => (
+                                            <span
+                                                key={`${chip.column}:${chip.value}`}
+                                                className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300 text-xs font-medium"
                                             >
-                                                Reset Filters
-                                            </button>
-                                            {/* Last updated - right-aligned */}
-                                            <span className="ml-auto text-gray-500 dark:text-slate-400">
-                                                Last updated: <span className="font-medium text-gray-700 dark:text-slate-200">{formattedLastUpdated}</span>
+                                                <span className="whitespace-nowrap">{chip.label}: {chip.value}</span>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setColumnFilter(chip.column, (columnFilters[chip.column] ?? []).filter((v) => v !== chip.value))}
+                                                    className="flex items-center justify-center w-4 h-4 rounded-full leading-none text-blue-500 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800 hover:text-blue-800 dark:hover:text-blue-100 transition-colors"
+                                                    aria-label={`Remove ${chip.label} filter ${chip.value}`}
+                                                    title={`Remove ${chip.label}: ${chip.value}`}
+                                                >
+                                                    ×
+                                                </button>
                                             </span>
-                                        </div>
-                                    )}
-
-                                    {/* Bottom bar (Reset, Total count) - shown when expanded */}
-                                    {!isFilterMinimized && (
-                                        <div className="flex items-center gap-2 pt-2">
-                                            <div className="flex items-center gap-1.5">
-                                                <label className="text-xs font-semibold text-gray-700 dark:text-slate-200 whitespace-nowrap">
-                                                    Search:
-                                                </label>
-                                                <input
-                                                    type="text"
-                                                    value={search}
-                                                    onChange={(e) => setSearch(e.target.value)}
-                                                    placeholder="Name, title, BIC..."
-                                                    className="w-64 px-2 py-0.5 text-xs border border-gray-300 dark:border-slate-500 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-slate-600 text-gray-900 dark:text-slate-100"
-                                                />
-                                            </div>
-                                            <button
-                                                onClick={resetFilters}
-                                                className="px-2 py-1 bg-white dark:bg-slate-600 border border-accent-300 dark:border-accent-600 text-accent-700 dark:text-accent-300 rounded text-xs font-medium shadow-sm hover:bg-accent-50 dark:hover:bg-slate-500 transition-all"
-                                            >
-                                                Reset Filters
-                                            </button>
-                                            <div className="px-2 py-1 bg-white dark:bg-slate-600 border border-gray-200 dark:border-slate-500 text-gray-600 dark:text-slate-300 rounded text-xs font-medium shadow-sm">
-                                                Total: <span className="text-gray-900 dark:text-slate-100">{displayRows.length}</span> records
-                                            </div>
-                                            <div className="text-xs text-gray-500 dark:text-slate-400 ml-auto">
-                                                Last updated: <span className="font-medium text-gray-700 dark:text-slate-200">{formattedLastUpdated}</span>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
+                                        ))}
+                                    </div>
+                                )}
                             </div>
                         </div>
 
@@ -561,27 +475,30 @@ function DraftingWorkLoad() {
                                                     const isSorted = columnSort.column === column;
                                                     const sortDirection = isSorted ? columnSort.direction : null;
 
-                                                    if (isProjectName) {
+                                                    // Excel-style header dropdown filter for these columns
+                                                    const isFilterable = isProjectNumber || isProjectName || isTitle || isBallInCourt || isSubmittalManager || isProcoreStatus;
+                                                    if (isFilterable) {
+                                                        const colInfo = uniqueValuesByColumn[column];
+                                                        const colSelected = columnFilters[column] ?? [];
                                                         return (
                                                             <th
                                                                 key={column}
-                                                                className="px-1 py-0.5 text-center text-xs font-bold text-gray-900 dark:text-slate-100 uppercase tracking-wider bg-gray-100 dark:bg-slate-700 border-r border-gray-300 dark:border-slate-600 dwl-col-name"
-                                                                style={{ width: '12%' }}
+                                                                className={`${headerPaddingClass} text-center text-xs font-bold text-gray-900 dark:text-slate-100 uppercase tracking-wider bg-gray-100 dark:bg-slate-700 border-r border-gray-300 dark:border-slate-600 ${columnClass}`}
+                                                                style={headerStyle}
                                                             >
-                                                                <button
-                                                                    onClick={handleProjectNameSortToggle}
-                                                                    className="flex items-center justify-center gap-1 hover:bg-gray-200 rounded px-1 py-0.5 transition-colors w-full"
-                                                                    title={
-                                                                        projectNameSortMode === 'normal' ? 'Click to sort A-Z' :
-                                                                            projectNameSortMode === 'a-z' ? 'Click to sort Z-A' :
-                                                                                'Click to sort by Order Number'
-                                                                    }
+                                                                <ColumnHeaderFilter
+                                                                    column={column}
+                                                                    values={colInfo?.values ?? []}
+                                                                    hasBlanks={colInfo?.hasBlanks ?? false}
+                                                                    selected={new Set(colSelected)}
+                                                                    onChange={(next) => setColumnFilter(column, [...next])}
+                                                                    sort={columnSort}
+                                                                    onSort={(dir) => setColumnSortDirect(column, dir)}
+                                                                    isActive={colSelected.length > 0}
+                                                                    autoWidth
                                                                 >
-                                                                    <span>{column}</span>
-                                                                    {projectNameSortMode === 'a-z' && <span className="text-xs">↑</span>}
-                                                                    {projectNameSortMode === 'z-a' && <span className="text-xs">↓</span>}
-                                                                    {projectNameSortMode === 'normal' && <span className="text-xs text-gray-400 dark:text-slate-400">↕</span>}
-                                                                </button>
+                                                                    {column}
+                                                                </ColumnHeaderFilter>
                                                             </th>
                                                         );
                                                     }

--- a/frontend/src/pages/Meetings.jsx
+++ b/frontend/src/pages/Meetings.jsx
@@ -1,0 +1,392 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: Admin page for the meeting → checklist → to-do/notify flow — paste a transcript, then curate
+ *          the agent-proposed checklist (yes / no / edit owner + due date). Accepted items notify their owner.
+ * exports:
+ *   Meetings: Page component (admin-only).
+ * imports_from: [react, ../utils/auth, ../services/meetingsApi]
+ * imported_by: [App.jsx]
+ * invariants:
+ *   - Admin-only; non-admins see an access-denied message (matches Board).
+ *   - Owner + due date are agent-proposed but the reviewer has final say before accepting.
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { checkAuth } from '../utils/auth';
+import {
+    createMeeting, fetchMeetings, fetchMeeting,
+    reviewChecklistItem, fetchAssignableUsers, scanDue,
+} from '../services/meetingsApi';
+
+const MEETING_TYPES = [
+    { value: 'internal_draft', label: 'Internal — Draft' },
+    { value: 'internal_shop', label: 'Internal — Shop' },
+    { value: 'gc_pm', label: 'GC / PM' },
+    { value: 'other', label: 'Other' },
+];
+const MEETING_TYPE_LABEL = Object.fromEntries(MEETING_TYPES.map(t => [t.value, t.label]));
+
+const ITEM_TYPES = [
+    { value: 'action', label: 'Action', badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' },
+    { value: 'needs_gc_update', label: 'GC update', badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300' },
+    { value: 'decision', label: 'Decision', badge: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300' },
+    { value: 'risk', label: 'Risk', badge: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' },
+    { value: 'fyi', label: 'FYI', badge: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300' },
+];
+const ITEM_TYPE_BADGE = Object.fromEntries(ITEM_TYPES.map(t => [t.value, t]));
+
+const draftFromItem = (it) => ({
+    title: it.title || '',
+    detail: it.detail || '',
+    item_type: it.item_type || 'action',
+    gc_facing: !!it.gc_facing,
+    owner_user_id: String(it.owner_user_id ?? it.proposed_owner_user_id ?? ''),
+    due_date: it.due_date ?? it.proposed_due_date ?? '',
+});
+
+// --- Self-contained demo (no backend / LLM / DB needed) --------------------
+// A realistic post-meeting checklist so the HITL review can be shown live to a
+// client. Review actions on a demo meeting mutate local state only.
+const DEMO_USERS = [
+    { id: 1, first_name: 'Bill', last_name: "O'Neill" },
+    { id: 2, first_name: 'David', last_name: 'Servold' },
+    { id: 3, first_name: 'Katie', last_name: 'Hearn' },
+    { id: 4, first_name: 'Luis', last_name: 'Solano' },
+    { id: 5, first_name: 'Gary', last_name: 'Almeida' },
+    { id: 6, first_name: 'Dalton', last_name: 'Rauer' },
+];
+
+const DEMO_TRANSCRIPT = `Shop touch-base — Tuesday AM
+
+Bill: Let's run the list. Stair 6 first — what happened with the treads?
+Luis: They didn't fit on the install attempt, the landing connection was off. We need to refab the treads and get them back to site, I'm thinking Thursday.
+Bill: Alright. Garrett's going to ask about Stair 5 again on our call.
+Gary: Five's still in drafting — realistically four weeks out before it's released for fab. I'll get him the updated timeline today so we're straight with him.
+David: On the loose lintels — those are galvanized, I need to confirm the lead time with Dencol before we promise a date.
+Gary: Pergola precast is still on hold, we're waiting on Wildcat to stamp the anchor detail. That's blocking, somebody needs to chase it.
+Luis: Area 2 relief angle is welded and through QC, it's basically ready to ship — just need to lock the delivery and install window.
+David: Trash room decking is still in drafting, so there's no on-site date to give yet.
+Bill: Good. Let's get the redo moving this morning.`;
+
+const _addDays = (n) => {
+    const d = new Date();
+    d.setDate(d.getDate() + n);
+    return d.toISOString().slice(0, 10);
+};
+
+function buildDemoMeeting() {
+    const mk = (id, item_type, title, owner, days, conf, gc, detail = null) => ({
+        id, status: 'proposed', item_type, title, detail, gc_facing: gc, confidence: conf,
+        proposed_owner_user_id: owner, owner_user_id: null,
+        proposed_due_date: days == null ? null : _addDays(days), due_date: null,
+        release_id: null, submittal_id: null,
+    });
+    return {
+        id: 'demo', demo: true, title: 'Shop touch-base (demo)',
+        meeting_type: 'internal_shop', project_number: '480', item_count: 6,
+        items: [
+            mk('d1', 'action', "Stair #6 — treads didn't fit; refab and get back to site", 4, 2, 0.93, false,
+                'Landing connection was off on the install attempt; redo treads.'),
+            mk('d2', 'needs_gc_update', 'Send Garrett the revised Stair #5 timeline — still in drafting (~4 weeks out)', 5, 1, 0.88, true),
+            mk('d3', 'action', 'Confirm galvanizing lead time on the loose lintels with Dencol', 2, 3, 0.76, false),
+            mk('d4', 'risk', 'Precast pergola on hold pending Wildcat stamp / anchor approval — escalate', 5, 1, 0.81, true),
+            mk('d5', 'action', 'Area 2 relief angle welded & through QC — coordinate ship + install window', 4, 4, 0.70, false),
+            mk('d6', 'decision', 'Trash room decking stays in drafting — no on-site date until released', 2, null, 0.64, false),
+        ],
+    };
+}
+
+export default function Meetings() {
+    const [isAdmin, setIsAdmin] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [meetings, setMeetings] = useState([]);
+    const [selected, setSelected] = useState(null);   // meeting + items
+    const [users, setUsers] = useState([]);
+    const [drafts, setDrafts] = useState({});          // itemId -> draft
+    const [form, setForm] = useState({ title: '', meeting_type: 'internal_shop', transcript: '' });
+    const [submitting, setSubmitting] = useState(false);
+    const [busyItem, setBusyItem] = useState(null);
+    const [error, setError] = useState(null);
+    const [scanMsg, setScanMsg] = useState(null);
+
+    useEffect(() => {
+        checkAuth().then(u => { setIsAdmin(u?.is_admin || false); setLoading(false); });
+    }, []);
+
+    const loadMeetings = useCallback(async () => {
+        try { setMeetings(await fetchMeetings()); } catch { setError('Failed to load meetings'); }
+    }, []);
+
+    useEffect(() => {
+        if (!isAdmin) return;
+        loadMeetings();
+        fetchAssignableUsers().then(setUsers).catch(() => {});
+    }, [isAdmin, loadMeetings]);
+
+    const seedDrafts = (meeting) => {
+        const d = {};
+        (meeting.items || []).forEach(it => { d[it.id] = draftFromItem(it); });
+        setDrafts(d);
+    };
+
+    const openMeeting = async (id) => {
+        setError(null);
+        try {
+            const m = await fetchMeeting(id);
+            setSelected(m);
+            seedDrafts(m);
+        } catch { setError('Failed to load meeting'); }
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!form.transcript.trim()) return;
+        setSubmitting(true); setError(null);
+        try {
+            const m = await createMeeting(form);
+            setSelected(m);
+            seedDrafts(m);
+            setMeetings(prev => [{ ...m }, ...prev]);
+            setForm({ title: '', meeting_type: form.meeting_type, transcript: '' });
+        } catch {
+            setError('Failed to ingest meeting');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const loadDemo = () => {
+        const m = buildDemoMeeting();
+        setForm(f => ({ ...f, title: m.title, meeting_type: 'internal_shop', transcript: DEMO_TRANSCRIPT }));
+        setSelected(m);
+        seedDrafts(m);
+        setError(null);
+    };
+
+    const setDraft = (itemId, patch) =>
+        setDrafts(prev => ({ ...prev, [itemId]: { ...prev[itemId], ...patch } }));
+
+    const replaceItem = (updated) =>
+        setSelected(prev => prev && ({
+            ...prev,
+            items: prev.items.map(it => (it.id === updated.id ? updated : it)),
+        }));
+
+    const review = async (itemId, action) => {
+        const d = drafts[itemId] || {};
+        const fields = action === 'reject' ? undefined : {
+            title: d.title,
+            detail: d.detail || null,
+            item_type: d.item_type,
+            gc_facing: d.gc_facing,
+            owner_user_id: d.owner_user_id ? Number(d.owner_user_id) : null,
+            due_date: d.due_date || null,
+        };
+        // Demo meeting: mutate local state only — no backend round-trip.
+        if (selected?.demo) {
+            const cur = selected.items.find(i => i.id === itemId);
+            const updated = action === 'reject' ? { ...cur, status: 'rejected' }
+                : action === 'done' ? { ...cur, status: 'done' }
+                    : { ...cur, status: 'accepted', ...fields };
+            replaceItem(updated);
+            return;
+        }
+        setBusyItem(itemId); setError(null);
+        try {
+            replaceItem(await reviewChecklistItem(itemId, { action, fields }));
+        } catch {
+            setError('Failed to update item');
+        } finally {
+            setBusyItem(null);
+        }
+    };
+
+    const runScan = async () => {
+        setScanMsg(null);
+        try { setScanMsg(`Notified ${await scanDue()} owner(s).`); }
+        catch { setScanMsg('Scan failed'); }
+    };
+
+    if (loading) return <div className="flex-1 flex items-center justify-center"><span className="text-gray-500 dark:text-slate-400">Loading…</span></div>;
+    if (!isAdmin) return <div className="flex-1 flex items-center justify-center"><span className="text-gray-500 dark:text-slate-400">Admin access required.</span></div>;
+
+    const items = selected?.items || [];
+    const proposedCount = items.filter(i => i.status === 'proposed').length;
+    const ownerOptions = selected?.demo ? DEMO_USERS : users;
+
+    return (
+        <div className="flex-1 p-4 md:p-6 max-w-[1400px] mx-auto w-full">
+            <h1 className="text-xl font-bold text-gray-900 dark:text-slate-100 mb-4">Meetings &amp; Action Items</h1>
+            {error && <div className="mb-3 px-3 py-2 rounded-lg bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300 text-sm">{error}</div>}
+
+            <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-5">
+                {/* Left: ingest + recent */}
+                <div className="space-y-5">
+                    <form onSubmit={handleSubmit} className="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 space-y-3">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-sm font-semibold text-gray-800 dark:text-slate-200">Log a meeting</h2>
+                            <button type="button" onClick={loadDemo}
+                                className="text-[11px] px-2 py-1 rounded-md border border-accent-300 dark:border-accent-600 text-accent-600 dark:text-accent-300 hover:bg-accent-50 dark:hover:bg-accent-900/20">
+                                Load demo
+                            </button>
+                        </div>
+                        <input
+                            type="text" placeholder="Title (e.g. Shop touch-base)"
+                            value={form.title} onChange={e => setForm({ ...form, title: e.target.value })}
+                            className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100"
+                        />
+                        <select
+                            value={form.meeting_type} onChange={e => setForm({ ...form, meeting_type: e.target.value })}
+                            className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100"
+                        >
+                            {MEETING_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+                        </select>
+                        <textarea
+                            placeholder="Paste the meeting transcript…" rows={8}
+                            value={form.transcript} onChange={e => setForm({ ...form, transcript: e.target.value })}
+                            className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 font-mono"
+                        />
+                        <button
+                            type="submit" disabled={submitting || !form.transcript.trim()}
+                            className="w-full px-3 py-2 text-sm font-medium rounded-lg bg-accent-500 hover:bg-accent-600 text-white disabled:opacity-50"
+                        >
+                            {submitting ? 'Extracting…' : 'Ingest & build checklist'}
+                        </button>
+                    </form>
+
+                    <div className="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+                        <div className="flex items-center justify-between mb-2">
+                            <h2 className="text-sm font-semibold text-gray-800 dark:text-slate-200">Recent meetings</h2>
+                            <button onClick={runScan} title="Send due-date notifications now"
+                                className="text-[11px] px-2 py-1 rounded-md border border-gray-300 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700">
+                                Scan due
+                            </button>
+                        </div>
+                        {scanMsg && <p className="text-[11px] text-gray-500 dark:text-slate-400 mb-2">{scanMsg}</p>}
+                        <ul className="space-y-1.5">
+                            {meetings.length === 0 && <li className="text-xs text-gray-400 dark:text-slate-500">No meetings yet.</li>}
+                            {meetings.map(m => (
+                                <li key={m.id}>
+                                    <button onClick={() => openMeeting(m.id)}
+                                        className={`w-full text-left rounded-lg border p-2 transition-colors ${selected?.id === m.id
+                                            ? 'border-accent-300 dark:border-accent-600 bg-accent-50 dark:bg-accent-900/20'
+                                            : 'border-gray-200 dark:border-slate-700 hover:border-gray-300 dark:hover:border-slate-600'}`}>
+                                        <div className="text-xs font-medium text-gray-900 dark:text-slate-100 truncate">{m.title}</div>
+                                        <div className="text-[11px] text-gray-400 dark:text-slate-500">
+                                            {MEETING_TYPE_LABEL[m.meeting_type] || m.meeting_type} · {m.item_count} item(s)
+                                            {m.project_number ? ` · #${m.project_number}` : ''}
+                                        </div>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                {/* Right: checklist review */}
+                <div className="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+                    {!selected ? (
+                        <div className="h-full flex items-center justify-center py-16 text-sm text-gray-400 dark:text-slate-500">
+                            Ingest a meeting or pick one to review its checklist.
+                        </div>
+                    ) : (
+                        <>
+                            <div className="flex items-center justify-between mb-3">
+                                <h2 className="text-sm font-semibold text-gray-800 dark:text-slate-200">
+                                    {selected.title}
+                                    {selected.demo && <span className="ml-2 px-1.5 py-0.5 text-[10px] font-semibold rounded bg-accent-100 text-accent-700 dark:bg-accent-900/40 dark:text-accent-300">DEMO</span>}
+                                    <span className="ml-2 text-xs font-normal text-gray-400 dark:text-slate-500">
+                                        {proposedCount} to review · {items.length} total
+                                    </span>
+                                </h2>
+                            </div>
+                            {items.length === 0 && <p className="text-sm text-gray-400 dark:text-slate-500">No action items were surfaced.</p>}
+                            <ul className="space-y-2.5">
+                                {items.map(it => (
+                                    <ChecklistRow
+                                        key={it.id} item={it} users={ownerOptions}
+                                        draft={drafts[it.id] || draftFromItem(it)}
+                                        busy={busyItem === it.id}
+                                        onDraft={(patch) => setDraft(it.id, patch)}
+                                        onAccept={() => review(it.id, 'accept')}
+                                        onReject={() => review(it.id, 'reject')}
+                                        onDone={() => review(it.id, 'done')}
+                                    />
+                                ))}
+                            </ul>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function ChecklistRow({ item, users, draft, busy, onDraft, onAccept, onReject, onDone }) {
+    const isProposed = item.status === 'proposed';
+    const badge = ITEM_TYPE_BADGE[item.item_type] || ITEM_TYPE_BADGE.action;
+    const ownerName = users.find(u => String(u.id) === String(item.owner_user_id));
+    const STATUS_PILL = {
+        accepted: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+        rejected: 'bg-gray-200 text-gray-500 dark:bg-slate-700 dark:text-slate-400',
+        done: 'bg-slate-200 text-slate-600 dark:bg-slate-600 dark:text-slate-200',
+        proposed: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300',
+    };
+
+    return (
+        <li className={`rounded-lg border p-3 ${item.status === 'rejected' ? 'opacity-60' : ''}
+            border-gray-200 dark:border-slate-700 bg-gray-50/40 dark:bg-slate-900/40`}>
+            <div className="flex items-center gap-2 mb-1.5">
+                <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${badge.badge}`}>{badge.label}</span>
+                {item.gc_facing && <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">GC-facing</span>}
+                {item.confidence != null && <span className="text-[10px] text-gray-400 dark:text-slate-500">conf {Math.round(item.confidence * 100)}%</span>}
+                <span className={`ml-auto px-1.5 py-0.5 text-[10px] font-medium rounded capitalize ${STATUS_PILL[item.status]}`}>{item.status}</span>
+            </div>
+
+            {isProposed ? (
+                <>
+                    <input
+                        type="text" value={draft.title} onChange={e => onDraft({ title: e.target.value })}
+                        className="w-full px-2 py-1.5 text-sm rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 mb-2"
+                    />
+                    <div className="flex flex-wrap items-center gap-2">
+                        <select value={draft.item_type} onChange={e => onDraft({ item_type: e.target.value })}
+                            className="px-2 py-1 text-xs rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-700 dark:text-slate-200">
+                            {ITEM_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+                        </select>
+                        <select value={draft.owner_user_id} onChange={e => onDraft({ owner_user_id: e.target.value })}
+                            className="px-2 py-1 text-xs rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-700 dark:text-slate-200">
+                            <option value="">— owner —</option>
+                            {users.map(u => <option key={u.id} value={u.id}>{u.first_name} {u.last_name}</option>)}
+                        </select>
+                        <input type="date" value={draft.due_date || ''} onChange={e => onDraft({ due_date: e.target.value })}
+                            className="px-2 py-1 text-xs rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-700 dark:text-slate-200" />
+                        <label className="flex items-center gap-1 text-xs text-gray-600 dark:text-slate-300">
+                            <input type="checkbox" checked={draft.gc_facing} onChange={e => onDraft({ gc_facing: e.target.checked })} /> GC
+                        </label>
+                        <div className="ml-auto flex gap-1.5">
+                            <button onClick={onReject} disabled={busy}
+                                className="px-2.5 py-1 text-xs rounded-md border border-gray-300 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-700 disabled:opacity-50">No</button>
+                            <button onClick={onAccept} disabled={busy}
+                                className="px-2.5 py-1 text-xs font-medium rounded-md bg-emerald-500 hover:bg-emerald-600 text-white disabled:opacity-50">Yes</button>
+                        </div>
+                    </div>
+                </>
+            ) : (
+                <div className="flex items-center gap-2">
+                    <span className={`text-sm text-gray-800 dark:text-slate-200 ${item.status === 'done' ? 'line-through' : ''}`}>{item.title}</span>
+                    <span className="ml-auto text-[11px] text-gray-500 dark:text-slate-400">
+                        {ownerName ? `${ownerName.first_name} ${ownerName.last_name}` : 'unassigned'}{item.due_date ? ` · due ${item.due_date}` : ''}
+                    </span>
+                    {item.status === 'accepted' && ownerName && item.due_date && (
+                        <span className="text-[11px] text-emerald-600 dark:text-emerald-400 whitespace-nowrap">🔔 reminder set</span>
+                    )}
+                    {item.status === 'accepted' && (
+                        <button onClick={onDone} disabled={busy}
+                            className="px-2 py-0.5 text-[11px] rounded-md border border-gray-300 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-700 disabled:opacity-50">Done</button>
+                    )}
+                </div>
+            )}
+        </li>
+    );
+}

--- a/frontend/src/services/meetingsApi.js
+++ b/frontend/src/services/meetingsApi.js
@@ -1,0 +1,55 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: HTTP calls for the meeting → checklist → to-do/notify feature so UI stays transport-agnostic.
+ * exports:
+ *   createMeeting: Ingest a transcript and get back the meeting + proposed checklist.
+ *   fetchMeetings: List recent meetings.
+ *   fetchMeeting: One meeting with its checklist items.
+ *   reviewChecklistItem: Accept / reject / done / edit an item (owner + due date editable).
+ *   fetchAssignableUsers: Active users for the owner dropdown.
+ *   scanDue: Manually trigger the deadline-notification scan.
+ * imports_from: [axios, ../utils/api]
+ * imported_by: [pages/Meetings.jsx]
+ * invariants:
+ *   - axios.defaults.withCredentials sends the session cookie on every request.
+ *   - All endpoints are under /brain (meetings + checklist-items).
+ */
+import axios from 'axios';
+import { API_BASE_URL } from '../utils/api';
+
+axios.defaults.withCredentials = true;
+
+const BASE = `${API_BASE_URL}/brain`;
+
+export async function createMeeting({ title, meeting_type, transcript, project_number }) {
+    const { data } = await axios.post(`${BASE}/meetings`, {
+        title, meeting_type, transcript, project_number,
+    });
+    return data; // meeting + items
+}
+
+export async function fetchMeetings() {
+    const { data } = await axios.get(`${BASE}/meetings`);
+    return data.meetings;
+}
+
+export async function fetchMeeting(id) {
+    const { data } = await axios.get(`${BASE}/meetings/${id}`);
+    return data; // meeting + items
+}
+
+export async function reviewChecklistItem(itemId, { action, fields } = {}) {
+    const { data } = await axios.patch(`${BASE}/checklist-items/${itemId}`, { action, fields });
+    return data; // updated item
+}
+
+export async function fetchAssignableUsers() {
+    const { data } = await axios.get(`${BASE}/meetings/assignable-users`);
+    return data.users;
+}
+
+export async function scanDue() {
+    const { data } = await axios.post(`${BASE}/checklist-items/scan-due`);
+    return data.notified;
+}

--- a/migrations/create_checklist_tables.py
+++ b/migrations/create_checklist_tables.py
@@ -1,0 +1,69 @@
+"""
+Migration: create the meeting-checklist tables (meetings, checklist_items) and add
+the checklist_item_id FK to notifications.
+
+Idempotent — safe to re-run. Mirrors migrations/create_board_tables.py.
+
+Run with:
+    python migrations/create_checklist_tables.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import inspect, text
+
+from app import create_app
+from app.models import db, Meeting, ChecklistItem  # noqa: F401 (imported so create_all sees them)
+
+
+def _table_exists(name: str) -> bool:
+    return name in inspect(db.engine).get_table_names()
+
+
+def _column_exists(table: str, column: str) -> bool:
+    return any(c["name"] == column for c in inspect(db.engine).get_columns(table))
+
+
+def migrate() -> bool:
+    app = create_app()
+    with app.app_context():
+        try:
+            # 1. New tables (create_all only creates what's missing)
+            if _table_exists("meetings") and _table_exists("checklist_items"):
+                print("✓ Tables 'meetings' and 'checklist_items' already exist.")
+            else:
+                print("Creating checklist tables...")
+                db.create_all()
+                if not (_table_exists("meetings") and _table_exists("checklist_items")):
+                    print("✗ ERROR: checklist tables were not created")
+                    return False
+                print("✓ Created 'meetings' and 'checklist_items'")
+
+            # 2. Add notifications.checklist_item_id if missing (simple ADD COLUMN works on SQLite + PG)
+            if _column_exists("notifications", "checklist_item_id"):
+                print("✓ notifications.checklist_item_id already present.")
+            else:
+                print("Adding notifications.checklist_item_id ...")
+                with db.engine.begin() as conn:
+                    conn.execute(text(
+                        "ALTER TABLE notifications ADD COLUMN checklist_item_id INTEGER"
+                    ))
+                if _column_exists("notifications", "checklist_item_id"):
+                    print("✓ Added notifications.checklist_item_id")
+                else:
+                    print("✗ ERROR: column was not added")
+                    return False
+
+            return True
+        except Exception as e:
+            print(f"✗ ERROR: {e}")
+            import traceback
+            traceback.print_exc()
+            return False
+
+
+if __name__ == "__main__":
+    sys.exit(0 if migrate() else 1)

--- a/tests/brain/test_meetings.py
+++ b/tests/brain/test_meetings.py
@@ -1,0 +1,185 @@
+"""Tests for the meeting → checklist → to-do/notify MVP.
+
+Extraction is stubbed/patched so tests are hermetic (no live Anthropic call).
+"""
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from app.models import db, Meeting, ChecklistItem, Notification
+from app.brain.meetings import service, extract
+from tests.conftest import make_user, make_release
+
+
+REVIEWER = "boneill@mhmw.com"  # matches Config.CHECKLIST_REVIEWER_USERNAME default
+
+
+def _items(**over):
+    base = dict(title="t", detail=None, item_type="action", owner_name=None,
+                due_date=None, gc_facing=False, release_ref=None,
+                submittal_ref=None, confidence=None)
+    base.update(over)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# Extractor (deterministic stub path)
+# --------------------------------------------------------------------------- #
+def test_stub_extractor_picks_action_lines_skips_chitchat(app):
+    transcript = (
+        "Shop touch-base\n"
+        "- 480-146 redo needed, did not fit, need to redo today\n"
+        "- Luis to order galvanized lintels by Thursday\n"
+        "- talked about the weekend\n"
+    )
+    with patch.object(extract.cfg, "ANTHROPIC_API_KEY", None):  # force stub
+        items = extract.extract_items(transcript)
+    titles = [i["title"] for i in items]
+    assert any("480-146" in t for t in titles)
+    assert any("lintels" in t for t in titles)
+    assert not any("weekend" in t for t in titles)  # chit-chat excluded
+    ref = next(i for i in items if "480-146" in i["title"])
+    assert ref["release_ref"] == "480-146"
+
+
+# --------------------------------------------------------------------------- #
+# Service: ingest + extract + notify reviewer
+# --------------------------------------------------------------------------- #
+def test_create_meeting_extracts_links_and_notifies_reviewer(app):
+    bill = make_user(REVIEWER, first_name="Bill", last_name="O'Neill", is_admin=True)
+    make_user("lsolano@mhmw.com", first_name="Luis", last_name="Solano", is_admin=True)
+    make_release(480, "146", job_name="Wood Partners - Alta Flatirons", stage="Fitup Start")
+    db.session.commit()
+
+    proposed = [
+        _items(title="480-146 redo, did not fit", release_ref="480-146", owner_name="Luis"),
+        _items(title="Order galvanized lintels", item_type="action"),
+    ]
+    with patch("app.brain.meetings.service.extract_items", return_value=proposed):
+        meeting = service.create_meeting_with_extraction(
+            title="Shop touch-base", meeting_type="internal_shop",
+            transcript="(stubbed)", created_by_id=bill.id,
+        )
+
+    items = meeting.items.order_by(ChecklistItem.id).all()
+    assert len(items) == 2
+    assert meeting.project_number == "480"          # auto-set from 480-146
+    assert items[0].release_id is not None          # auto-linked to the release
+    assert items[0].proposed_owner_user_id is not None  # "Luis" resolved
+    assert items[0].status == "proposed"
+    # reviewer (Bill) got exactly one "checklist ready" notification
+    assert Notification.query.filter_by(user_id=bill.id, type="checklist_ready").count() == 1
+
+
+def test_unresolved_reviewer_does_not_crash(app):
+    # No user matches the configured reviewer username → ingestion still succeeds.
+    with patch("app.brain.meetings.service.extract_items", return_value=[_items(title="x")]):
+        meeting = service.create_meeting_with_extraction(
+            title="m", meeting_type="other", transcript="x",
+        )
+    assert meeting.items.count() == 1
+
+
+# --------------------------------------------------------------------------- #
+# Service: review (yes / no / edit owner+date)
+# --------------------------------------------------------------------------- #
+def test_review_accept_defaults_then_overrides_owner_and_due(app):
+    bill = make_user(REVIEWER, first_name="Bill", is_admin=True)
+    luis = make_user("lsolano@mhmw.com", first_name="Luis", is_admin=True)
+    m = Meeting(title="m", meeting_type="internal_shop")
+    db.session.add(m); db.session.flush()
+    item = ChecklistItem(meeting_id=m.id, title="do thing",
+                         proposed_owner_user_id=luis.id, proposed_due_date=date(2026, 6, 10))
+    db.session.add(item); db.session.commit()
+
+    # accept with no overrides -> inherits the agent's proposal
+    service.review_item(item.id, action="accept", reviewer=bill)
+    item = db.session.get(ChecklistItem, item.id)
+    assert item.status == "accepted"
+    assert item.owner_user_id == luis.id and item.due_date == date(2026, 6, 10)
+    assert item.reviewed_by == bill.id and item.reviewed_at is not None
+
+    # edit overrides owner + date (reviewer has final say)
+    service.review_item(item.id, fields={"owner_user_id": bill.id, "due_date": "2026-07-01"},
+                        reviewer=bill)
+    item = db.session.get(ChecklistItem, item.id)
+    assert item.owner_user_id == bill.id and item.due_date == date(2026, 7, 1)
+
+
+def test_review_reject(app):
+    m = Meeting(title="m", meeting_type="other")
+    db.session.add(m); db.session.flush()
+    item = ChecklistItem(meeting_id=m.id, title="nope")
+    db.session.add(item); db.session.commit()
+    service.review_item(item.id, action="reject")
+    assert db.session.get(ChecklistItem, item.id).status == "rejected"
+
+
+# --------------------------------------------------------------------------- #
+# Service: deadline notifications + dedup
+# --------------------------------------------------------------------------- #
+def test_notify_due_items_pings_owner_once(app):
+    owner = make_user("lsolano@mhmw.com", first_name="Luis", is_admin=True)
+    m = Meeting(title="m", meeting_type="other")
+    db.session.add(m); db.session.flush()
+    item = ChecklistItem(meeting_id=m.id, title="due soon", status="accepted",
+                         owner_user_id=owner.id, due_date=date(2026, 6, 2))
+    db.session.add(item); db.session.commit()
+
+    sent = service.notify_due_items(today=date(2026, 6, 2))
+    assert sent == 1
+    note = Notification.query.filter_by(user_id=owner.id, type="checklist_due").first()
+    assert note is not None and note.checklist_item_id == item.id
+    # dedup: a second scan in the same window sends nothing
+    assert service.notify_due_items(today=date(2026, 6, 2)) == 0
+
+
+def test_notify_skips_unaccepted_and_far_future(app):
+    owner = make_user("lsolano@mhmw.com", first_name="Luis", is_admin=True)
+    m = Meeting(title="m", meeting_type="other")
+    db.session.add(m); db.session.flush()
+    db.session.add_all([
+        ChecklistItem(meeting_id=m.id, title="proposed", status="proposed",
+                      owner_user_id=owner.id, due_date=date(2026, 6, 2)),
+        ChecklistItem(meeting_id=m.id, title="far off", status="accepted",
+                      owner_user_id=owner.id, due_date=date(2026, 12, 31)),
+    ])
+    db.session.commit()
+    assert service.notify_due_items(today=date(2026, 6, 2)) == 0
+
+
+# --------------------------------------------------------------------------- #
+# HTTP surface
+# --------------------------------------------------------------------------- #
+def test_create_meeting_endpoint_rejects_non_admin(client, mock_non_admin_user):
+    with patch("app.auth.utils.get_current_user", return_value=mock_non_admin_user):
+        resp = client.post("/brain/meetings", json={"transcript": "x"})
+    assert resp.status_code == 403
+
+
+def test_create_and_review_endpoints_happy_path(app, client):
+    admin = make_user(REVIEWER, first_name="Bill", is_admin=True)
+    proposed = [_items(title="do the thing")]
+    with patch("app.auth.utils.get_current_user", return_value=admin), \
+         patch("app.brain.meetings.routes.get_current_user", return_value=admin), \
+         patch("app.brain.meetings.service.extract_items", return_value=proposed):
+        resp = client.post("/brain/meetings", json={
+            "title": "Shop", "meeting_type": "internal_shop", "transcript": "(stub)",
+        })
+        assert resp.status_code == 201
+        item_id = resp.get_json()["items"][0]["id"]
+
+        resp = client.patch(f"/brain/checklist-items/{item_id}", json={
+            "action": "accept", "fields": {"due_date": "2026-06-15"},
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "accepted" and body["due_date"] == "2026-06-15"
+
+
+def test_create_meeting_endpoint_requires_transcript(app, client):
+    admin = make_user(REVIEWER, first_name="Bill", is_admin=True)
+    with patch("app.auth.utils.get_current_user", return_value=admin):
+        resp = client.post("/brain/meetings", json={"title": "x"})
+    assert resp.status_code == 400

--- a/tests/brain/test_red_date_auto_clear.py
+++ b/tests/brain/test_red_date_auto_clear.py
@@ -105,6 +105,98 @@ class TestStageCompleteCascade:
             ]
             assert children == []
 
+    def test_stage_to_install_complete_clears_hard_date_and_sets_job_comp(self, app):
+        with app.app_context():
+            r = _make_release(
+                1, "A",
+                start_install=date(2026, 6, 1),
+                start_install_formula=None,
+                start_install_formulaTF=False,  # hard date present
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = _stage_command_patches()
+            with patches[0], patches[1], patches[2]:
+                result = UpdateStageCommand(
+                    job_id=1, release="A", stage="Install Complete"
+                ).execute()
+
+            db.session.refresh(r)
+            assert r.start_install_formulaTF is True
+            assert r.job_comp == "X"  # Install Complete sets the Install Prog marker
+            assert result.extras.get("hard_date_cleared") is True
+
+            stage_event = ReleaseEvents.query.filter_by(action="update_stage").first()
+            hard_date_children = [
+                e for e in ReleaseEvents.query.all()
+                if e.action == "updated"
+                and isinstance(e.payload, dict)
+                and e.payload.get("field") == "start_install_formulaTF"
+            ]
+            assert len(hard_date_children) == 1
+            assert hard_date_children[0].payload.get("reason") == "stage_set_to_install_complete"
+            assert hard_date_children[0].payload.get("parent_event_id") == stage_event.id
+
+            job_comp_children = [
+                e for e in ReleaseEvents.query.all()
+                if e.action == "updated"
+                and isinstance(e.payload, dict)
+                and e.payload.get("field") == "job_comp"
+            ]
+            assert len(job_comp_children) == 1
+            assert job_comp_children[0].payload.get("reason") == "stage_set_to_install_complete"
+
+    def test_stage_to_complete_does_not_touch_job_comp(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Weld Start", job_comp=None)
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = _stage_command_patches()
+            with patches[0], patches[1], patches[2]:
+                UpdateStageCommand(job_id=1, release="A", stage="Complete").execute()
+
+            db.session.refresh(r)
+            assert r.stage == "Complete"
+            assert r.job_comp is None  # Complete is inert toward Install Prog
+
+            job_comp_children = [
+                e for e in ReleaseEvents.query.all()
+                if e.action == "updated"
+                and isinstance(e.payload, dict)
+                and e.payload.get("field") == "job_comp"
+            ]
+            assert job_comp_children == []
+
+    def test_stage_off_install_complete_clears_job_comp(self, app):
+        with app.app_context():
+            r = _make_release(
+                1, "A",
+                stage="Install Complete",
+                stage_group="COMPLETE",
+                job_comp="X",
+            )
+            db.session.commit()
+
+            from app.brain.job_log.features.stage.command import UpdateStageCommand
+            patches = _stage_command_patches()
+            with patches[0], patches[1], patches[2]:
+                UpdateStageCommand(job_id=1, release="A", stage="Weld Start").execute()
+
+            db.session.refresh(r)
+            assert r.stage == "Weld Start"
+            assert r.job_comp is None  # leaving Install Complete clears the 'X'
+
+            job_comp_children = [
+                e for e in ReleaseEvents.query.all()
+                if e.action == "updated"
+                and isinstance(e.payload, dict)
+                and e.payload.get("field") == "job_comp"
+                and e.payload.get("reason") == "stage_changed_from_install_complete"
+            ]
+            assert len(job_comp_children) == 1
+
     def test_stage_to_non_complete_does_not_clear(self, app):
         with app.app_context():
             r = _make_release(
@@ -149,6 +241,7 @@ class TestJobCompCascade:
             r2 = Releases.query.filter_by(job=1, release="A").first()
             assert r2.start_install_formulaTF is True
             assert r2.job_comp == "X"
+            assert r2.stage == "Install Complete"  # 'X' marks install complete
 
             children = [
                 e for e in ReleaseEvents.query.all()
@@ -200,6 +293,40 @@ class TestJobCompCascade:
             db.session.expire_all()
             r2 = Releases.query.filter_by(job=1, release="A").first()
             assert r2.start_install_formulaTF is False  # not cleared
+            assert r2.stage == "Install Start"  # a percentage means install has begun
+            assert r2.fab_order == 10  # fab_order untouched on percentage
+
+    def test_job_comp_non_numeric_leaves_stage_unchanged(self, app, admin_client):
+        with app.app_context():
+            _make_release(1, "A", stage="Weld Start")
+            db.session.commit()
+
+            resp = admin_client.patch(
+                "/brain/update-job-comp/1/A",
+                json={"job_comp": "MFP"},
+            )
+            assert resp.status_code == 200
+
+            db.session.expire_all()
+            r2 = Releases.query.filter_by(job=1, release="A").first()
+            assert r2.job_comp == "MFP"
+            assert r2.stage == "Weld Start"  # non-numeric value is not install progress
+
+    def test_job_comp_cleared_leaves_stage_unchanged(self, app, admin_client):
+        with app.app_context():
+            _make_release(1, "A", job_comp="X", stage="Install Complete")
+            db.session.commit()
+
+            resp = admin_client.patch(
+                "/brain/update-job-comp/1/A",
+                json={"job_comp": ""},
+            )
+            assert resp.status_code == 200
+
+            db.session.expire_all()
+            r2 = Releases.query.filter_by(job=1, release="A").first()
+            assert (r2.job_comp or "") == ""
+            assert r2.stage == "Install Complete"  # clearing the cell does not touch the stage
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stage_ordering.py
+++ b/tests/test_stage_ordering.py
@@ -143,7 +143,8 @@ def test_bounds_self_excluded(app):
 # ---------------------------------------------------------------------------
 
 def test_stage_change_to_complete_clears_fab_order(client, app):
-    """Moving to Complete clears fab_order to NULL and cascades job_comp='X'."""
+    """Moving to Complete clears fab_order to NULL. Complete no longer touches
+    job_comp — that cascade now belongs to Install Complete."""
     with app.app_context():
         make_release(1, "A", "Weld Complete", "FABRICATION", 10)
         db.session.commit()
@@ -160,7 +161,7 @@ def test_stage_change_to_complete_clears_fab_order(client, app):
     with app.app_context():
         job = Releases.query.filter_by(job=1, release="A").first()
         assert job.fab_order is None
-        assert job.job_comp == 'X'
+        assert job.job_comp is None
 
 
 def test_stage_change_to_paint_complete_sets_tier_2(client, app):


### PR DESCRIPTION
## What this adds
MVP of the **meeting → checklist → to-do/notify** flow (the human-in-the-loop layer of the Hive Mind roadmap).

### Backend
- `Meeting` + `ChecklistItem` models (+ `Notification.checklist_item_id` FK)
- `app/brain/meetings/`: transcript extraction (Anthropic Messages API with a deterministic keyword **stub fallback** — works with no key / offline / in tests), service (create+extract, review yes/no/edit with **owner + due date editable**, deadline notify with dedup), admin-only routes on `brain_bp`
- daily `checklist_due_scan` APScheduler job (06:00 America/Denver)
- idempotent migration `migrations/create_checklist_tables.py`
- 10 tests in `tests/brain/test_meetings.py`

### Frontend
- `/meetings` admin page: paste a transcript → agent-proposed checklist → reviewer **yes / no / edit** (owner + due) → accepted items show "reminder set"
- Self-contained **Load demo** mode (no backend/LLM/network) for client demos
- Route + admin nav wiring (`App.jsx`, `AppShell`, `MobileNavDrawer`)

### Ingestion
Stubbed for now (paste/POST a transcript). Recall.ai / Teams adapters land behind the same boundary later.

## Deploy notes
- ⚠️ `frontend/dist` is gitignored — the Render build must run the frontend build (`npm --prefix frontend ci && npm --prefix frontend run build`) for the UI to appear.
- `ANTHROPIC_API_KEY` is optional (stub fallback; the demo is fully client-side). Add it for good extraction quality.
- DB: `notifications.checklist_item_id` is **already applied on sandbox**. On any other target DB, run `migrations/create_checklist_tables.py` once (the two tables auto-create on boot; only that column needs the script).

## Verification
- 10 new tests pass; existing suite unaffected (7 pre-existing, unrelated failures).
- Frontend lint + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
