### PR TITLE
Invoicing report: DRR-only, lifecycle events, billing redesign

### DIFF
--- a/app/history/__init__.py
+++ b/app/history/__init__.py
@@ -531,38 +531,62 @@ def monthly_invoicing_report():
                 'created_at': format_datetime_mountain(e.created_at),
             })
 
+        # A DRR appears when it has >=1 create/open/close event *in the month*;
+        # create its item shell here. The lifecycle dates themselves are
+        # backfilled below from full history, so a DRR closed this month still
+        # shows when it was created/opened in an earlier month.
+        submittal_items_by_id = {}
         for e in submittal_events:
             s = submittals_by_id.get(e.submittal_id)
             # Billing view: DRR submittals only (drop non-DRR and orphan events).
             if not s or s.type != DRR_TYPE:
                 continue
             # Lifecycle view: only create / open / close events.
-            kind = _submittal_event_kind(e.action, e.payload)
-            if kind is None:
+            if _submittal_event_kind(e.action, e.payload) is None:
+                continue
+            if e.submittal_id in submittal_items_by_id:
                 continue
             number = str(s.project_number) if s.project_number else 'Unknown'
             bucket = _bucket(number, s.project_name)
-            item = bucket['_submittals'].get(e.submittal_id)
-            if item is None:
-                item = {
-                    'submittal_id': e.submittal_id,
-                    'title': s.title,
-                    'status': s.status,
-                    'submittal_manager': s.submittal_manager,
-                    'events': [],
-                }
-                bucket['_submittals'][e.submittal_id] = item
-            item['events'].append({
-                'id': e.id,
-                'action': e.action,
-                'kind': kind,
-                'new_value': _extract_submittal_new_value_from_payload(e.action, e.payload),
-                'payload': e.payload,
-                'source': e.source,
-                'internal_user_id': e.internal_user_id,
-                'external_user_id': e.external_user_id,
-                'created_at': format_datetime_mountain(e.created_at),
-            })
+            item = {
+                'submittal_id': e.submittal_id,
+                'title': s.title,
+                'status': s.status,
+                'submittal_manager': s.submittal_manager,
+                'events': [],
+            }
+            bucket['_submittals'][e.submittal_id] = item
+            submittal_items_by_id[e.submittal_id] = item
+
+        # Backfill each included DRR's create/open/close dates from its full
+        # history up to the end of the month (its lifecycle state "as of" then) —
+        # the most recent event of each kind, even if from a prior month.
+        if submittal_items_by_id:
+            lifecycle = {}  # submittal_id -> {kind: (created_at_dt, event_dict)}
+            lifecycle_events = SubmittalEvents.query.filter(
+                SubmittalEvents.submittal_id.in_(submittal_items_by_id.keys()),
+                SubmittalEvents.created_at < end_utc,
+                SubmittalEvents.is_system_echo == False,  # noqa: E712
+            ).order_by(SubmittalEvents.created_at.asc()).all()
+            for e in lifecycle_events:
+                kind = _submittal_event_kind(e.action, e.payload)
+                if kind is None:
+                    continue
+                # Asc order means the last write per kind is the most recent.
+                lifecycle.setdefault(e.submittal_id, {})[kind] = (e.created_at, {
+                    'id': e.id,
+                    'action': e.action,
+                    'kind': kind,
+                    'new_value': _extract_submittal_new_value_from_payload(e.action, e.payload),
+                    'payload': e.payload,
+                    'source': e.source,
+                    'internal_user_id': e.internal_user_id,
+                    'external_user_id': e.external_user_id,
+                    'created_at': format_datetime_mountain(e.created_at),
+                })
+            for sid, item in submittal_items_by_id.items():
+                ordered = sorted(lifecycle.get(sid, {}).values(), key=lambda pair: pair[0])
+                item['events'] = [ev for (_dt, ev) in ordered]
 
         result_projects = []
         for number in sorted(projects.keys(), key=_project_sort_key):

--- a/app/history/__init__.py
+++ b/app/history/__init__.py
@@ -133,6 +133,56 @@ def _extract_submittal_new_value_from_payload(action, payload):
     return str(payload) if payload else None
 
 
+# ---------------------------------------------------------------------------
+# Invoicing report filters (Katie Hearn's billing view)
+# ---------------------------------------------------------------------------
+
+# Only "Drafting Release Review" (DRR) submittals are billing milestones.
+DRR_TYPE = "Drafting Release Review"
+
+# Release events the invoicing report hides: fab-order, start-install dates,
+# and due dates carry no billing signal.
+_EXCLUDED_RELEASE_ACTIONS = frozenset({
+    'update_fab_order', 'update_due_date', 'update_start_install', 'clear_hard_date',
+})
+_EXCLUDED_RELEASE_FIELDS = frozenset({
+    'fab_order', 'start_install', 'start_install_formula', 'start_install_formulaTF', 'due_date',
+})
+
+
+def _submittal_event_kind(action, payload):
+    """Classify a submittal event for the invoicing report's lifecycle view.
+
+    Returns 'create', 'open', or 'close' for the three events Katie wants to
+    see, or None for anything else (ball-in-court changes, order bumps, status
+    changes to other values) — those are filtered out.
+    """
+    if action == 'created':
+        return 'create'
+
+    if action == 'updated' and isinstance(payload, dict):
+        status = payload.get('status')
+        new_val = status.get('new') if isinstance(status, dict) else None
+        if new_val:
+            normalized = str(new_val).strip().lower()
+            if normalized == 'open':
+                return 'open'
+            if normalized.startswith('clos'):
+                return 'close'
+
+    return None
+
+
+def _release_event_excluded(action, payload):
+    """True when a release event should be hidden from the invoicing report."""
+    if action in _EXCLUDED_RELEASE_ACTIONS:
+        return True
+    if action == 'updated' and isinstance(payload, dict):
+        if payload.get('field') in _EXCLUDED_RELEASE_FIELDS:
+            return True
+    return False
+
+
 def _month_range_utc(year, month):
     """Return [start, end) naive-UTC datetimes bounding a Mountain-Time month.
 
@@ -451,6 +501,8 @@ def monthly_invoicing_report():
             return bucket
 
         for e in release_events:
+            if _release_event_excluded(e.action, e.payload):
+                continue
             number = str(e.job)
             r = releases_by_key.get((e.job, e.release))
             bucket = _bucket(number, r.job_name if r else None)
@@ -481,22 +533,29 @@ def monthly_invoicing_report():
 
         for e in submittal_events:
             s = submittals_by_id.get(e.submittal_id)
-            number = str(s.project_number) if (s and s.project_number) else 'Unknown'
-            bucket = _bucket(number, s.project_name if s else None)
+            # Billing view: DRR submittals only (drop non-DRR and orphan events).
+            if not s or s.type != DRR_TYPE:
+                continue
+            # Lifecycle view: only create / open / close events.
+            kind = _submittal_event_kind(e.action, e.payload)
+            if kind is None:
+                continue
+            number = str(s.project_number) if s.project_number else 'Unknown'
+            bucket = _bucket(number, s.project_name)
             item = bucket['_submittals'].get(e.submittal_id)
             if item is None:
                 item = {
                     'submittal_id': e.submittal_id,
-                    'title': s.title if s else None,
-                    'status': s.status if s else None,
-                    'ball_in_court': s.ball_in_court if s else None,
-                    'submittal_manager': s.submittal_manager if s else None,
+                    'title': s.title,
+                    'status': s.status,
+                    'submittal_manager': s.submittal_manager,
                     'events': [],
                 }
                 bucket['_submittals'][e.submittal_id] = item
             item['events'].append({
                 'id': e.id,
                 'action': e.action,
+                'kind': kind,
                 'new_value': _extract_submittal_new_value_from_payload(e.action, e.payload),
                 'payload': e.payload,
                 'source': e.source,

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -64,6 +64,27 @@ const TINT = {
     accent: 'bg-accent-50 text-accent-600 ring-accent-200/70 dark:bg-accent-400/10 dark:text-accent-200 dark:ring-accent-400/30',
 };
 
+// Solid dot color per tint family — used as timeline nodes.
+const DOT = {
+    emerald: 'bg-emerald-500', blue: 'bg-blue-500', violet: 'bg-violet-500',
+    amber: 'bg-amber-500', orange: 'bg-orange-500', purple: 'bg-purple-500',
+    red: 'bg-red-500', slate: 'bg-slate-400 dark:bg-slate-500', accent: 'bg-accent-500',
+};
+
+// Friendly labels for release event actions (Katie shouldn't read raw keys).
+const ACTION_LABEL = {
+    update_stage: 'Stage',
+    updated: 'Updated',
+    list_move: 'Moved',
+    update_installer: 'Installer',
+    pickup_received: 'Pickup',
+    create_card: 'Created',
+    created: 'Created',
+    update_name: 'Renamed',
+    update_description: 'Description',
+};
+const actionLabel = (a) => ACTION_LABEL[a] || (a || '').replace(/_/g, ' ');
+
 // Solid dots used as section/legend markers.
 const KIND_META = {
     create: { label: 'Created', tint: 'emerald', dot: 'bg-emerald-500' },
@@ -238,25 +259,28 @@ function ReleaseRow({ release, expanded, onToggle }) {
                 </span>
             </ToggleRow>
             {expanded && (
-                <ul className="pl-20 pr-4 py-3 space-y-2.5 bg-gray-50/80 dark:bg-slate-900/40 border-t border-gray-100 dark:border-slate-700/60">
-                    {r.events.length === 0 && (
-                        <li className="text-sm text-gray-400 dark:text-slate-500 italic">No changes this month.</li>
+                <div className="pl-16 pr-4 py-4 bg-gray-50/80 dark:bg-slate-900/40 border-t border-gray-100 dark:border-slate-700/60">
+                    {r.events.length === 0 ? (
+                        <p className="text-sm text-gray-400 dark:text-slate-500 italic">No changes this month.</p>
+                    ) : (
+                        <ol className="relative ml-1 border-l-2 border-gray-200 dark:border-slate-700 space-y-4">
+                            {r.events.map((ev) => (
+                                <li key={ev.id} className="relative pl-6">
+                                    <span className={`absolute -left-[7px] top-1.5 w-3 h-3 rounded-full ring-4 ring-gray-50 dark:ring-slate-900 ${DOT[actionTint(ev.action)]}`} />
+                                    <div className="flex items-baseline gap-2 flex-wrap">
+                                        <Badge tint={actionTint(ev.action)}>{actionLabel(ev.action)}</Badge>
+                                        {ev.new_value && (
+                                            <span className="text-base font-medium text-gray-800 dark:text-slate-100">{ev.new_value}</span>
+                                        )}
+                                    </div>
+                                    <div className="mt-1 text-xs text-gray-400 dark:text-slate-500">
+                                        {prettyDate(ev.created_at)} · {prettyTime(ev.created_at)}{ev.source ? ` · ${ev.source}` : ''}
+                                    </div>
+                                </li>
+                            ))}
+                        </ol>
                     )}
-                    {r.events.map((ev) => (
-                        <li key={ev.id} className="flex items-center gap-4 text-sm">
-                            <span className="w-52 shrink-0">
-                                <Badge tint={actionTint(ev.action)}>{ev.action}</Badge>
-                            </span>
-                            <span className="flex-1 min-w-0 truncate text-gray-700 dark:text-slate-200">
-                                {ev.new_value || ''}
-                            </span>
-                            <span className="shrink-0 text-gray-400 dark:text-slate-500 whitespace-nowrap">
-                                {prettyDate(ev.created_at)} · {prettyTime(ev.created_at)}
-                                {ev.source ? ` · ${ev.source}` : ''}
-                            </span>
-                        </li>
-                    ))}
-                </ul>
+                </div>
             )}
         </div>
     );
@@ -264,10 +288,10 @@ function ReleaseRow({ release, expanded, onToggle }) {
 
 function SummaryStat({ value, label, tint }) {
     return (
-        <div className="flex items-center gap-3 px-6">
-            <span className={`w-3.5 h-3.5 rounded-full ${tint}`} />
+        <div className="flex items-center gap-3 px-5">
+            <span className={`w-3 h-3 rounded-full ${tint}`} />
             <div className="flex flex-col leading-none">
-                <span className="text-4xl font-bold text-gray-900 dark:text-slate-50 tabular-nums">{value}</span>
+                <span className="text-3xl font-bold text-gray-900 dark:text-slate-50 tabular-nums">{value}</span>
                 <span className="text-xs uppercase tracking-widest text-gray-400 dark:text-slate-500 mt-1.5">{label}</span>
             </div>
         </div>
@@ -403,7 +427,7 @@ function InvoicingReport() {
             {/* Header: title + month/year picker */}
             <div className="flex flex-wrap items-end gap-3 mb-6">
                 <div>
-                    <h1 className="text-4xl font-bold text-gray-900 dark:text-slate-50">
+                    <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-50">
                         Invoicing <span className="text-accent-500 dark:text-accent-300">— {report?.month_label || `${MONTHS[month - 1]} ${year}`}</span>
                     </h1>
                     <p className="text-base text-gray-500 dark:text-slate-400 mt-1">
@@ -491,12 +515,12 @@ function InvoicingReport() {
                         return (
                             <div key={pKey} className={pOpen ? 'bg-gray-50/40 dark:bg-slate-800/60' : ''}>
                                 {/* Level 1 — Project */}
-                                <ToggleRow open={pOpen} onToggle={() => toggleProject(pKey)} depthClass="px-4 py-4">
+                                <ToggleRow open={pOpen} onToggle={() => toggleProject(pKey)} depthClass="px-4 py-3.5">
                                     <Chevron open={pOpen} />
-                                    <span className="px-2.5 py-1 rounded-md text-lg font-bold font-mono bg-accent-50 text-accent-700 dark:bg-accent-400/10 dark:text-accent-200 ring-1 ring-inset ring-accent-200/60 dark:ring-accent-400/20">
+                                    <span className="px-2.5 py-1 rounded-md text-base font-bold font-mono bg-accent-50 text-accent-700 dark:bg-accent-400/10 dark:text-accent-200 ring-1 ring-inset ring-accent-200/60 dark:ring-accent-400/20">
                                         {proj.project_number}
                                     </span>
-                                    <span className="text-lg text-gray-700 dark:text-slate-200 font-medium truncate">
+                                    <span className="text-base text-gray-700 dark:text-slate-200 font-medium truncate">
                                         {proj.project_name || '—'}
                                     </span>
                                     <span className="ml-auto flex items-center gap-3 shrink-0">

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -247,13 +247,13 @@ function ReleaseRow({ release, expanded, onToggle }) {
                             ? <Badge tint={stageTint(r.stage)}>{r.stage}</Badge>
                             : <span className="text-gray-300 dark:text-slate-600">—</span>}
                     </span>
-                    <span className="w-24 text-gray-400 dark:text-slate-500 whitespace-nowrap">
+                    <span className="w-28 text-gray-400 dark:text-slate-500 whitespace-nowrap">
                         Install <span className="font-semibold text-gray-700 dark:text-slate-200">
                             {r.install_prog || <span className="text-gray-300 dark:text-slate-600 font-normal">—</span>}
                         </span>
                     </span>
-                    <span className="w-24 text-gray-400 dark:text-slate-500 whitespace-nowrap">
-                        Inv <span className="font-semibold text-gray-700 dark:text-slate-200">
+                    <span className="w-36 text-gray-400 dark:text-slate-500 whitespace-nowrap">
+                        Invoiced <span className="font-semibold text-gray-700 dark:text-slate-200">
                             {r.invoiced || <span className="text-gray-300 dark:text-slate-600 font-normal">—</span>}
                         </span>
                     </span>
@@ -532,7 +532,7 @@ function InvoicingReport() {
                                             {proj.submittals.length} DRR
                                         </Badge>
                                         <Badge tint={proj.releases.length ? 'blue' : 'slate'} className={proj.releases.length ? '' : 'opacity-60'}>
-                                            {proj.releases.length} rel
+                                            {proj.releases.length} releases
                                         </Badge>
                                     </span>
                                 </ToggleRow>

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -241,18 +241,22 @@ function ReleaseRow({ release, expanded, onToggle }) {
                 <span className="flex-1 min-w-0 text-base text-gray-800 dark:text-slate-100 truncate" title={label}>
                     {label}
                 </span>
-                <span className="hidden md:flex items-center gap-4 shrink-0">
-                    {r.stage && <Badge tint={stageTint(r.stage)}>{r.stage}</Badge>}
-                    {r.install_prog != null && r.install_prog !== '' && (
-                        <span className="text-sm text-gray-400 dark:text-slate-500">
-                            Install <span className="font-semibold text-gray-600 dark:text-slate-300">{r.install_prog}</span>
+                <span className="hidden md:flex items-center gap-4 shrink-0 text-sm">
+                    <span className="w-44 flex items-center">
+                        {r.stage
+                            ? <Badge tint={stageTint(r.stage)}>{r.stage}</Badge>
+                            : <span className="text-gray-300 dark:text-slate-600">—</span>}
+                    </span>
+                    <span className="w-24 text-gray-400 dark:text-slate-500 whitespace-nowrap">
+                        Install <span className="font-semibold text-gray-700 dark:text-slate-200">
+                            {r.install_prog || <span className="text-gray-300 dark:text-slate-600 font-normal">—</span>}
                         </span>
-                    )}
-                    {r.invoiced != null && r.invoiced !== '' && (
-                        <span className="text-sm text-gray-400 dark:text-slate-500">
-                            Inv <span className="font-semibold text-gray-600 dark:text-slate-300">{r.invoiced}</span>
+                    </span>
+                    <span className="w-24 text-gray-400 dark:text-slate-500 whitespace-nowrap">
+                        Inv <span className="font-semibold text-gray-700 dark:text-slate-200">
+                            {r.invoiced || <span className="text-gray-300 dark:text-slate-600 font-normal">—</span>}
                         </span>
-                    )}
+                    </span>
                 </span>
                 <span className="shrink-0 w-28 text-right text-sm font-medium text-gray-400 dark:text-slate-500 whitespace-nowrap">
                     {r.total_changes} {r.total_changes === 1 ? 'change' : 'changes'}

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -7,12 +7,13 @@
  * exports:
  *   InvoicingReport: Page component with month/year picker, project filter, CSV export, and
  *     nested expand/collapse cards.
- * imports_from: [react, ../services/invoicingApi, ../utils/auth, ../utils/csv, ../components/ColumnHeaderFilter]
+ * imports_from: [react, ../services/invoicingApi, ../utils/auth, ../utils/csv, ../utils/stageProgress,
+ *   ../components/ColumnHeaderFilter]
  * imported_by: [frontend/src/App.jsx]
  * invariants:
  *   - Renders an access message (no fetch) unless userCanAccessInvoicing(user) is true.
  *   - Backend already filters to DRR submittals and create/open/close + meaningful release events,
- *     and formats event.created_at as a Mountain-Time string; render it as-is.
+ *     and formats event.created_at as a Mountain-Time string ("May 04, 2026 07:32:15 AM").
  *   - Submittal events carry a `kind` of 'create' | 'open' | 'close' driving the status timeline.
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -20,6 +21,7 @@ import { invoicingApi } from '../services/invoicingApi';
 import ColumnHeaderFilter from '../components/ColumnHeaderFilter';
 import { checkAuth, userCanAccessInvoicing } from '../utils/auth';
 import { downloadCsv } from '../utils/csv';
+import { isCompleteStage } from '../utils/stageProgress';
 
 const MONTHS = [
     'January', 'February', 'March', 'April', 'May', 'June',
@@ -33,34 +35,79 @@ const projectLabel = (p) => {
     return name ? `${p.project_number} — ${name}` : String(p.project_number);
 };
 
-// Colors for the release event badges (action-based).
-function actionColor(action) {
-    if (!action) return 'bg-gray-100 text-gray-800 dark:bg-slate-700 dark:text-slate-200';
-    const a = action.toLowerCase();
-    const colors = {
-        update: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
-        updated: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
-        update_stage: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200',
-        list_move: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200',
-        created: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
-        create: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
-        delete: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
-    };
-    return colors[a] || colors[a.split('_')[0]] || 'bg-gray-100 text-gray-800 dark:bg-slate-700 dark:text-slate-200';
+// ---------------------------------------------------------------------------
+// Date formatting — the backend sends "May 04, 2026 07:32:15 AM" (Mountain).
+// Split it into a tidy date + time so the timeline reads cleanly.
+// ---------------------------------------------------------------------------
+function splitDateTime(s) {
+    if (!s) return { date: '', time: '' };
+    const m = String(s).match(/^(.*?\d{4})\s+(.*)$/);
+    return m ? { date: m[1], time: m[2] } : { date: String(s), time: '' };
+}
+// "May 04, 2026" -> "May 4, 2026"
+const prettyDate = (s) => splitDateTime(s).date.replace(/\b0(\d),/, '$1,');
+// "07:32:15 AM" -> "7:32 AM"
+const prettyTime = (s) => splitDateTime(s).time.replace(/:\d{2}\s/, ' ').replace(/^0/, '');
+
+// ---------------------------------------------------------------------------
+// Color tokens — tinted, ring-bordered badges that work in light + dark.
+// ---------------------------------------------------------------------------
+const TINT = {
+    emerald: 'bg-emerald-50 text-emerald-700 ring-emerald-200/70 dark:bg-emerald-500/10 dark:text-emerald-300 dark:ring-emerald-500/30',
+    blue: 'bg-blue-50 text-blue-700 ring-blue-200/70 dark:bg-blue-500/10 dark:text-blue-300 dark:ring-blue-500/30',
+    violet: 'bg-violet-50 text-violet-700 ring-violet-200/70 dark:bg-violet-500/10 dark:text-violet-300 dark:ring-violet-500/30',
+    amber: 'bg-amber-50 text-amber-700 ring-amber-200/70 dark:bg-amber-500/10 dark:text-amber-300 dark:ring-amber-500/30',
+    orange: 'bg-orange-50 text-orange-700 ring-orange-200/70 dark:bg-orange-500/10 dark:text-orange-300 dark:ring-orange-500/30',
+    purple: 'bg-purple-50 text-purple-700 ring-purple-200/70 dark:bg-purple-500/10 dark:text-purple-300 dark:ring-purple-500/30',
+    red: 'bg-red-50 text-red-700 ring-red-200/70 dark:bg-red-500/10 dark:text-red-300 dark:ring-red-500/30',
+    slate: 'bg-slate-100 text-slate-600 ring-slate-200/80 dark:bg-slate-500/10 dark:text-slate-300 dark:ring-slate-500/30',
+    accent: 'bg-accent-50 text-accent-600 ring-accent-200/70 dark:bg-accent-400/10 dark:text-accent-200 dark:ring-accent-400/30',
+};
+
+// Solid dots used as section/legend markers.
+const KIND_META = {
+    create: { label: 'Created', tint: 'emerald', dot: 'bg-emerald-500' },
+    open: { label: 'Opened', tint: 'blue', dot: 'bg-blue-500' },
+    close: { label: 'Closed', tint: 'slate', dot: 'bg-slate-400 dark:bg-slate-500' },
+};
+
+// Stage → color family, mirroring the Job Log's fab progression.
+function stageTint(stage) {
+    const s = (stage || '').toLowerCase();
+    if (isCompleteStage(stage)) return 'emerald';
+    if (s.includes('hold')) return 'red';
+    if (s.includes('install') || s.includes('ship')) return 'blue';
+    if (s.includes('paint') || s.includes('store')) return 'violet';
+    if (s.includes('weld') || s.includes('qc')) return 'amber';
+    if (s.includes('fitup') || s.includes('cut') || s.includes('material')) return 'orange';
+    return 'slate';
 }
 
-// Colors + labels for the submittal lifecycle timeline (kind-based).
-const KIND_LABEL = { create: 'Created', open: 'Opened', close: 'Closed' };
-const KIND_DOT = {
-    create: 'bg-green-500',
-    open: 'bg-blue-500',
-    close: 'bg-slate-500 dark:bg-slate-400',
-};
+// Release event action → color family.
+function actionTint(action) {
+    const a = (action || '').toLowerCase();
+    if (a.startsWith('create')) return 'emerald';
+    if (a.startsWith('delete')) return 'red';
+    if (a.includes('stage')) return 'accent';
+    if (a.includes('list_move')) return 'purple';
+    if (a.includes('install') || a.includes('ship')) return 'blue';
+    if (a.includes('pickup') || a.includes('received')) return 'amber';
+    return 'slate';
+}
+
+function Badge({ tint = 'slate', dot = false, className = '', children }) {
+    return (
+        <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ring-1 ring-inset ${TINT[tint]} ${className}`}>
+            {dot && <span className={`w-1.5 h-1.5 rounded-full ${KIND_META[dot]?.dot || 'bg-current'}`} />}
+            {children}
+        </span>
+    );
+}
 
 function Chevron({ open }) {
     return (
         <span
-            className={`inline-block text-gray-400 dark:text-slate-500 transition-transform duration-150 ${open ? 'rotate-90' : ''}`}
+            className={`inline-block text-gray-400 dark:text-slate-500 transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
             aria-hidden="true"
         >
             ▸
@@ -83,40 +130,57 @@ function ToggleRow({ open, onToggle, depthClass, children }) {
             aria-expanded={open}
             onClick={onToggle}
             onKeyDown={handleKey}
-            className={`flex items-center gap-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-700/50 focus:outline-none focus:ring-2 focus:ring-accent-500 ${depthClass}`}
+            className={`flex items-center gap-2 cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-slate-700/40 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent-400/60 ${depthClass}`}
         >
             {children}
         </div>
     );
 }
 
-// Most recent date string for a given lifecycle kind (events are newest-first).
-const kindDate = (events, kind) => {
-    const ev = events.find((e) => e.kind === kind);
-    return ev ? ev.created_at : null;
-};
+// Most recent event of a given lifecycle kind (events arrive newest-first).
+const kindEvent = (events, kind) => events.find((e) => e.kind === kind) || null;
 
-// DRR submittals as a compact create/open/close timeline table. No expand needed —
-// the three lifecycle dates are the whole story for a billing month.
+// A single timeline cell: a colored date chip + muted time, or a soft dash.
+function TimelineCell({ event, kind }) {
+    if (!event) {
+        return (
+            <td className="px-3 py-2.5 align-top">
+                <span className="text-gray-300 dark:text-slate-600 select-none">—</span>
+            </td>
+        );
+    }
+    const meta = KIND_META[kind];
+    return (
+        <td className="px-3 py-2.5 align-top whitespace-nowrap">
+            <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-xs font-medium ring-1 ring-inset ${TINT[meta.tint]}`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${meta.dot}`} />
+                {prettyDate(event.created_at)}
+            </span>
+            <div className="mt-0.5 pl-1 text-[10px] text-gray-400 dark:text-slate-500">{prettyTime(event.created_at)}</div>
+        </td>
+    );
+}
+
+// DRR submittals rendered as a create/open/close lifecycle table.
 function SubmittalTimeline({ submittals }) {
     if (submittals.length === 0) {
         return (
-            <div className="pl-12 pr-3 py-2 text-xs text-gray-500 dark:text-slate-400">
+            <div className="px-6 py-3 text-xs text-gray-400 dark:text-slate-500 italic">
                 No DRR submittal activity this month.
             </div>
         );
     }
     return (
         <div className="overflow-x-auto">
-            <table className="w-full text-xs">
+            <table className="w-full text-sm">
                 <thead>
-                    <tr className="text-left text-gray-500 dark:text-slate-400">
-                        <th className="pl-12 pr-3 py-1.5 font-medium">DRR Submittal</th>
+                    <tr className="text-left text-[11px] uppercase tracking-wide text-gray-400 dark:text-slate-500">
+                        <th className="pl-12 pr-3 py-1.5 font-semibold">DRR Submittal</th>
                         {['create', 'open', 'close'].map((k) => (
-                            <th key={k} className="px-3 py-1.5 font-medium whitespace-nowrap w-44">
+                            <th key={k} className="px-3 py-1.5 font-semibold w-44">
                                 <span className="inline-flex items-center gap-1.5">
-                                    <span className={`inline-block w-2 h-2 rounded-full ${KIND_DOT[k]}`} />
-                                    {KIND_LABEL[k]}
+                                    <span className={`inline-block w-2 h-2 rounded-full ${KIND_META[k].dot}`} />
+                                    {KIND_META[k].label}
                                 </span>
                             </th>
                         ))}
@@ -126,23 +190,16 @@ function SubmittalTimeline({ submittals }) {
                     {submittals.map((s) => {
                         const label = `${s.submittal_id}${s.title ? ` — ${s.title}` : ''}`;
                         return (
-                            <tr key={s.submittal_id} className="border-t border-gray-100 dark:border-slate-700/70">
-                                <td className="pl-12 pr-3 py-2 text-gray-800 dark:text-slate-100">
-                                    <span className="block truncate max-w-md" title={label}>{label}</span>
+                            <tr key={s.submittal_id} className="border-t border-gray-100 dark:border-slate-700/60 hover:bg-gray-50/70 dark:hover:bg-slate-700/30">
+                                <td className="pl-12 pr-3 py-2.5 align-top">
+                                    <span className="block truncate max-w-md text-gray-800 dark:text-slate-100" title={label}>{label}</span>
                                     {s.submittal_manager && (
-                                        <span className="text-[11px] text-gray-400 dark:text-slate-500">
-                                            Mgr: {s.submittal_manager}
-                                        </span>
+                                        <span className="text-[11px] text-gray-400 dark:text-slate-500">{s.submittal_manager}</span>
                                     )}
                                 </td>
-                                {['create', 'open', 'close'].map((k) => {
-                                    const d = kindDate(s.events, k);
-                                    return (
-                                        <td key={k} className="px-3 py-2 whitespace-nowrap text-gray-600 dark:text-slate-300">
-                                            {d || <span className="text-gray-300 dark:text-slate-600">—</span>}
-                                        </td>
-                                    );
-                                })}
+                                {['create', 'open', 'close'].map((k) => (
+                                    <TimelineCell key={k} event={kindEvent(s.events, k)} kind={k} />
+                                ))}
                             </tr>
                         );
                     })}
@@ -156,50 +213,45 @@ function SubmittalTimeline({ submittals }) {
 function ReleaseRow({ release, expanded, onToggle }) {
     const r = release;
     const label = `${r.release}${r.description ? ` — ${r.description}` : ''}`;
-    const meta = [
-        { label: 'Stage', value: r.stage, width: 'w-40' },
-        { label: 'Install', value: r.install_prog, width: 'w-24' },
-        { label: 'Invoiced', value: r.invoiced, width: 'w-24' },
-    ];
     return (
-        <div className="border-t border-gray-100 dark:border-slate-700">
-            <ToggleRow open={expanded} onToggle={onToggle} depthClass="pl-12 pr-3 py-2">
+        <div className="border-t border-gray-100 dark:border-slate-700/60">
+            <ToggleRow open={expanded} onToggle={onToggle} depthClass="pl-12 pr-3 py-2.5">
                 <Chevron open={expanded} />
                 <span className="flex-1 min-w-0 text-sm text-gray-800 dark:text-slate-100 truncate" title={label}>
                     {label}
                 </span>
-                <span className="hidden md:flex items-center gap-4 text-[11px] text-gray-500 dark:text-slate-400 shrink-0">
-                    {meta.map((m) => (
-                        <span key={m.label} className={`${m.width} shrink-0 truncate`}>
-                            {m.value != null && m.value !== '' && (
-                                <>
-                                    <span className="text-gray-400 dark:text-slate-500">{m.label}:</span> {m.value}
-                                </>
-                            )}
+                <span className="hidden md:flex items-center gap-2 shrink-0">
+                    {r.stage && <Badge tint={stageTint(r.stage)}>{r.stage}</Badge>}
+                    {r.install_prog != null && r.install_prog !== '' && (
+                        <span className="text-[11px] text-gray-400 dark:text-slate-500">
+                            Install <span className="font-semibold text-gray-600 dark:text-slate-300">{r.install_prog}</span>
                         </span>
-                    ))}
+                    )}
+                    {r.invoiced != null && r.invoiced !== '' && (
+                        <span className="text-[11px] text-gray-400 dark:text-slate-500">
+                            Inv <span className="font-semibold text-gray-600 dark:text-slate-300">{r.invoiced}</span>
+                        </span>
+                    )}
                 </span>
-                <span className="shrink-0 w-20 text-right text-xs font-medium text-gray-500 dark:text-slate-400 whitespace-nowrap">
+                <span className="shrink-0 w-20 text-right text-[11px] font-medium text-gray-400 dark:text-slate-500 whitespace-nowrap">
                     {r.total_changes} {r.total_changes === 1 ? 'change' : 'changes'}
                 </span>
             </ToggleRow>
             {expanded && (
-                <ul className="pl-16 pr-3 py-2 space-y-2 bg-gray-50 dark:bg-slate-800/60">
+                <ul className="pl-16 pr-3 py-2 space-y-1.5 bg-gray-50/80 dark:bg-slate-900/40 border-t border-gray-100 dark:border-slate-700/60">
                     {r.events.length === 0 && (
-                        <li className="text-xs text-gray-500 dark:text-slate-400">No changes this month.</li>
+                        <li className="text-xs text-gray-400 dark:text-slate-500 italic">No changes this month.</li>
                     )}
                     {r.events.map((ev) => (
                         <li key={ev.id} className="flex items-center gap-3 text-xs">
-                            <span className="w-40 shrink-0">
-                                <span className={`inline-block px-2 py-0.5 rounded-full font-medium ${actionColor(ev.action)}`}>
-                                    {ev.action}
-                                </span>
+                            <span className="w-44 shrink-0">
+                                <Badge tint={actionTint(ev.action)}>{ev.action}</Badge>
                             </span>
-                            <span className="flex-1 min-w-0 truncate text-gray-800 dark:text-slate-100">
+                            <span className="flex-1 min-w-0 truncate text-gray-700 dark:text-slate-200">
                                 {ev.new_value || ''}
                             </span>
-                            <span className="shrink-0 text-gray-500 dark:text-slate-400 whitespace-nowrap">
-                                {ev.created_at}
+                            <span className="shrink-0 text-gray-400 dark:text-slate-500 whitespace-nowrap">
+                                {prettyDate(ev.created_at)} · {prettyTime(ev.created_at)}
                                 {ev.source ? ` · ${ev.source}` : ''}
                             </span>
                         </li>
@@ -210,11 +262,14 @@ function ReleaseRow({ release, expanded, onToggle }) {
     );
 }
 
-function SummaryStat({ value, label }) {
+function SummaryStat({ value, label, tint }) {
     return (
-        <div className="flex flex-col items-center px-3">
-            <span className="text-xl font-bold text-gray-900 dark:text-slate-100 leading-none">{value}</span>
-            <span className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-slate-400 mt-0.5">{label}</span>
+        <div className="flex items-center gap-2.5 px-4">
+            <span className={`w-2.5 h-2.5 rounded-full ${tint}`} />
+            <div className="flex flex-col leading-none">
+                <span className="text-2xl font-bold text-gray-900 dark:text-slate-50 tabular-nums">{value}</span>
+                <span className="text-[10px] uppercase tracking-widest text-gray-400 dark:text-slate-500 mt-1">{label}</span>
+            </div>
         </div>
     );
 }
@@ -273,7 +328,6 @@ function InvoicingReport() {
 
     const projects = useMemo(() => report?.projects || [], [report]);
 
-    // Combined project values for the dropdown, sorted by project number.
     const projectValues = useMemo(
         () => projects.map(projectLabel).sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
         [projects],
@@ -290,7 +344,6 @@ function InvoicingReport() {
         [projects, projectFilter, columnSort],
     );
 
-    // Totals across the currently visible projects.
     const totals = useMemo(() => visibleProjects.reduce(
         (acc, p) => {
             acc.submittals += p.submittals.length;
@@ -308,7 +361,7 @@ function InvoicingReport() {
                 const item = `${s.submittal_id}${s.title ? ` — ${s.title}` : ''}`;
                 for (const ev of s.events) {
                     rows.push([p.project_number, p.project_name || '', 'DRR Submittal', item,
-                        KIND_LABEL[ev.kind] || ev.action, ev.new_value || '', ev.created_at, ev.source || '']);
+                        KIND_META[ev.kind]?.label || ev.action, ev.new_value || '', ev.created_at, ev.source || '']);
                 }
             }
             for (const r of p.releases) {
@@ -343,14 +396,15 @@ function InvoicingReport() {
     const years = [];
     for (let y = now.getFullYear(); y >= now.getFullYear() - 5; y -= 1) years.push(y);
     const hasData = !loading && !error && visibleProjects.length > 0;
+    const selectClass = 'mt-1 px-2.5 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-accent-400/60';
 
     return (
         <div className="flex-1 w-full max-w-5xl mx-auto p-4 sm:p-6">
             {/* Header: title + month/year picker */}
             <div className="flex flex-wrap items-end gap-3 mb-4">
                 <div>
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">
-                        Invoicing — {report?.month_label || `${MONTHS[month - 1]} ${year}`}
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">
+                        Invoicing <span className="text-accent-500 dark:text-accent-300">— {report?.month_label || `${MONTHS[month - 1]} ${year}`}</span>
                     </h1>
                     <p className="text-sm text-gray-500 dark:text-slate-400">
                         DRR submittal lifecycle and release progress, grouped by project.
@@ -359,26 +413,14 @@ function InvoicingReport() {
                 <div className="ml-auto flex items-end gap-2">
                     <label className="flex flex-col text-xs font-medium text-gray-600 dark:text-slate-400">
                         Month
-                        <select
-                            value={month}
-                            onChange={(e) => setMonth(parseInt(e.target.value, 10))}
-                            className="mt-1 px-2 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
-                        >
-                            {MONTHS.map((m, i) => (
-                                <option key={m} value={i + 1}>{m}</option>
-                            ))}
+                        <select value={month} onChange={(e) => setMonth(parseInt(e.target.value, 10))} className={selectClass}>
+                            {MONTHS.map((m, i) => (<option key={m} value={i + 1}>{m}</option>))}
                         </select>
                     </label>
                     <label className="flex flex-col text-xs font-medium text-gray-600 dark:text-slate-400">
                         Year
-                        <select
-                            value={year}
-                            onChange={(e) => setYear(parseInt(e.target.value, 10))}
-                            className="mt-1 px-2 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
-                        >
-                            {years.map((y) => (
-                                <option key={y} value={y}>{y}</option>
-                            ))}
+                        <select value={year} onChange={(e) => setYear(parseInt(e.target.value, 10))} className={selectClass}>
+                            {years.map((y) => (<option key={y} value={y}>{y}</option>))}
                         </select>
                     </label>
                 </div>
@@ -386,14 +428,14 @@ function InvoicingReport() {
 
             {/* Summary bar: totals + filter + export */}
             {hasData && (
-                <div className="flex flex-wrap items-center gap-3 mb-4 p-3 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+                <div className="flex flex-wrap items-center gap-3 mb-5 p-3 rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
                     <div className="flex items-center divide-x divide-gray-200 dark:divide-slate-700">
-                        <SummaryStat value={visibleProjects.length} label="Projects" />
-                        <SummaryStat value={totals.submittals} label="DRR" />
-                        <SummaryStat value={totals.releases} label="Releases" />
+                        <SummaryStat value={visibleProjects.length} label="Projects" tint="bg-accent-500" />
+                        <SummaryStat value={totals.submittals} label="DRR" tint="bg-emerald-500" />
+                        <SummaryStat value={totals.releases} label="Releases" tint="bg-blue-500" />
                     </div>
                     <div className="ml-auto flex items-center gap-2">
-                        <span className="px-2 py-1 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm">
+                        <span className="px-2.5 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm">
                             <ColumnHeaderFilter
                                 column="project"
                                 values={projectValues}
@@ -411,74 +453,79 @@ function InvoicingReport() {
                         <button
                             type="button"
                             onClick={exportCsv}
-                            className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700"
+                            className="inline-flex items-center gap-1.5 px-3.5 py-2 text-sm font-semibold rounded-lg bg-accent-500 text-white shadow-sm hover:bg-accent-600 focus:outline-none focus:ring-2 focus:ring-accent-400/60 transition-colors"
                         >
-                            Export CSV
+                            <span aria-hidden="true">↓</span> Export CSV
                         </button>
                     </div>
                 </div>
             )}
 
             {loading && (
-                <div className="py-12 text-center text-gray-500 dark:text-slate-400">Loading report…</div>
+                <div className="py-16 text-center text-gray-500 dark:text-slate-400">Loading report…</div>
             )}
 
             {error && !loading && (
-                <div className="py-4 px-4 rounded-lg bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-200 text-sm">
+                <div className="py-4 px-4 rounded-xl bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-200 text-sm ring-1 ring-red-200/60 dark:ring-red-500/30">
                     {error}
                 </div>
             )}
 
             {!loading && !error && projects.length === 0 && (
-                <div className="py-12 text-center text-gray-500 dark:text-slate-400">
+                <div className="py-16 text-center text-gray-500 dark:text-slate-400">
                     No project activity for {report?.month_label || `${MONTHS[month - 1]} ${year}`}.
                 </div>
             )}
 
             {!loading && !error && projects.length > 0 && visibleProjects.length === 0 && (
-                <div className="py-12 text-center text-gray-500 dark:text-slate-400">
+                <div className="py-16 text-center text-gray-500 dark:text-slate-400">
                     No projects match the current filters.
                 </div>
             )}
 
             {hasData && (
-                <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700">
+                <div className="rounded-2xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-800 shadow-sm divide-y divide-gray-100 dark:divide-slate-700/70">
                     {visibleProjects.map((proj) => {
                         const pKey = proj.project_number;
                         const pOpen = expandedProjects.has(pKey);
                         return (
-                            <div key={pKey}>
+                            <div key={pKey} className={pOpen ? 'bg-gray-50/40 dark:bg-slate-800/60' : ''}>
                                 {/* Level 1 — Project */}
                                 <ToggleRow open={pOpen} onToggle={() => toggleProject(pKey)} depthClass="px-3 py-3">
                                     <Chevron open={pOpen} />
-                                    <span className="font-semibold text-gray-900 dark:text-slate-100">
+                                    <span className="px-2 py-0.5 rounded-md text-sm font-bold font-mono bg-accent-50 text-accent-700 dark:bg-accent-400/10 dark:text-accent-200 ring-1 ring-inset ring-accent-200/60 dark:ring-accent-400/20">
                                         {proj.project_number}
                                     </span>
-                                    <span className="text-gray-600 dark:text-slate-300 truncate">
+                                    <span className="text-gray-700 dark:text-slate-200 font-medium truncate">
                                         {proj.project_name || '—'}
                                     </span>
-                                    <span className="ml-auto text-xs text-gray-500 dark:text-slate-400 whitespace-nowrap">
-                                        {proj.submittals.length} DRR · {proj.releases.length} releases
+                                    <span className="ml-auto flex items-center gap-2 shrink-0">
+                                        <Badge tint={proj.submittals.length ? 'emerald' : 'slate'} className={proj.submittals.length ? '' : 'opacity-60'}>
+                                            {proj.submittals.length} DRR
+                                        </Badge>
+                                        <Badge tint={proj.releases.length ? 'blue' : 'slate'} className={proj.releases.length ? '' : 'opacity-60'}>
+                                            {proj.releases.length} rel
+                                        </Badge>
                                     </span>
                                 </ToggleRow>
 
                                 {pOpen && (
-                                    <div className="border-t border-gray-100 dark:border-slate-700">
+                                    <div className="border-t border-gray-100 dark:border-slate-700/60">
                                         {/* DRR Submittals — lifecycle timeline */}
-                                        <div className="py-2 bg-gray-50/60 dark:bg-slate-800/40">
-                                            <div className="pl-8 pr-3 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                                        <div className="py-2.5">
+                                            <div className="pl-8 pr-3 pb-1 text-[11px] font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
                                                 DRR Submittals
                                             </div>
                                             <SubmittalTimeline submittals={proj.submittals} />
                                         </div>
 
                                         {/* Releases — expandable event rows */}
-                                        <div className="py-2 border-t border-gray-100 dark:border-slate-700">
-                                            <div className="pl-8 pr-3 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                                        <div className="py-2.5 border-t border-gray-100 dark:border-slate-700/60">
+                                            <div className="pl-8 pr-3 pb-1 text-[11px] font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
                                                 Releases
                                             </div>
                                             {proj.releases.length === 0 && (
-                                                <div className="pl-12 pr-3 py-2 text-xs text-gray-500 dark:text-slate-400">
+                                                <div className="px-6 py-2 text-xs text-gray-400 dark:text-slate-500 italic">
                                                     No release activity this month.
                                                 </div>
                                             )}

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -292,12 +292,12 @@ function ReleaseRow({ release, expanded, onToggle }) {
 
 function SummaryStat({ value, label, tint }) {
     return (
-        <div className="flex items-center gap-3 px-5">
-            <span className={`w-3 h-3 rounded-full ${tint}`} />
-            <div className="flex flex-col leading-none">
+        <div className="flex flex-col px-5">
+            <div className="flex items-center gap-2 leading-none">
+                <span className={`w-2.5 h-2.5 rounded-full ${tint}`} />
                 <span className="text-3xl font-bold text-gray-900 dark:text-slate-50 tabular-nums">{value}</span>
-                <span className="text-xs uppercase tracking-widest text-gray-400 dark:text-slate-500 mt-1.5">{label}</span>
             </div>
+            <span className="text-xs uppercase tracking-widest text-gray-400 dark:text-slate-500 mt-1.5 pl-[18px]">{label}</span>
         </div>
     );
 }

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -1,21 +1,25 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: Monthly invoicing report — every project with activity in a chosen month, expandable into its
- *   submittals and releases and their change history for that month. Gated to khearn + admins.
+ * purpose: Monthly invoicing report — every project with billing activity in a chosen month,
+ *   expandable into its DRR submittals (create/open/close lifecycle) and releases (stage/install/
+ *   invoiced progress) for that month. Gated to khearn + admins.
  * exports:
- *   InvoicingReport: Page component with month/year picker and nested expand/collapse rows.
- * imports_from: [react, ../services/invoicingApi, ../utils/auth]
+ *   InvoicingReport: Page component with month/year picker, project filter, CSV export, and
+ *     nested expand/collapse cards.
+ * imports_from: [react, ../services/invoicingApi, ../utils/auth, ../utils/csv, ../components/ColumnHeaderFilter]
  * imported_by: [frontend/src/App.jsx]
  * invariants:
  *   - Renders an access message (no fetch) unless userCanAccessInvoicing(user) is true.
- *   - Backend already formats event.created_at as a Mountain-Time string; render it as-is.
- *   - Only projects/items with changes in the selected month are returned by the API.
+ *   - Backend already filters to DRR submittals and create/open/close + meaningful release events,
+ *     and formats event.created_at as a Mountain-Time string; render it as-is.
+ *   - Submittal events carry a `kind` of 'create' | 'open' | 'close' driving the status timeline.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { invoicingApi } from '../services/invoicingApi';
 import ColumnHeaderFilter from '../components/ColumnHeaderFilter';
 import { checkAuth, userCanAccessInvoicing } from '../utils/auth';
+import { downloadCsv } from '../utils/csv';
 
 const MONTHS = [
     'January', 'February', 'March', 'April', 'May', 'June',
@@ -29,20 +33,29 @@ const projectLabel = (p) => {
     return name ? `${p.project_number} — ${name}` : String(p.project_number);
 };
 
+// Colors for the release event badges (action-based).
 function actionColor(action) {
     if (!action) return 'bg-gray-100 text-gray-800 dark:bg-slate-700 dark:text-slate-200';
     const a = action.toLowerCase();
     const colors = {
         update: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
         updated: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
-        update_stage: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
-        create: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
-        created: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
-        delete: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+        update_stage: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200',
         list_move: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200',
+        created: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+        create: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+        delete: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
     };
     return colors[a] || colors[a.split('_')[0]] || 'bg-gray-100 text-gray-800 dark:bg-slate-700 dark:text-slate-200';
 }
+
+// Colors + labels for the submittal lifecycle timeline (kind-based).
+const KIND_LABEL = { create: 'Created', open: 'Opened', close: 'Closed' };
+const KIND_DOT = {
+    create: 'bg-green-500',
+    open: 'bg-blue-500',
+    close: 'bg-slate-500 dark:bg-slate-400',
+};
 
 function Chevron({ open }) {
     return (
@@ -77,10 +90,77 @@ function ToggleRow({ open, onToggle, depthClass, children }) {
     );
 }
 
-// One submittal/release item, expandable into its month's change history.
-// `meta` is an array of { label, value, width } summary fields rendered as fixed-width
-// columns so they align vertically across rows; empty values keep their slot.
-function ItemRow({ label, meta = [], totalChanges, events, expanded, onToggle }) {
+// Most recent date string for a given lifecycle kind (events are newest-first).
+const kindDate = (events, kind) => {
+    const ev = events.find((e) => e.kind === kind);
+    return ev ? ev.created_at : null;
+};
+
+// DRR submittals as a compact create/open/close timeline table. No expand needed —
+// the three lifecycle dates are the whole story for a billing month.
+function SubmittalTimeline({ submittals }) {
+    if (submittals.length === 0) {
+        return (
+            <div className="pl-12 pr-3 py-2 text-xs text-gray-500 dark:text-slate-400">
+                No DRR submittal activity this month.
+            </div>
+        );
+    }
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+                <thead>
+                    <tr className="text-left text-gray-500 dark:text-slate-400">
+                        <th className="pl-12 pr-3 py-1.5 font-medium">DRR Submittal</th>
+                        {['create', 'open', 'close'].map((k) => (
+                            <th key={k} className="px-3 py-1.5 font-medium whitespace-nowrap w-44">
+                                <span className="inline-flex items-center gap-1.5">
+                                    <span className={`inline-block w-2 h-2 rounded-full ${KIND_DOT[k]}`} />
+                                    {KIND_LABEL[k]}
+                                </span>
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {submittals.map((s) => {
+                        const label = `${s.submittal_id}${s.title ? ` — ${s.title}` : ''}`;
+                        return (
+                            <tr key={s.submittal_id} className="border-t border-gray-100 dark:border-slate-700/70">
+                                <td className="pl-12 pr-3 py-2 text-gray-800 dark:text-slate-100">
+                                    <span className="block truncate max-w-md" title={label}>{label}</span>
+                                    {s.submittal_manager && (
+                                        <span className="text-[11px] text-gray-400 dark:text-slate-500">
+                                            Mgr: {s.submittal_manager}
+                                        </span>
+                                    )}
+                                </td>
+                                {['create', 'open', 'close'].map((k) => {
+                                    const d = kindDate(s.events, k);
+                                    return (
+                                        <td key={k} className="px-3 py-2 whitespace-nowrap text-gray-600 dark:text-slate-300">
+                                            {d || <span className="text-gray-300 dark:text-slate-600">—</span>}
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+// One release, expandable into its month's change events.
+function ReleaseRow({ release, expanded, onToggle }) {
+    const r = release;
+    const label = `${r.release}${r.description ? ` — ${r.description}` : ''}`;
+    const meta = [
+        { label: 'Stage', value: r.stage, width: 'w-40' },
+        { label: 'Install', value: r.install_prog, width: 'w-24' },
+        { label: 'Invoiced', value: r.invoiced, width: 'w-24' },
+    ];
     return (
         <div className="border-t border-gray-100 dark:border-slate-700">
             <ToggleRow open={expanded} onToggle={onToggle} depthClass="pl-12 pr-3 py-2">
@@ -88,29 +168,27 @@ function ItemRow({ label, meta = [], totalChanges, events, expanded, onToggle })
                 <span className="flex-1 min-w-0 text-sm text-gray-800 dark:text-slate-100 truncate" title={label}>
                     {label}
                 </span>
-                {meta.length > 0 && (
-                    <span className="hidden md:flex items-center gap-4 text-[11px] text-gray-500 dark:text-slate-400 shrink-0">
-                        {meta.map((m) => (
-                            <span key={m.label} className={`${m.width} shrink-0 truncate`}>
-                                {m.value != null && m.value !== '' && (
-                                    <>
-                                        <span className="text-gray-400 dark:text-slate-500">{m.label}:</span> {m.value}
-                                    </>
-                                )}
-                            </span>
-                        ))}
-                    </span>
-                )}
+                <span className="hidden md:flex items-center gap-4 text-[11px] text-gray-500 dark:text-slate-400 shrink-0">
+                    {meta.map((m) => (
+                        <span key={m.label} className={`${m.width} shrink-0 truncate`}>
+                            {m.value != null && m.value !== '' && (
+                                <>
+                                    <span className="text-gray-400 dark:text-slate-500">{m.label}:</span> {m.value}
+                                </>
+                            )}
+                        </span>
+                    ))}
+                </span>
                 <span className="shrink-0 w-20 text-right text-xs font-medium text-gray-500 dark:text-slate-400 whitespace-nowrap">
-                    {totalChanges} {totalChanges === 1 ? 'change' : 'changes'}
+                    {r.total_changes} {r.total_changes === 1 ? 'change' : 'changes'}
                 </span>
             </ToggleRow>
             {expanded && (
                 <ul className="pl-16 pr-3 py-2 space-y-2 bg-gray-50 dark:bg-slate-800/60">
-                    {events.length === 0 && (
+                    {r.events.length === 0 && (
                         <li className="text-xs text-gray-500 dark:text-slate-400">No changes this month.</li>
                     )}
-                    {events.map((ev) => (
+                    {r.events.map((ev) => (
                         <li key={ev.id} className="flex items-center gap-3 text-xs">
                             <span className="w-40 shrink-0">
                                 <span className={`inline-block px-2 py-0.5 rounded-full font-medium ${actionColor(ev.action)}`}>
@@ -132,6 +210,15 @@ function ItemRow({ label, meta = [], totalChanges, events, expanded, onToggle })
     );
 }
 
+function SummaryStat({ value, label }) {
+    return (
+        <div className="flex flex-col items-center px-3">
+            <span className="text-xl font-bold text-gray-900 dark:text-slate-100 leading-none">{value}</span>
+            <span className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-slate-400 mt-0.5">{label}</span>
+        </div>
+    );
+}
+
 function InvoicingReport() {
     const now = new Date();
     const [authorized, setAuthorized] = useState(null); // null = checking
@@ -142,7 +229,6 @@ function InvoicingReport() {
     const [error, setError] = useState(null);
 
     const [expandedProjects, setExpandedProjects] = useState(new Set());
-    const [expandedSections, setExpandedSections] = useState(new Set());
     const [expandedItems, setExpandedItems] = useState(new Set());
 
     // Single combined project filter (Excel-style). Empty Set = no filter.
@@ -161,7 +247,6 @@ function InvoicingReport() {
             setReport(data);
             // Reset expansion when the dataset changes.
             setExpandedProjects(new Set());
-            setExpandedSections(new Set());
             setExpandedItems(new Set());
         } catch (err) {
             setError(err.message);
@@ -184,8 +269,58 @@ function InvoicingReport() {
         });
     };
     const toggleProject = toggle(setExpandedProjects);
-    const toggleSection = toggle(setExpandedSections);
     const toggleItem = toggle(setExpandedItems);
+
+    const projects = useMemo(() => report?.projects || [], [report]);
+
+    // Combined project values for the dropdown, sorted by project number.
+    const projectValues = useMemo(
+        () => projects.map(projectLabel).sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
+        [projects],
+    );
+
+    const visibleProjects = useMemo(
+        () => projects
+            .filter((p) => projectFilter.size === 0 || projectFilter.has(projectLabel(p)))
+            .sort((a, b) => {
+                if (!columnSort.column) return 0;
+                const mult = columnSort.direction === 'desc' ? -1 : 1;
+                return mult * projectLabel(a).localeCompare(projectLabel(b), undefined, { numeric: true });
+            }),
+        [projects, projectFilter, columnSort],
+    );
+
+    // Totals across the currently visible projects.
+    const totals = useMemo(() => visibleProjects.reduce(
+        (acc, p) => {
+            acc.submittals += p.submittals.length;
+            acc.releases += p.releases.length;
+            return acc;
+        },
+        { submittals: 0, releases: 0 },
+    ), [visibleProjects]);
+
+    const exportCsv = useCallback(() => {
+        const headers = ['Project #', 'Project', 'Section', 'Item', 'Event', 'Detail', 'Date', 'Source'];
+        const rows = [];
+        for (const p of visibleProjects) {
+            for (const s of p.submittals) {
+                const item = `${s.submittal_id}${s.title ? ` — ${s.title}` : ''}`;
+                for (const ev of s.events) {
+                    rows.push([p.project_number, p.project_name || '', 'DRR Submittal', item,
+                        KIND_LABEL[ev.kind] || ev.action, ev.new_value || '', ev.created_at, ev.source || '']);
+                }
+            }
+            for (const r of p.releases) {
+                const item = `${r.release}${r.description ? ` — ${r.description}` : ''}`;
+                for (const ev of r.events) {
+                    rows.push([p.project_number, p.project_name || '', 'Release', item,
+                        ev.action, ev.new_value || '', ev.created_at, ev.source || '']);
+                }
+            }
+        }
+        downloadCsv(`invoicing-${year}-${String(month).padStart(2, '0')}.csv`, headers, rows);
+    }, [visibleProjects, month, year]);
 
     if (authorized === null) {
         return (
@@ -205,30 +340,20 @@ function InvoicingReport() {
         );
     }
 
-    const projects = report?.projects || [];
     const years = [];
     for (let y = now.getFullYear(); y >= now.getFullYear() - 5; y -= 1) years.push(y);
-
-    // Combined project values for the dropdown, sorted by project number.
-    const projectValues = projects
-        .map(projectLabel)
-        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-
-    const visibleProjects = projects
-        .filter((p) => projectFilter.size === 0 || projectFilter.has(projectLabel(p)))
-        .sort((a, b) => {
-            if (!columnSort.column) return 0;
-            const mult = columnSort.direction === 'desc' ? -1 : 1;
-            return mult * projectLabel(a).localeCompare(projectLabel(b), undefined, { numeric: true });
-        });
+    const hasData = !loading && !error && visibleProjects.length > 0;
 
     return (
         <div className="flex-1 w-full max-w-5xl mx-auto p-4 sm:p-6">
-            <div className="flex flex-wrap items-end gap-3 mb-5">
+            {/* Header: title + month/year picker */}
+            <div className="flex flex-wrap items-end gap-3 mb-4">
                 <div>
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Invoicing Report</h1>
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">
+                        Invoicing — {report?.month_label || `${MONTHS[month - 1]} ${year}`}
+                    </h1>
                     <p className="text-sm text-gray-500 dark:text-slate-400">
-                        Monthly change history for releases and submittals, grouped by project.
+                        DRR submittal lifecycle and release progress, grouped by project.
                     </p>
                 </div>
                 <div className="ml-auto flex items-end gap-2">
@@ -259,24 +384,38 @@ function InvoicingReport() {
                 </div>
             </div>
 
-            {!loading && !error && projects.length > 0 && (
-                <div className="flex flex-wrap items-center gap-2 mb-3 text-sm font-medium text-gray-700 dark:text-slate-200">
-                    <span className="text-xs text-gray-500 dark:text-slate-400">Filter:</span>
-                    <span className="px-2 py-1 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800">
-                        <ColumnHeaderFilter
-                            column="project"
-                            values={projectValues}
-                            hasBlanks={false}
-                            selected={projectFilter}
-                            onChange={(next) => setProjectFilter(new Set(next))}
-                            sort={columnSort}
-                            onSort={(dir) => setColumnSort(dir ? { column: 'project', direction: dir } : { column: null, direction: null })}
-                            isActive={projectFilter.size > 0}
-                            autoWidth
+            {/* Summary bar: totals + filter + export */}
+            {hasData && (
+                <div className="flex flex-wrap items-center gap-3 mb-4 p-3 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+                    <div className="flex items-center divide-x divide-gray-200 dark:divide-slate-700">
+                        <SummaryStat value={visibleProjects.length} label="Projects" />
+                        <SummaryStat value={totals.submittals} label="DRR" />
+                        <SummaryStat value={totals.releases} label="Releases" />
+                    </div>
+                    <div className="ml-auto flex items-center gap-2">
+                        <span className="px-2 py-1 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm">
+                            <ColumnHeaderFilter
+                                column="project"
+                                values={projectValues}
+                                hasBlanks={false}
+                                selected={projectFilter}
+                                onChange={(next) => setProjectFilter(new Set(next))}
+                                sort={columnSort}
+                                onSort={(dir) => setColumnSort(dir ? { column: 'project', direction: dir } : { column: null, direction: null })}
+                                isActive={projectFilter.size > 0}
+                                autoWidth
+                            >
+                                Project # / Name
+                            </ColumnHeaderFilter>
+                        </span>
+                        <button
+                            type="button"
+                            onClick={exportCsv}
+                            className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700"
                         >
-                            Project # / Name
-                        </ColumnHeaderFilter>
-                    </span>
+                            Export CSV
+                        </button>
+                    </div>
                 </div>
             )}
 
@@ -302,15 +441,11 @@ function InvoicingReport() {
                 </div>
             )}
 
-            {!loading && !error && visibleProjects.length > 0 && (
+            {hasData && (
                 <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700">
                     {visibleProjects.map((proj) => {
                         const pKey = proj.project_number;
                         const pOpen = expandedProjects.has(pKey);
-                        const subSectionKey = `${pKey}:submittals`;
-                        const relSectionKey = `${pKey}:releases`;
-                        const subOpen = expandedSections.has(subSectionKey);
-                        const relOpen = expandedSections.has(relSectionKey);
                         return (
                             <div key={pKey}>
                                 {/* Level 1 — Project */}
@@ -323,87 +458,41 @@ function InvoicingReport() {
                                         {proj.project_name || '—'}
                                     </span>
                                     <span className="ml-auto text-xs text-gray-500 dark:text-slate-400 whitespace-nowrap">
-                                        {proj.submittals.length} submittals · {proj.releases.length} releases
+                                        {proj.submittals.length} DRR · {proj.releases.length} releases
                                     </span>
                                 </ToggleRow>
 
                                 {pOpen && (
-                                    <div>
-                                        {/* Level 2 — Submittals */}
-                                        <div className="border-t border-gray-100 dark:border-slate-700">
-                                            <ToggleRow open={subOpen} onToggle={() => toggleSection(subSectionKey)} depthClass="pl-8 pr-3 py-2 bg-gray-50/60 dark:bg-slate-800/40">
-                                                <Chevron open={subOpen} />
-                                                <span className="text-sm font-medium text-gray-700 dark:text-slate-200">
-                                                    Submittals
-                                                </span>
-                                                <span className="ml-auto text-xs text-gray-500 dark:text-slate-400">
-                                                    {proj.submittals.length}
-                                                </span>
-                                            </ToggleRow>
-                                            {subOpen && proj.submittals.map((s) => {
-                                                const key = `${pKey}:sub:${s.submittal_id}`;
-                                                const label = `${s.submittal_id}${s.title ? ` — ${s.title}` : ''}`;
-                                                const meta = [
-                                                    { label: 'Status', value: s.status, width: 'w-40' },
-                                                    { label: 'BIC', value: s.ball_in_court, width: 'w-44' },
-                                                    { label: 'Sub Mgr', value: s.submittal_manager, width: 'w-44' },
-                                                ];
-                                                return (
-                                                    <ItemRow
-                                                        key={key}
-                                                        label={label}
-                                                        meta={meta}
-                                                        totalChanges={s.total_changes}
-                                                        events={s.events}
-                                                        expanded={expandedItems.has(key)}
-                                                        onToggle={() => toggleItem(key)}
-                                                    />
-                                                );
-                                            })}
-                                            {subOpen && proj.submittals.length === 0 && (
-                                                <div className="pl-12 pr-3 py-2 text-xs text-gray-500 dark:text-slate-400 border-t border-gray-100 dark:border-slate-700">
-                                                    No submittal changes this month.
-                                                </div>
-                                            )}
+                                    <div className="border-t border-gray-100 dark:border-slate-700">
+                                        {/* DRR Submittals — lifecycle timeline */}
+                                        <div className="py-2 bg-gray-50/60 dark:bg-slate-800/40">
+                                            <div className="pl-8 pr-3 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                                                DRR Submittals
+                                            </div>
+                                            <SubmittalTimeline submittals={proj.submittals} />
                                         </div>
 
-                                        {/* Level 2 — Releases */}
-                                        <div className="border-t border-gray-100 dark:border-slate-700">
-                                            <ToggleRow open={relOpen} onToggle={() => toggleSection(relSectionKey)} depthClass="pl-8 pr-3 py-2 bg-gray-50/60 dark:bg-slate-800/40">
-                                                <Chevron open={relOpen} />
-                                                <span className="text-sm font-medium text-gray-700 dark:text-slate-200">
-                                                    Releases
-                                                </span>
-                                                <span className="ml-auto text-xs text-gray-500 dark:text-slate-400">
-                                                    {proj.releases.length}
-                                                </span>
-                                            </ToggleRow>
-                                            {relOpen && proj.releases.map((r) => {
+                                        {/* Releases — expandable event rows */}
+                                        <div className="py-2 border-t border-gray-100 dark:border-slate-700">
+                                            <div className="pl-8 pr-3 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                                                Releases
+                                            </div>
+                                            {proj.releases.length === 0 && (
+                                                <div className="pl-12 pr-3 py-2 text-xs text-gray-500 dark:text-slate-400">
+                                                    No release activity this month.
+                                                </div>
+                                            )}
+                                            {proj.releases.map((r) => {
                                                 const key = `${pKey}:rel:${r.job}-${r.release}`;
-                                                const label = `${r.release}${r.description ? ` — ${r.description}` : ''}`;
-                                                const meta = [
-                                                    { label: 'PM', value: r.pm, width: 'w-16' },
-                                                    { label: 'Stage', value: r.stage, width: 'w-40' },
-                                                    { label: 'Install', value: r.install_prog, width: 'w-24' },
-                                                    { label: 'Invoiced', value: r.invoiced, width: 'w-28' },
-                                                ];
                                                 return (
-                                                    <ItemRow
+                                                    <ReleaseRow
                                                         key={key}
-                                                        label={label}
-                                                        meta={meta}
-                                                        totalChanges={r.total_changes}
-                                                        events={r.events}
+                                                        release={r}
                                                         expanded={expandedItems.has(key)}
                                                         onToggle={() => toggleItem(key)}
                                                     />
                                                 );
                                             })}
-                                            {relOpen && proj.releases.length === 0 && (
-                                                <div className="pl-12 pr-3 py-2 text-xs text-gray-500 dark:text-slate-400 border-t border-gray-100 dark:border-slate-700">
-                                                    No release changes this month.
-                                                </div>
-                                            )}
                                         </div>
                                     </div>
                                 )}

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -244,7 +244,7 @@ function ReleaseRow({ release, expanded, onToggle }) {
                 <span className="hidden md:flex items-center gap-4 shrink-0 text-sm">
                     <span className="w-44 flex items-center">
                         {r.stage
-                            ? <Badge tint={stageTint(r.stage)}>{r.stage}</Badge>
+                            ? <Badge tint={stageTint(r.stage)} className="w-40 justify-center whitespace-nowrap">{r.stage}</Badge>
                             : <span className="text-gray-300 dark:text-slate-600">—</span>}
                     </span>
                     <span className="w-28 text-gray-400 dark:text-slate-500 whitespace-nowrap">

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -97,8 +97,8 @@ function actionTint(action) {
 
 function Badge({ tint = 'slate', dot = false, className = '', children }) {
     return (
-        <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ring-1 ring-inset ${TINT[tint]} ${className}`}>
-            {dot && <span className={`w-1.5 h-1.5 rounded-full ${KIND_META[dot]?.dot || 'bg-current'}`} />}
+        <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium ring-1 ring-inset ${TINT[tint]} ${className}`}>
+            {dot && <span className={`w-2 h-2 rounded-full ${KIND_META[dot]?.dot || 'bg-current'}`} />}
             {children}
         </span>
     );
@@ -107,7 +107,7 @@ function Badge({ tint = 'slate', dot = false, className = '', children }) {
 function Chevron({ open }) {
     return (
         <span
-            className={`inline-block text-gray-400 dark:text-slate-500 transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
+            className={`inline-block text-lg text-gray-400 dark:text-slate-500 transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
             aria-hidden="true"
         >
             ▸
@@ -144,19 +144,19 @@ const kindEvent = (events, kind) => events.find((e) => e.kind === kind) || null;
 function TimelineCell({ event, kind }) {
     if (!event) {
         return (
-            <td className="px-3 py-2.5 align-top">
-                <span className="text-gray-300 dark:text-slate-600 select-none">—</span>
+            <td className="px-4 py-4 align-top">
+                <span className="text-xl text-gray-300 dark:text-slate-600 select-none">—</span>
             </td>
         );
     }
     const meta = KIND_META[kind];
     return (
-        <td className="px-3 py-2.5 align-top whitespace-nowrap">
-            <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-xs font-medium ring-1 ring-inset ${TINT[meta.tint]}`}>
-                <span className={`w-1.5 h-1.5 rounded-full ${meta.dot}`} />
+        <td className="px-4 py-4 align-top whitespace-nowrap">
+            <span className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-base font-medium ring-1 ring-inset ${TINT[meta.tint]}`}>
+                <span className={`w-2 h-2 rounded-full ${meta.dot}`} />
                 {prettyDate(event.created_at)}
             </span>
-            <div className="mt-0.5 pl-1 text-[10px] text-gray-400 dark:text-slate-500">{prettyTime(event.created_at)}</div>
+            <div className="mt-1 pl-1 text-xs text-gray-400 dark:text-slate-500">{prettyTime(event.created_at)}</div>
         </td>
     );
 }
@@ -165,21 +165,21 @@ function TimelineCell({ event, kind }) {
 function SubmittalTimeline({ submittals }) {
     if (submittals.length === 0) {
         return (
-            <div className="px-6 py-3 text-xs text-gray-400 dark:text-slate-500 italic">
+            <div className="px-8 py-4 text-sm text-gray-400 dark:text-slate-500 italic">
                 No DRR submittal activity this month.
             </div>
         );
     }
     return (
         <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="w-full text-base">
                 <thead>
-                    <tr className="text-left text-[11px] uppercase tracking-wide text-gray-400 dark:text-slate-500">
-                        <th className="pl-12 pr-3 py-1.5 font-semibold">DRR Submittal</th>
+                    <tr className="text-left text-xs uppercase tracking-wide text-gray-400 dark:text-slate-500">
+                        <th className="pl-14 pr-4 py-2.5 font-semibold">DRR Submittal</th>
                         {['create', 'open', 'close'].map((k) => (
-                            <th key={k} className="px-3 py-1.5 font-semibold w-44">
-                                <span className="inline-flex items-center gap-1.5">
-                                    <span className={`inline-block w-2 h-2 rounded-full ${KIND_META[k].dot}`} />
+                            <th key={k} className="px-4 py-2.5 font-semibold w-52">
+                                <span className="inline-flex items-center gap-2">
+                                    <span className={`inline-block w-2.5 h-2.5 rounded-full ${KIND_META[k].dot}`} />
                                     {KIND_META[k].label}
                                 </span>
                             </th>
@@ -191,10 +191,10 @@ function SubmittalTimeline({ submittals }) {
                         const label = `${s.submittal_id}${s.title ? ` — ${s.title}` : ''}`;
                         return (
                             <tr key={s.submittal_id} className="border-t border-gray-100 dark:border-slate-700/60 hover:bg-gray-50/70 dark:hover:bg-slate-700/30">
-                                <td className="pl-12 pr-3 py-2.5 align-top">
-                                    <span className="block truncate max-w-md text-gray-800 dark:text-slate-100" title={label}>{label}</span>
+                                <td className="pl-14 pr-4 py-4 align-top">
+                                    <span className="block truncate max-w-xl text-gray-800 dark:text-slate-100" title={label}>{label}</span>
                                     {s.submittal_manager && (
-                                        <span className="text-[11px] text-gray-400 dark:text-slate-500">{s.submittal_manager}</span>
+                                        <span className="text-sm text-gray-400 dark:text-slate-500">{s.submittal_manager}</span>
                                     )}
                                 </td>
                                 {['create', 'open', 'close'].map((k) => (
@@ -215,36 +215,36 @@ function ReleaseRow({ release, expanded, onToggle }) {
     const label = `${r.release}${r.description ? ` — ${r.description}` : ''}`;
     return (
         <div className="border-t border-gray-100 dark:border-slate-700/60">
-            <ToggleRow open={expanded} onToggle={onToggle} depthClass="pl-12 pr-3 py-2.5">
+            <ToggleRow open={expanded} onToggle={onToggle} depthClass="pl-14 pr-4 py-3.5">
                 <Chevron open={expanded} />
-                <span className="flex-1 min-w-0 text-sm text-gray-800 dark:text-slate-100 truncate" title={label}>
+                <span className="flex-1 min-w-0 text-base text-gray-800 dark:text-slate-100 truncate" title={label}>
                     {label}
                 </span>
-                <span className="hidden md:flex items-center gap-2 shrink-0">
+                <span className="hidden md:flex items-center gap-4 shrink-0">
                     {r.stage && <Badge tint={stageTint(r.stage)}>{r.stage}</Badge>}
                     {r.install_prog != null && r.install_prog !== '' && (
-                        <span className="text-[11px] text-gray-400 dark:text-slate-500">
+                        <span className="text-sm text-gray-400 dark:text-slate-500">
                             Install <span className="font-semibold text-gray-600 dark:text-slate-300">{r.install_prog}</span>
                         </span>
                     )}
                     {r.invoiced != null && r.invoiced !== '' && (
-                        <span className="text-[11px] text-gray-400 dark:text-slate-500">
+                        <span className="text-sm text-gray-400 dark:text-slate-500">
                             Inv <span className="font-semibold text-gray-600 dark:text-slate-300">{r.invoiced}</span>
                         </span>
                     )}
                 </span>
-                <span className="shrink-0 w-20 text-right text-[11px] font-medium text-gray-400 dark:text-slate-500 whitespace-nowrap">
+                <span className="shrink-0 w-28 text-right text-sm font-medium text-gray-400 dark:text-slate-500 whitespace-nowrap">
                     {r.total_changes} {r.total_changes === 1 ? 'change' : 'changes'}
                 </span>
             </ToggleRow>
             {expanded && (
-                <ul className="pl-16 pr-3 py-2 space-y-1.5 bg-gray-50/80 dark:bg-slate-900/40 border-t border-gray-100 dark:border-slate-700/60">
+                <ul className="pl-20 pr-4 py-3 space-y-2.5 bg-gray-50/80 dark:bg-slate-900/40 border-t border-gray-100 dark:border-slate-700/60">
                     {r.events.length === 0 && (
-                        <li className="text-xs text-gray-400 dark:text-slate-500 italic">No changes this month.</li>
+                        <li className="text-sm text-gray-400 dark:text-slate-500 italic">No changes this month.</li>
                     )}
                     {r.events.map((ev) => (
-                        <li key={ev.id} className="flex items-center gap-3 text-xs">
-                            <span className="w-44 shrink-0">
+                        <li key={ev.id} className="flex items-center gap-4 text-sm">
+                            <span className="w-52 shrink-0">
                                 <Badge tint={actionTint(ev.action)}>{ev.action}</Badge>
                             </span>
                             <span className="flex-1 min-w-0 truncate text-gray-700 dark:text-slate-200">
@@ -264,11 +264,11 @@ function ReleaseRow({ release, expanded, onToggle }) {
 
 function SummaryStat({ value, label, tint }) {
     return (
-        <div className="flex items-center gap-2.5 px-4">
-            <span className={`w-2.5 h-2.5 rounded-full ${tint}`} />
+        <div className="flex items-center gap-3 px-6">
+            <span className={`w-3.5 h-3.5 rounded-full ${tint}`} />
             <div className="flex flex-col leading-none">
-                <span className="text-2xl font-bold text-gray-900 dark:text-slate-50 tabular-nums">{value}</span>
-                <span className="text-[10px] uppercase tracking-widest text-gray-400 dark:text-slate-500 mt-1">{label}</span>
+                <span className="text-4xl font-bold text-gray-900 dark:text-slate-50 tabular-nums">{value}</span>
+                <span className="text-xs uppercase tracking-widest text-gray-400 dark:text-slate-500 mt-1.5">{label}</span>
             </div>
         </div>
     );
@@ -396,28 +396,28 @@ function InvoicingReport() {
     const years = [];
     for (let y = now.getFullYear(); y >= now.getFullYear() - 5; y -= 1) years.push(y);
     const hasData = !loading && !error && visibleProjects.length > 0;
-    const selectClass = 'mt-1 px-2.5 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-accent-400/60';
+    const selectClass = 'mt-1.5 px-3 py-2 text-base rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-accent-400/60';
 
     return (
-        <div className="flex-1 w-full max-w-5xl mx-auto p-4 sm:p-6">
+        <div className="flex-1 w-full max-w-[1600px] mx-auto p-6 sm:p-8">
             {/* Header: title + month/year picker */}
-            <div className="flex flex-wrap items-end gap-3 mb-4">
+            <div className="flex flex-wrap items-end gap-3 mb-6">
                 <div>
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">
+                    <h1 className="text-4xl font-bold text-gray-900 dark:text-slate-50">
                         Invoicing <span className="text-accent-500 dark:text-accent-300">— {report?.month_label || `${MONTHS[month - 1]} ${year}`}</span>
                     </h1>
-                    <p className="text-sm text-gray-500 dark:text-slate-400">
+                    <p className="text-base text-gray-500 dark:text-slate-400 mt-1">
                         DRR submittal lifecycle and release progress, grouped by project.
                     </p>
                 </div>
-                <div className="ml-auto flex items-end gap-2">
-                    <label className="flex flex-col text-xs font-medium text-gray-600 dark:text-slate-400">
+                <div className="ml-auto flex items-end gap-3">
+                    <label className="flex flex-col text-sm font-medium text-gray-600 dark:text-slate-400">
                         Month
                         <select value={month} onChange={(e) => setMonth(parseInt(e.target.value, 10))} className={selectClass}>
                             {MONTHS.map((m, i) => (<option key={m} value={i + 1}>{m}</option>))}
                         </select>
                     </label>
-                    <label className="flex flex-col text-xs font-medium text-gray-600 dark:text-slate-400">
+                    <label className="flex flex-col text-sm font-medium text-gray-600 dark:text-slate-400">
                         Year
                         <select value={year} onChange={(e) => setYear(parseInt(e.target.value, 10))} className={selectClass}>
                             {years.map((y) => (<option key={y} value={y}>{y}</option>))}
@@ -428,14 +428,14 @@ function InvoicingReport() {
 
             {/* Summary bar: totals + filter + export */}
             {hasData && (
-                <div className="flex flex-wrap items-center gap-3 mb-5 p-3 rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
+                <div className="flex flex-wrap items-center gap-4 mb-6 p-5 rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
                     <div className="flex items-center divide-x divide-gray-200 dark:divide-slate-700">
                         <SummaryStat value={visibleProjects.length} label="Projects" tint="bg-accent-500" />
                         <SummaryStat value={totals.submittals} label="DRR" tint="bg-emerald-500" />
                         <SummaryStat value={totals.releases} label="Releases" tint="bg-blue-500" />
                     </div>
-                    <div className="ml-auto flex items-center gap-2">
-                        <span className="px-2.5 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm">
+                    <div className="ml-auto flex items-center gap-3">
+                        <span className="px-3 py-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-base">
                             <ColumnHeaderFilter
                                 column="project"
                                 values={projectValues}
@@ -453,7 +453,7 @@ function InvoicingReport() {
                         <button
                             type="button"
                             onClick={exportCsv}
-                            className="inline-flex items-center gap-1.5 px-3.5 py-2 text-sm font-semibold rounded-lg bg-accent-500 text-white shadow-sm hover:bg-accent-600 focus:outline-none focus:ring-2 focus:ring-accent-400/60 transition-colors"
+                            className="inline-flex items-center gap-2 px-5 py-2.5 text-base font-semibold rounded-lg bg-accent-500 text-white shadow-sm hover:bg-accent-600 focus:outline-none focus:ring-2 focus:ring-accent-400/60 transition-colors"
                         >
                             <span aria-hidden="true">↓</span> Export CSV
                         </button>
@@ -462,23 +462,23 @@ function InvoicingReport() {
             )}
 
             {loading && (
-                <div className="py-16 text-center text-gray-500 dark:text-slate-400">Loading report…</div>
+                <div className="py-20 text-center text-lg text-gray-500 dark:text-slate-400">Loading report…</div>
             )}
 
             {error && !loading && (
-                <div className="py-4 px-4 rounded-xl bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-200 text-sm ring-1 ring-red-200/60 dark:ring-red-500/30">
+                <div className="py-4 px-5 rounded-xl bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-200 text-base ring-1 ring-red-200/60 dark:ring-red-500/30">
                     {error}
                 </div>
             )}
 
             {!loading && !error && projects.length === 0 && (
-                <div className="py-16 text-center text-gray-500 dark:text-slate-400">
+                <div className="py-20 text-center text-lg text-gray-500 dark:text-slate-400">
                     No project activity for {report?.month_label || `${MONTHS[month - 1]} ${year}`}.
                 </div>
             )}
 
             {!loading && !error && projects.length > 0 && visibleProjects.length === 0 && (
-                <div className="py-16 text-center text-gray-500 dark:text-slate-400">
+                <div className="py-20 text-center text-lg text-gray-500 dark:text-slate-400">
                     No projects match the current filters.
                 </div>
             )}
@@ -491,15 +491,15 @@ function InvoicingReport() {
                         return (
                             <div key={pKey} className={pOpen ? 'bg-gray-50/40 dark:bg-slate-800/60' : ''}>
                                 {/* Level 1 — Project */}
-                                <ToggleRow open={pOpen} onToggle={() => toggleProject(pKey)} depthClass="px-3 py-3">
+                                <ToggleRow open={pOpen} onToggle={() => toggleProject(pKey)} depthClass="px-4 py-4">
                                     <Chevron open={pOpen} />
-                                    <span className="px-2 py-0.5 rounded-md text-sm font-bold font-mono bg-accent-50 text-accent-700 dark:bg-accent-400/10 dark:text-accent-200 ring-1 ring-inset ring-accent-200/60 dark:ring-accent-400/20">
+                                    <span className="px-2.5 py-1 rounded-md text-lg font-bold font-mono bg-accent-50 text-accent-700 dark:bg-accent-400/10 dark:text-accent-200 ring-1 ring-inset ring-accent-200/60 dark:ring-accent-400/20">
                                         {proj.project_number}
                                     </span>
-                                    <span className="text-gray-700 dark:text-slate-200 font-medium truncate">
+                                    <span className="text-lg text-gray-700 dark:text-slate-200 font-medium truncate">
                                         {proj.project_name || '—'}
                                     </span>
-                                    <span className="ml-auto flex items-center gap-2 shrink-0">
+                                    <span className="ml-auto flex items-center gap-3 shrink-0">
                                         <Badge tint={proj.submittals.length ? 'emerald' : 'slate'} className={proj.submittals.length ? '' : 'opacity-60'}>
                                             {proj.submittals.length} DRR
                                         </Badge>
@@ -512,20 +512,20 @@ function InvoicingReport() {
                                 {pOpen && (
                                     <div className="border-t border-gray-100 dark:border-slate-700/60">
                                         {/* DRR Submittals — lifecycle timeline */}
-                                        <div className="py-2.5">
-                                            <div className="pl-8 pr-3 pb-1 text-[11px] font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
+                                        <div className="py-3">
+                                            <div className="pl-10 pr-4 pb-1.5 text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
                                                 DRR Submittals
                                             </div>
                                             <SubmittalTimeline submittals={proj.submittals} />
                                         </div>
 
                                         {/* Releases — expandable event rows */}
-                                        <div className="py-2.5 border-t border-gray-100 dark:border-slate-700/60">
-                                            <div className="pl-8 pr-3 pb-1 text-[11px] font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
+                                        <div className="py-3 border-t border-gray-100 dark:border-slate-700/60">
+                                            <div className="pl-10 pr-4 pb-1.5 text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
                                                 Releases
                                             </div>
                                             {proj.releases.length === 0 && (
-                                                <div className="px-6 py-2 text-xs text-gray-400 dark:text-slate-500 italic">
+                                                <div className="px-8 py-3 text-sm text-gray-400 dark:text-slate-500 italic">
                                                     No release activity this month.
                                                 </div>
                                             )}

--- a/frontend/src/pages/InvoicingReport.jsx
+++ b/frontend/src/pages/InvoicingReport.jsx
@@ -211,7 +211,7 @@ function SubmittalTimeline({ submittals }) {
                     {submittals.map((s) => {
                         const label = `${s.submittal_id}${s.title ? ` — ${s.title}` : ''}`;
                         return (
-                            <tr key={s.submittal_id} className="border-t border-gray-100 dark:border-slate-700/60 hover:bg-gray-50/70 dark:hover:bg-slate-700/30">
+                            <tr key={s.submittal_id} className="border-t border-gray-200 dark:border-slate-700/60 hover:bg-gray-50/70 dark:hover:bg-slate-700/30">
                                 <td className="pl-14 pr-4 py-4 align-top">
                                     <span className="block truncate max-w-xl text-gray-800 dark:text-slate-100" title={label}>{label}</span>
                                     {s.submittal_manager && (
@@ -235,7 +235,7 @@ function ReleaseRow({ release, expanded, onToggle }) {
     const r = release;
     const label = `${r.release}${r.description ? ` — ${r.description}` : ''}`;
     return (
-        <div className="border-t border-gray-100 dark:border-slate-700/60">
+        <div className="border-t border-gray-200 dark:border-slate-700/60">
             <ToggleRow open={expanded} onToggle={onToggle} depthClass="pl-14 pr-4 py-3.5">
                 <Chevron open={expanded} />
                 <span className="flex-1 min-w-0 text-base text-gray-800 dark:text-slate-100 truncate" title={label}>
@@ -259,7 +259,7 @@ function ReleaseRow({ release, expanded, onToggle }) {
                 </span>
             </ToggleRow>
             {expanded && (
-                <div className="pl-16 pr-4 py-4 bg-gray-50/80 dark:bg-slate-900/40 border-t border-gray-100 dark:border-slate-700/60">
+                <div className="pl-16 pr-4 py-4 bg-gray-50/80 dark:bg-slate-900/40 border-t border-gray-200 dark:border-slate-700/60">
                     {r.events.length === 0 ? (
                         <p className="text-sm text-gray-400 dark:text-slate-500 italic">No changes this month.</p>
                     ) : (
@@ -508,7 +508,7 @@ function InvoicingReport() {
             )}
 
             {hasData && (
-                <div className="rounded-2xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-800 shadow-sm divide-y divide-gray-100 dark:divide-slate-700/70">
+                <div className="rounded-2xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-800 shadow-sm divide-y divide-gray-200 dark:divide-slate-700/70">
                     {visibleProjects.map((proj) => {
                         const pKey = proj.project_number;
                         const pOpen = expandedProjects.has(pKey);
@@ -534,7 +534,7 @@ function InvoicingReport() {
                                 </ToggleRow>
 
                                 {pOpen && (
-                                    <div className="border-t border-gray-100 dark:border-slate-700/60">
+                                    <div className="border-t border-gray-200 dark:border-slate-700/60">
                                         {/* DRR Submittals — lifecycle timeline */}
                                         <div className="py-3">
                                             <div className="pl-10 pr-4 pb-1.5 text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
@@ -544,7 +544,7 @@ function InvoicingReport() {
                                         </div>
 
                                         {/* Releases — expandable event rows */}
-                                        <div className="py-3 border-t border-gray-100 dark:border-slate-700/60">
+                                        <div className="py-3 border-t border-gray-200 dark:border-slate-700/60">
                                             <div className="pl-10 pr-4 pb-1.5 text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">
                                                 Releases
                                             </div>

--- a/frontend/src/utils/csv.js
+++ b/frontend/src/utils/csv.js
@@ -1,0 +1,35 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: Minimal dependency-free CSV builder + browser download helper.
+ * exports:
+ *   toCsv: Build an RFC-4180-ish CSV string from headers + row arrays.
+ *   downloadCsv: Build a CSV and trigger a browser download (UTF-8 with BOM for Excel).
+ * imported_by: [frontend/src/pages/InvoicingReport.jsx]
+ */
+
+function escapeCell(value) {
+    const s = value == null ? '' : String(value);
+    // Quote cells containing a comma, quote, or newline; double embedded quotes.
+    return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export function toCsv(headers, rows) {
+    const lines = [headers.map(escapeCell).join(',')];
+    for (const row of rows) lines.push(row.map(escapeCell).join(','));
+    return lines.join('\r\n');
+}
+
+export function downloadCsv(filename, headers, rows) {
+    const csv = toCsv(headers, rows);
+    // Leading BOM so Excel detects UTF-8.
+    const blob = new Blob(['﻿', csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}

--- a/tests/test_invoicing_report.py
+++ b/tests/test_invoicing_report.py
@@ -125,6 +125,25 @@ def seeded(app):
                                      payload_hash="h-5678-fab", source="Brain",
                                      created_at=datetime(2026, 5, 16, 12, 0)))
 
+        # Project 9012 — DRR created + opened in April, closed in May. Viewing
+        # May must still surface the April create/open dates (lifecycle backfill).
+        db.session.add(Projects(name="Lakeside Tower", job_number="9012"))
+        db.session.add(Submittals(submittal_id="S-4", project_number="9012",
+                                  project_name="Lakeside Tower", title="Late close",
+                                  type=DRR_TYPE, status="Closed", submittal_manager="Amy Lee"))
+        db.session.add(SubmittalEvents(submittal_id="S-4", action="created",
+                                       payload={"title": "Late close", "status": "Draft"},
+                                       payload_hash="h-s4-create", source="Procore",
+                                       created_at=datetime(2026, 4, 5, 12, 0)))
+        db.session.add(SubmittalEvents(submittal_id="S-4", action="updated",
+                                       payload={"status": {"old": "Draft", "new": "Open"}},
+                                       payload_hash="h-s4-open", source="Procore",
+                                       created_at=datetime(2026, 4, 10, 12, 0)))
+        db.session.add(SubmittalEvents(submittal_id="S-4", action="updated",
+                                       payload={"status": {"old": "Open", "new": "Closed"}},
+                                       payload_hash="h-s4-close", source="Procore",
+                                       created_at=datetime(2026, 5, 20, 12, 0)))
+
         # --- April 2026 (out of range) ---
         db.session.add(SubmittalEvents(submittal_id="S-1", action="created",
                                        payload={"title": "Glazing schedule"},
@@ -185,7 +204,23 @@ def test_project_pruned_when_all_events_excluded(seeded):
     """5678's only May event is a fab-order change, so the project drops out."""
     data = _get_report(seeded).get_json()
     projects = {p["project_number"] for p in data["projects"]}
-    assert projects == {"1234"}
+    assert projects == {"1234", "9012"}
+    assert "5678" not in projects
+
+
+def test_submittal_lifecycle_backfills_prior_month_dates(seeded):
+    """A DRR closed in May still reports its April create/open dates."""
+    data = _get_report(seeded).get_json()
+    p9012 = next(p for p in data["projects"] if p["project_number"] == "9012")
+    assert [s["submittal_id"] for s in p9012["submittals"]] == ["S-4"]
+    sub = p9012["submittals"][0]
+    assert sub["total_changes"] == 3
+    by_kind = {ev["kind"]: ev["created_at"] for ev in sub["events"]}
+    assert set(by_kind) == {"create", "open", "close"}
+    # Create and open happened in April; close in May — all three are present.
+    assert by_kind["create"].startswith("April")
+    assert by_kind["open"].startswith("April")
+    assert by_kind["close"].startswith("May")
 
 
 def test_releases_drop_fab_install_due_events(seeded):

--- a/tests/test_invoicing_report.py
+++ b/tests/test_invoicing_report.py
@@ -2,6 +2,12 @@
 
 Layer: integration (HTTP via test_client + in-memory DB). Auth is patched at
 app.auth.utils.get_current_user — the decorator resolves the user there.
+
+The report is Katie Hearn's billing view, so it applies several filters:
+  * Submittals: DRR ("Drafting Release Review") type only.
+  * Submittal events: create / open / close lifecycle only (no BIC/order changes).
+  * Releases: no fab-order, start-install, or due-date events.
+  * Submittal items never expose ball_in_court.
 """
 from datetime import datetime
 from unittest.mock import Mock, patch
@@ -17,6 +23,7 @@ from app.models import (
     Projects,
 )
 
+DRR_TYPE = "Drafting Release Review"
 
 REPORT_URL = "/api/reports/monthly-invoicing?year=2026&month=5"
 
@@ -33,57 +40,103 @@ def _mock_user(*, username="someone@mhmw.com", is_admin=False):
 
 @pytest.fixture
 def seeded(app):
-    """Seed two projects with releases/submittals and events in May and April 2026."""
+    """Seed projects exercising every invoicing filter, in May and April 2026."""
     with app.app_context():
         # Project 1234 — canonical name from Projects table.
         db.session.add(Projects(name="Downtown Mall", job_number="1234"))
         db.session.add(Releases(job=1234, release="V2", job_name="Downtown Mall (excel)",
                                 description="Storefront frames", pm="JD", stage="Complete",
                                 job_comp="X", invoiced="X"))
+        # DRR submittal — appears, with ball_in_court that must NOT surface.
         db.session.add(Submittals(submittal_id="S-1", project_number="1234",
                                   project_name="Downtown Mall", title="Glazing schedule",
-                                  status="Approved", ball_in_court="Jane Smith",
+                                  type=DRR_TYPE, status="Closed", ball_in_court="Jane Smith",
                                   submittal_manager="Bob Jones"))
-        # Project 5678 — no Projects row; name falls back to release/submittal values.
+        # Non-DRR submittal — must be excluded entirely.
+        db.session.add(Submittals(submittal_id="S-3", project_number="1234",
+                                  project_name="Downtown Mall", title="GC approval pkg",
+                                  type="Submittal for GC Approval", status="Open"))
+        # Project 5678 — its only May event is an excluded fab-order change, so the
+        # whole project must drop out of the report.
         db.session.add(Releases(job=5678, release="A", job_name="Airport Hangar",
                                 description="Canopy"))
-        db.session.add(Submittals(submittal_id="S-2", project_number="5678",
-                                  project_name="Airport Hangar", title="Anchor bolts",
-                                  status="Open"))
 
-        # May 2026 events (in range).
+        # --- May 2026 release events for 1234/V2 ---
         db.session.add(ReleaseEvents(job=1234, release="V2", action="update_stage",
                                      payload={"from": "Released", "to": "Welded QC"},
-                                     payload_hash="h-rel-may-1", source="Brain",
+                                     payload_hash="h-rel-stage", source="Brain",
                                      created_at=datetime(2026, 5, 15, 12, 0)))
-        # A field-level 'updated' event: new_value should surface the field name.
         db.session.add(ReleaseEvents(job=1234, release="V2", action="updated",
                                      payload={"field": "job_comp", "old_value": None, "new_value": "X"},
-                                     payload_hash="h-rel-may-field", source="Brain",
+                                     payload_hash="h-rel-jobcomp", source="Brain",
                                      created_at=datetime(2026, 5, 17, 12, 0)))
-        db.session.add(ReleaseEvents(job=5678, release="A", action="update_fab_order",
+        # Excluded release events (fab order, start install, due date).
+        db.session.add(ReleaseEvents(job=1234, release="V2", action="update_fab_order",
                                      payload={"from": 5.0, "to": 7.0},
-                                     payload_hash="h-rel-may-2", source="Brain",
+                                     payload_hash="h-rel-fab", source="Brain",
                                      created_at=datetime(2026, 5, 16, 12, 0)))
-        db.session.add(SubmittalEvents(submittal_id="S-1", action="updated",
-                                       payload={"status": {"old": "Open", "new": "Approved"}},
-                                       payload_hash="h-sub-may-1", source="Procore",
+        db.session.add(ReleaseEvents(job=1234, release="V2", action="updated",
+                                     payload={"field": "start_install", "old_value": None, "new_value": "2026-06-01"},
+                                     payload_hash="h-rel-si", source="Brain",
+                                     created_at=datetime(2026, 5, 18, 12, 0)))
+        db.session.add(ReleaseEvents(job=1234, release="V2", action="update_due_date",
+                                     payload={"from": None, "to": "2026-06-10"},
+                                     payload_hash="h-rel-due", source="Trello",
+                                     created_at=datetime(2026, 5, 19, 12, 0)))
+
+        # --- May 2026 submittal events for DRR S-1 ---
+        db.session.add(SubmittalEvents(submittal_id="S-1", action="created",
+                                       payload={"title": "Glazing schedule", "status": "Draft"},
+                                       payload_hash="h-sub-create", source="Procore",
                                        created_at=datetime(2026, 5, 10, 12, 0)))
-        # A system-echo event in May — must be excluded.
         db.session.add(SubmittalEvents(submittal_id="S-1", action="updated",
-                                       payload={"status": {"old": "Approved", "new": "Open"}},
-                                       payload_hash="h-sub-may-echo", source="Brain",
+                                       payload={"status": {"old": "Draft", "new": "Open"}},
+                                       payload_hash="h-sub-open", source="Procore",
+                                       created_at=datetime(2026, 5, 12, 12, 0)))
+        db.session.add(SubmittalEvents(submittal_id="S-1", action="updated",
+                                       payload={"status": {"old": "Open", "new": "Closed"}},
+                                       payload_hash="h-sub-close", source="Procore",
+                                       created_at=datetime(2026, 5, 14, 12, 0)))
+        # Ball-in-court-only update — must be excluded.
+        db.session.add(SubmittalEvents(submittal_id="S-1", action="updated",
+                                       payload={"ball_in_court": {"old": "Jane", "new": "Bob"}},
+                                       payload_hash="h-sub-bic", source="Procore",
+                                       created_at=datetime(2026, 5, 13, 12, 0)))
+        # Status change to a non-open/close value — must be excluded.
+        db.session.add(SubmittalEvents(submittal_id="S-1", action="updated",
+                                       payload={"status": {"old": "Closed", "new": "Approved"}},
+                                       payload_hash="h-sub-appr", source="Procore",
+                                       created_at=datetime(2026, 5, 15, 12, 0)))
+        # System-echo open event — excluded by the echo filter.
+        db.session.add(SubmittalEvents(submittal_id="S-1", action="updated",
+                                       payload={"status": {"old": "Draft", "new": "Open"}},
+                                       payload_hash="h-sub-echo", source="Brain",
                                        is_system_echo=True,
                                        created_at=datetime(2026, 5, 11, 12, 0)))
+        # Non-DRR submittal event — excluded because S-3 is not a DRR.
+        db.session.add(SubmittalEvents(submittal_id="S-3", action="created",
+                                       payload={"title": "GC approval pkg", "status": "Open"},
+                                       payload_hash="h-sub-nondrr", source="Procore",
+                                       created_at=datetime(2026, 5, 9, 12, 0)))
 
-        # April 2026 event (out of range) — its project should not appear.
-        db.session.add(SubmittalEvents(submittal_id="S-2", action="created",
-                                       payload={"title": "Anchor bolts"},
-                                       payload_hash="h-sub-apr-1", source="Procore",
+        # --- May 2026: project 5678's only event is excluded (fab order) ---
+        db.session.add(ReleaseEvents(job=5678, release="A", action="update_fab_order",
+                                     payload={"from": 5.0, "to": 7.0},
+                                     payload_hash="h-5678-fab", source="Brain",
+                                     created_at=datetime(2026, 5, 16, 12, 0)))
+
+        # --- April 2026 (out of range) ---
+        db.session.add(SubmittalEvents(submittal_id="S-1", action="created",
+                                       payload={"title": "Glazing schedule"},
+                                       payload_hash="h-sub-apr", source="Procore",
                                        created_at=datetime(2026, 4, 20, 12, 0)))
         db.session.commit()
     return app
 
+
+# --------------------------------------------------------------------------- #
+# Auth
+# --------------------------------------------------------------------------- #
 
 def test_requires_auth(client):
     resp = client.get(REPORT_URL)
@@ -110,73 +163,86 @@ def test_allowed_for_khearn(seeded):
     assert resp.status_code == 200
 
 
-def test_report_groups_and_filters_by_month(seeded):
+# --------------------------------------------------------------------------- #
+# Filtering behavior
+# --------------------------------------------------------------------------- #
+
+def _get_report(seeded, url=REPORT_URL):
     with patch("app.auth.utils.get_current_user",
                return_value=_mock_user(is_admin=True)):
-        resp = seeded.test_client().get(REPORT_URL)
-    data = resp.get_json()
+        resp = seeded.test_client().get(url)
+    return resp
 
+
+def test_month_metadata(seeded):
+    data = _get_report(seeded).get_json()
     assert data["year"] == 2026
     assert data["month"] == 5
     assert data["month_label"] == "May 2026"
 
-    projects = {p["project_number"]: p for p in data["projects"]}
-    # Project 5678 only had an April submittal event + a May release event;
-    # it appears because of the release event, but its submittal must be absent.
-    assert set(projects) == {"1234", "5678"}
 
-    # Canonical name preferred from Projects table.
-    assert projects["1234"]["project_name"] == "Downtown Mall"
-    # Fallback name when no Projects row.
-    assert projects["5678"]["project_name"] == "Airport Hangar"
+def test_project_pruned_when_all_events_excluded(seeded):
+    """5678's only May event is a fab-order change, so the project drops out."""
+    data = _get_report(seeded).get_json()
+    projects = {p["project_number"] for p in data["projects"]}
+    assert projects == {"1234"}
 
-    # Project 1234: one release with two changes, one submittal with one change
-    # (system-echo excluded).
-    p1234 = projects["1234"]
+
+def test_releases_drop_fab_install_due_events(seeded):
+    data = _get_report(seeded).get_json()
+    p1234 = next(p for p in data["projects"] if p["project_number"] == "1234")
     assert len(p1234["releases"]) == 1
     rel = p1234["releases"][0]
-    assert rel["release"] == "V2"
+    # Only the stage change and the job_comp update survive.
     assert rel["total_changes"] == 2
-    # Release summary fields surfaced for the one-line row.
-    assert rel["pm"] == "JD"
-    assert rel["stage"] == "Complete"
-    assert rel["install_prog"] == "X"
-    assert rel["invoiced"] == "X"
-    # Field-level 'updated' event names the changed field.
     new_values = [ev["new_value"] for ev in rel["events"]]
     assert "Welded QC" in new_values
     assert "job_comp → X" in new_values
-    # Most recent change first: job_comp (May 17) precedes the stage change (May 15).
-    assert rel["events"][0]["new_value"] == "job_comp → X"
-    assert rel["events"][-1]["new_value"] == "Welded QC"
+    actions = {ev["action"] for ev in rel["events"]}
+    assert "update_fab_order" not in actions
+    assert "update_due_date" not in actions
+    # The start_install field-level update is gone too.
+    assert all("start_install" not in (ev["new_value"] or "") for ev in rel["events"])
+    # Release summary fields still surface for the one-line row.
+    assert rel["stage"] == "Complete"
+    assert rel["install_prog"] == "X"
+    assert rel["invoiced"] == "X"
 
-    assert len(p1234["submittals"]) == 1
+
+def test_submittals_drr_only_with_lifecycle_events(seeded):
+    data = _get_report(seeded).get_json()
+    p1234 = next(p for p in data["projects"] if p["project_number"] == "1234")
+    # Non-DRR S-3 is excluded; only DRR S-1 remains.
+    assert [s["submittal_id"] for s in p1234["submittals"]] == ["S-1"]
+
     sub = p1234["submittals"][0]
-    assert sub["submittal_id"] == "S-1"
-    assert sub["total_changes"] == 1
-    # Submittal summary fields surfaced for the one-line row.
-    assert sub["status"] == "Approved"
-    assert sub["ball_in_court"] == "Jane Smith"
+    # create + open + close survive; BIC-only and Approved updates are dropped.
+    assert sub["total_changes"] == 3
+    kinds = [ev["kind"] for ev in sub["events"]]
+    # Events are newest-first: close (May 14), open (May 12), create (May 10).
+    assert kinds == ["close", "open", "create"]
+
+
+def test_submittal_items_omit_ball_in_court(seeded):
+    data = _get_report(seeded).get_json()
+    p1234 = next(p for p in data["projects"] if p["project_number"] == "1234")
+    sub = p1234["submittals"][0]
+    assert "ball_in_court" not in sub
+    # Other summary fields remain.
+    assert sub["status"] == "Closed"
     assert sub["submittal_manager"] == "Bob Jones"
 
-    # Project 5678: release event present, submittal S-2 (April) excluded.
-    p5678 = projects["5678"]
-    assert len(p5678["releases"]) == 1
-    assert p5678["submittals"] == []
 
+# --------------------------------------------------------------------------- #
+# Edge cases
+# --------------------------------------------------------------------------- #
 
 def test_empty_month_returns_no_projects(seeded):
-    with patch("app.auth.utils.get_current_user",
-               return_value=_mock_user(is_admin=True)):
-        resp = seeded.test_client().get("/api/reports/monthly-invoicing?year=2026&month=1")
-    data = resp.get_json()
-    assert resp.status_code == 200
+    data = _get_report(seeded, "/api/reports/monthly-invoicing?year=2026&month=1").get_json()
     assert data["projects"] == []
     assert data["total_projects"] == 0
 
 
 def test_invalid_month_rejected(seeded):
-    with patch("app.auth.utils.get_current_user",
-               return_value=_mock_user(is_admin=True)):
-        resp = seeded.test_client().get("/api/reports/monthly-invoicing?year=2026&month=13")
+    resp = _get_report(seeded, "/api/reports/monthly-invoicing?year=2026&month=13")
     assert resp.status_code == 400


### PR DESCRIPTION
Addresses Katie Hearn's feedback on the invoicing tab (email 2026-06-04, "Invoicing report").

## Changes

**Submittals**
- Limited to **DRR** (`Drafting Release Review`) type only.
- **Ball-in-court (BIC)** removed from the report.
- Status updates restricted to the **create / open / close** lifecycle (BIC-only, order-bump, and other status changes are filtered out).

**Releases**
- Dropped **fab-order**, **start-install-date**, and **due-date** events. Stage changes, install progress (`job_comp`), invoiced, name/description, and list moves remain.

**Visual redesign**
- Header reads `Invoicing — {month}` with a summary bar (Projects / DRR / Releases totals).
- DRR submittals render as a **Created / Opened / Closed timeline table**.
- Release events shown as expandable rows with colored badges.
- **Export CSV** button (new `frontend/src/utils/csv.js` helper).

All filtering is server-side so counts, pruning, and export stay consistent.

## Testing
- `pytest tests/test_invoicing_report.py tests/brain/` → **113 passed**
- ESLint clean on changed files; `npm run build` succeeds.

## Notes
- Closed-status matched case-insensitively (`clos*`); worth confirming against live Procore data.
- Layout is a first cut — expect one iteration after Katie reacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)