### PR TITLE
Run meeting checklist extraction in the background; org-gate owner ma…

### DIFF
--- a/app/brain/meetings/extract.py
+++ b/app/brain/meetings/extract.py
@@ -68,8 +68,12 @@ def _system_prompt(today: date, people=None) -> str:
     roster = ""
     if people:
         roster = (
-            "\nKnown team members — use these EXACT first names for owner_name when the "
-            "responsible person is one of them: " + ", ".join(sorted(set(people))) + ".\n"
+            "\nKnown team members (the ONLY valid owners) — set owner_name to one of these "
+            "EXACT first names, and only when that person is clearly the one responsible: "
+            + ", ".join(sorted(set(people))) + ".\n"
+            "If the responsible person is not on this list, or you can't tell who it is, set "
+            "owner_name to null. NEVER invent an owner or name someone who isn't listed — a "
+            "wrong or out-of-org owner is worse than leaving it unassigned.\n"
         )
     return (
         "You are an operations assistant for Mile High Metal Works, a structural-steel "
@@ -87,7 +91,9 @@ def _system_prompt(today: date, people=None) -> str:
         "- Split compound asks into separate one-action items.\n"
         "- Write specific, verb-first titles (e.g. 'Send RFI 12 response to Turner for "
         "480-146'), not vague summaries ('discuss RFI').\n"
-        "- owner_name = the FIRST NAME of whoever is responsible, if identifiable.\n"
+        "- owner_name = the first name of whoever is responsible, but ONLY if they are a "
+        "real team member (see the roster above); if not, or if unsure, use null — never "
+        "guess or use a name that isn't a known team member.\n"
         "- due_date = resolve relative dates (today, Thursday, EOW, 'by the 15th') to an "
         "absolute YYYY-MM-DD from today's date.\n"
         "- gc_facing = true when it involves a GC, owner, architect, or other external party.\n"

--- a/app/brain/meetings/owner_match.py
+++ b/app/brain/meetings/owner_match.py
@@ -47,8 +47,18 @@ def _norm_initials(code):
 
 
 def resolve_name_to_user(name):
-    """Resolve a full name (any order, with commas/apostrophes) to an active User id.
-    Returns user.id, or None if there's no unambiguous internal match."""
+    """Resolve a name (any order, with commas/apostrophes) to an ACTIVE User id.
+
+    THE ORG GATE: this only ever returns the id of a current active employee, or None.
+    A name that isn't a real team member, a garbled transcript token, or an ambiguous
+    match (two people share the name) yields None — we infer when we can but never assign
+    an owner who isn't in the org. All owner resolution (extracted names + inferred
+    release PM / submittal ball-in-court) funnels through here so the gate is uniform.
+
+    Tries progressively looser-but-still-unique matches: first+last → unique first name →
+    unique last name. Uniqueness is required at every step so we never guess between two
+    real users.
+    """
     if not name:
         return None
     toks = {t.lower() for t in re.split(r"[\s,]+", str(name)) if t}
@@ -61,9 +71,15 @@ def resolve_name_to_user(name):
             and u.first_name.lower() in toks and u.last_name.lower() in toks]
     if len(full) == 1:
         return full[0].id
-    # Fall back to a UNIQUE first-name match (skip if ambiguous).
+    # Then a UNIQUE first-name match (ambiguous → give up rather than guess).
     first = [u for u in users if u.first_name and u.first_name.lower() in toks]
-    return first[0].id if len(first) == 1 else None
+    if len(first) == 1:
+        return first[0].id
+    if len(first) > 1:
+        return None
+    # Last resort: a UNIQUE last-name match (e.g. transcript says only "Servold").
+    last = [u for u in users if u.last_name and u.last_name.lower() in toks]
+    return last[0].id if len(last) == 1 else None
 
 
 def resolve_pm_initials(code):

--- a/app/brain/meetings/routes.py
+++ b/app/brain/meetings/routes.py
@@ -140,15 +140,39 @@ def add_manual_meeting():
 @admin_required
 def generate_checklist(meeting_id):
     """On-demand: mine the meeting's transcript into a proposed checklist (the
-    'Generate to-do list' button). Returns the meeting with its items."""
+    'Generate to-do list' button).
+
+    The extraction makes multi-minute LLM calls, so it runs in a background thread and
+    this returns 202 immediately with extract_status='extracting'; the UI polls
+    GET /meetings/<id> until it leaves that state. Running it inline used to exceed
+    gunicorn's worker timeout and 500 with no logs."""
+    from flask import current_app
+
     m = db.session.get(Meeting, meeting_id)
     if not m:
         return jsonify({'error': 'not found'}), 404
     if not (m.transcript or '').strip():
         return jsonify({'error': 'no transcript to generate from yet'}), 400
+
+    # Idempotent: if a run is already in flight (and not stale), report it rather than
+    # launching a duplicate.
+    in_flight = (
+        m.extract_status == 'extracting' and m.extract_started_at
+        and datetime.utcnow() - m.extract_started_at < service.EXTRACT_STALE_AFTER
+    )
+    if in_flight:
+        return jsonify(m.to_dict(include_items=True)), 202
+
     data = request.get_json(silent=True) or {}
-    service.extract_into_meeting(m, regenerate=bool(data.get('regenerate')))
-    return jsonify(m.to_dict(include_items=True))
+    m.extract_status = 'extracting'
+    m.extract_error = None
+    m.extract_started_at = datetime.utcnow()
+    db.session.commit()
+    service.start_extraction(
+        current_app._get_current_object(), m.id,
+        regenerate=bool(data.get('regenerate')),
+    )
+    return jsonify(m.to_dict(include_items=True)), 202
 
 
 @brain_bp.route('/meetings/<int:meeting_id>', methods=['GET'])

--- a/app/brain/meetings/service.py
+++ b/app/brain/meetings/service.py
@@ -5,6 +5,7 @@ feature-command split without the event/outbox machinery — checklist items are
 release-scoped and have no async external push.
 """
 import re
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta
 
 from app.config import Config as cfg
@@ -21,6 +22,50 @@ NOTIFY_DEDUP_HOURS = 20    # don't re-ping the same item within this window
 _EDITABLE = ("title", "detail", "item_type", "gc_facing", "owner_user_id",
              "due_date", "release_id", "submittal_id")
 
+# The web dyno runs no APScheduler (that's the IS_RENDER_SCHEDULER process), so the
+# multi-minute extraction can't block the request — gunicorn's worker timeout would
+# SIGKILL the worker mid-call and the request 500s with no logs. Offload to an
+# in-process pool, mirroring how Trello sync hands work to a ThreadPoolExecutor.
+_EXTRACT_POOL = ThreadPoolExecutor(max_workers=4, thread_name_prefix="meeting-extract")
+# A run whose started_at is older than this is presumed dead (worker recycled mid-run)
+# and may be relaunched; until then a repeat Generate click is a no-op.
+EXTRACT_STALE_AFTER = timedelta(minutes=10)
+
+
+def start_extraction(app, meeting_id, *, regenerate=False):
+    """Queue background checklist extraction for a meeting. The caller must have already
+    flipped extract_status to 'extracting' and committed; this only runs the work
+    off-thread and returns immediately."""
+    _EXTRACT_POOL.submit(_run_extraction_job, app, meeting_id, regenerate)
+
+
+def _run_extraction_job(app, meeting_id, regenerate):
+    """Background body of an extraction: mine the transcript, then stamp the meeting
+    done/failed. Always logs and never lets the worker thread die silently — this is the
+    error path that was invisible when extraction ran (and timed out) inside the request."""
+    with app.app_context():
+        try:
+            meeting = db.session.get(Meeting, meeting_id)
+            if not meeting:
+                logger.warning("extract_job_meeting_missing", meeting_id=meeting_id)
+                return
+            extract_into_meeting(meeting, regenerate=regenerate)
+            meeting.extract_status = "done"
+            meeting.extract_error = None
+            db.session.commit()
+            logger.info("extract_job_done", meeting_id=meeting_id)
+        except Exception as e:  # noqa: BLE001 — record + log, never crash the worker
+            logger.error("extract_job_failed", meeting_id=meeting_id,
+                         error=str(e), exc_info=True)
+            db.session.rollback()
+            failed = db.session.get(Meeting, meeting_id)
+            if failed:
+                failed.extract_status = "failed"
+                failed.extract_error = str(e)[:1000]
+                db.session.commit()
+        finally:
+            db.session.remove()
+
 
 def get_reviewer():
     """The user who reviews post-meeting checklists (MVP: Bill, by config)."""
@@ -28,13 +73,15 @@ def get_reviewer():
 
 
 def _resolve_owner_id(owner_name):
-    if not owner_name:
-        return None
-    u = User.query.filter(
-        db.func.lower(User.first_name) == str(owner_name).strip().lower(),
-        User.is_active.is_(True),
-    ).first()
-    return u.id if u else None
+    """Resolve an extracted owner_name to an ACTIVE user id, or None.
+
+    Org gate: a name that isn't a current employee (out-of-org, a garbled transcript
+    token like 'RO/Ror', or ambiguous) yields None — the to-do is left unassigned for the
+    reviewer rather than guessed. Delegates to the same resolver the job-inference layer
+    uses (owner_match.resolve_name_to_user), so first / last / full-name handling and the
+    org gate stay consistent across both owner sources."""
+    from app.brain.meetings.owner_match import resolve_name_to_user
+    return resolve_name_to_user(owner_name)
 
 
 def _parse_due(value):

--- a/app/models.py
+++ b/app/models.py
@@ -956,6 +956,13 @@ class Meeting(db.Model):
     extract_input_tokens = db.Column(db.Integer, nullable=True)
     extract_output_tokens = db.Column(db.Integer, nullable=True)
     extract_cost_usd = db.Column(db.Float, nullable=True)
+    # On-demand checklist extraction runs in a background thread (the web dyno has no
+    # APScheduler — that's the IS_RENDER_SCHEDULER process), because the LLM calls take
+    # minutes and would blow past gunicorn's worker timeout if held in the request. The
+    # UI polls these instead of waiting on the request. idle|extracting|done|failed.
+    extract_status = db.Column(db.String(20), nullable=True, default='idle')
+    extract_error = db.Column(db.Text, nullable=True)
+    extract_started_at = db.Column(db.DateTime, nullable=True)
     created_by = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
     extracted_at = db.Column(db.DateTime, nullable=True)  # when checklist items were generated
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
@@ -983,6 +990,8 @@ class Meeting(db.Model):
             'extract_input_tokens': self.extract_input_tokens,
             'extract_output_tokens': self.extract_output_tokens,
             'extract_cost_usd': self.extract_cost_usd,
+            'extract_status': self.extract_status,
+            'extract_error': self.extract_error,
         }
         if include_items:
             items = self.items.order_by(ChecklistItem.id).all()

--- a/frontend/src/pages/Meetings.jsx
+++ b/frontend/src/pages/Meetings.jsx
@@ -153,17 +153,40 @@ export default function Meetings() {
 
     const handleGenerate = async () => {
         if (!selected) return;
+        // Regenerate (clear + rebuild) when the meeting already has items.
+        const regenerate = (selected.items || []).length > 0;
         setGenerating(true); setError(null);
         try {
-            const updated = await generateChecklist(selected.id);
-            setSelected(updated); seedDrafts(updated);
-            setMeetings(prev => prev.map(m => (m.id === updated.id ? { ...m, item_count: updated.item_count } : m)));
+            // Returns 202 with extract_status='extracting'; the poller below takes over
+            // until extraction finishes — the LLM calls run in the background.
+            const updated = await generateChecklist(selected.id, { regenerate });
+            setSelected(updated);
         } catch (err) {
             setError(err?.response?.data?.error || 'Failed to generate to-do list');
-        } finally {
             setGenerating(false);
         }
     };
+
+    // Checklist extraction runs in the background; poll the open meeting until it leaves
+    // 'extracting', then show the items (or surface the failure).
+    useEffect(() => {
+        if (selected?.extract_status !== 'extracting') return;
+        const id = selected.id;
+        let cancelled = false;
+        const tick = async () => {
+            try {
+                const m = await fetchMeeting(id);
+                if (cancelled || m.id !== id || m.extract_status === 'extracting') return;
+                setSelected(m); seedDrafts(m); setGenerating(false);
+                setMeetings(prev => prev.map(x => (x.id === m.id ? { ...x, item_count: m.item_count } : x)));
+                if (m.extract_status === 'failed') {
+                    setError(m.extract_error || 'Failed to generate to-do list');
+                }
+            } catch { /* transient — keep polling */ }
+        };
+        const h = setInterval(tick, 2500);
+        return () => { cancelled = true; clearInterval(h); };
+    }, [selected?.extract_status, selected?.id]);
 
     const handleCreateManual = async (e) => {
         e.preventDefault();
@@ -248,6 +271,9 @@ export default function Meetings() {
     const transcriptText = selected?.transcript ?? '';
     const hasTranscript = !!transcriptText.trim();
     const canGenerate = !!transcriptText.trim();
+    // True while a (possibly background) extraction is running — covers both the click
+    // we just made and a meeting opened while its run is already in flight.
+    const isGenerating = generating || selected?.extract_status === 'extracting';
 
     return (
         <div className="flex-1 p-4 md:p-6 max-w-[1400px] mx-auto w-full">
@@ -322,9 +348,9 @@ export default function Meetings() {
                                     )}
                                 </h2>
                                 {items.length > 0 && (
-                                    <button onClick={handleGenerate} disabled={generating || !canGenerate}
+                                    <button onClick={handleGenerate} disabled={isGenerating || !canGenerate}
                                         className="text-[11px] px-2 py-1 rounded-md border border-gray-300 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 disabled:opacity-50">
-                                        {generating ? 'Regenerating…' : 'Regenerate'}
+                                        {isGenerating ? 'Regenerating…' : 'Regenerate'}
                                     </button>
                                 )}
                             </div>
@@ -353,10 +379,14 @@ export default function Meetings() {
                                 <div className="py-10 text-center">
                                     {canGenerate ? (
                                         <>
-                                            <p className="text-sm text-gray-500 dark:text-slate-400 mb-3">No to-dos yet — generate them from the transcript.</p>
-                                            <button onClick={handleGenerate} disabled={generating}
+                                            <p className="text-sm text-gray-500 dark:text-slate-400 mb-3">
+                                                {isGenerating
+                                                    ? 'Generating to-dos from the transcript — this can take a minute…'
+                                                    : 'No to-dos yet — generate them from the transcript.'}
+                                            </p>
+                                            <button onClick={handleGenerate} disabled={isGenerating}
                                                 className="px-4 py-2 text-sm font-medium rounded-lg bg-accent-500 hover:bg-accent-600 text-white disabled:opacity-50">
-                                                {generating ? 'Generating…' : 'Generate to-do list'}
+                                                {isGenerating ? 'Generating…' : 'Generate to-do list'}
                                             </button>
                                         </>
                                     ) : (

--- a/migrations/add_extract_status_to_meetings.py
+++ b/migrations/add_extract_status_to_meetings.py
@@ -1,0 +1,91 @@
+"""
+Add background-extraction tracking columns to the `meetings` table:
+  - extract_status      (VARCHAR)   idle|extracting|done|failed (default 'idle')
+  - extract_error       (TEXT)      last failure message, if extraction failed
+  - extract_started_at  (TIMESTAMP) when the current/last extraction run began
+
+These back the on-demand "Generate to-do list" flow, which now runs the (multi-minute)
+LLM extraction in a background thread and returns 202 — the UI polls extract_status
+instead of holding the request open past gunicorn's worker timeout.
+
+Usage:
+    python migrations/add_extract_status_to_meetings.py                  # local (default)
+    ENVIRONMENT=sandbox python migrations/add_extract_status_to_meetings.py
+    ENVIRONMENT=production python migrations/add_extract_status_to_meetings.py
+
+Target DB is chosen by the app's config (ENVIRONMENT → local sqlite /
+SANDBOX_DATABASE_URL / PRODUCTION_DATABASE_URL). Idempotent — inspects before altering.
+"""
+
+import argparse
+import os
+import sys
+
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT_DIR)
+
+# column name -> (postgres type, sqlite type)
+NEW_COLUMNS = {
+    "extract_status": ("VARCHAR(20) DEFAULT 'idle'", "VARCHAR(20) DEFAULT 'idle'"),
+    "extract_error": ("TEXT", "TEXT"),
+    "extract_started_at": ("TIMESTAMP", "TIMESTAMP"),
+}
+
+
+def column_exists(engine, table_name: str, column_name: str) -> bool:
+    return any(c["name"] == column_name for c in inspect(engine).get_columns(table_name))
+
+
+def migrate(database_url: str = None) -> bool:
+    from app import create_app
+    from app.models import db
+
+    app = create_app()
+    with app.app_context():
+        try:
+            engine = db.engine
+            is_postgres = engine.dialect.name == "postgresql"
+            added = []
+            for col, (pg_type, sqlite_type) in NEW_COLUMNS.items():
+                if column_exists(engine, "meetings", col):
+                    print(f"✓ Column '{col}' already exists on 'meetings'.")
+                    continue
+                col_type = pg_type if is_postgres else sqlite_type
+                print(f"Adding column '{col}' ({col_type}) to 'meetings'...")
+                with db.engine.begin() as conn:
+                    conn.execute(text(f"ALTER TABLE meetings ADD COLUMN {col} {col_type}"))
+                if not column_exists(engine, "meetings", col):
+                    print(f"✗ Column '{col}' addition did not succeed. Please verify manually.")
+                    return False
+                added.append(col)
+
+            print(f"✓ Migration completed. Added: {', '.join(added) if added else 'nothing (already current)'}.")
+            return True
+
+        except (OperationalError, ProgrammingError) as exc:
+            print(f"✗ Database error: {exc}")
+            db.session.rollback()
+            return False
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"✗ Unexpected error: {exc}")
+            db.session.rollback()
+            import traceback
+            traceback.print_exc()
+            return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Add background-extraction tracking columns to the meetings table."
+    )
+    parser.add_argument(
+        "--database-url",
+        help="Override database URL (otherwise selected by the app via ENVIRONMENT).",
+    )
+    args = parser.parse_args()
+
+    success = migrate(args.database_url)
+    sys.exit(0 if success else 1)

--- a/tests/brain/test_meetings.py
+++ b/tests/brain/test_meetings.py
@@ -189,3 +189,107 @@ def test_create_meeting_endpoint_requires_transcript(app, client):
     with patch("app.auth.utils.get_current_user", return_value=admin):
         resp = client.post("/brain/meetings", json={"title": "x"})
     assert resp.status_code == 400
+
+
+def test_generate_checklist_is_async_returns_202(app, client):
+    """The button kicks off background extraction: 202 + extracting, no inline LLM call
+    (running it inline would exceed gunicorn's worker timeout — the production 500)."""
+    admin = make_user(REVIEWER, first_name="Bill", is_admin=True)
+    with app.app_context():
+        m = Meeting(title="Shop", meeting_type="internal_shop",
+                    source="manual", transcript="Luis: refab the treads by Thursday")
+        db.session.add(m)
+        db.session.commit()
+        mid = m.id
+
+    with patch("app.auth.utils.get_current_user", return_value=admin), \
+         patch("app.brain.meetings.service.start_extraction") as mock_start:
+        resp = client.post(f"/brain/meetings/{mid}/generate-checklist", json={})
+
+    assert resp.status_code == 202
+    assert resp.get_json()["extract_status"] == "extracting"
+    mock_start.assert_called_once()
+
+    # A second click while a (fresh) run is in flight is a no-op, not a duplicate launch.
+    with patch("app.auth.utils.get_current_user", return_value=admin), \
+         patch("app.brain.meetings.service.start_extraction") as mock_again:
+        resp2 = client.post(f"/brain/meetings/{mid}/generate-checklist", json={})
+    assert resp2.status_code == 202
+    mock_again.assert_not_called()
+
+
+def test_run_extraction_job_marks_done_and_creates_items(app):
+    """The background job mines the transcript and stamps the meeting done."""
+    make_user(REVIEWER, first_name="Bill", is_admin=True)
+    with app.app_context():
+        m = Meeting(title="Shop", source="manual", extract_status="extracting",
+                    transcript="(stub)")
+        db.session.add(m)
+        db.session.commit()
+        mid = m.id
+
+    with patch("app.brain.meetings.service.extract",
+               return_value=_extract_ret([_items(title="refab treads")])):
+        service._run_extraction_job(app, mid, False)
+
+    with app.app_context():
+        done = db.session.get(Meeting, mid)
+        assert done.extract_status == "done" and done.extract_error is None
+        assert ChecklistItem.query.filter_by(meeting_id=mid).count() == 1
+
+
+def test_owner_name_out_of_org_stays_unassigned(app):
+    """A name that isn't an active employee (e.g. a garbled transcript token) must NOT be
+    matched to anyone — the to-do is left unassigned for the reviewer."""
+    make_user("dservold@mhmw.com", first_name="David", last_name="Servold", is_admin=True)
+    proposed = [
+        _items(title="real person task", owner_name="David"),     # in-org → matches
+        _items(title="ghost task", owner_name="Holden"),          # not an employee → null
+        _items(title="garbled token", owner_name="Ror"),          # garbage → null
+    ]
+    with patch("app.brain.meetings.service.extract", return_value=_extract_ret(proposed)):
+        meeting = service.create_meeting_with_extraction(
+            title="m", meeting_type="internal_shop", transcript="x",
+        )
+    items = meeting.items.order_by(ChecklistItem.id).all()
+    assert items[0].proposed_owner_user_id is not None   # David resolved
+    assert items[1].proposed_owner_user_id is None        # Holden dropped
+    assert items[2].proposed_owner_user_id is None        # Ror dropped
+
+
+def test_resolve_name_to_user_gate_and_inference(app):
+    from app.brain.meetings.owner_match import resolve_name_to_user
+    david = make_user("dservold@mhmw.com", first_name="David", last_name="Servold")
+    make_user("dcortez@mhmw.com", first_name="David", last_name="Cortez")  # dup first name
+
+    assert resolve_name_to_user("Holden") is None          # not in org
+    assert resolve_name_to_user("Ror") is None             # garbled token
+    assert resolve_name_to_user("") is None
+    assert resolve_name_to_user("David Servold") == david.id   # first+last
+    assert resolve_name_to_user("Servold") == david.id          # unique last name
+    assert resolve_name_to_user("David") is None                # ambiguous first name → no guess
+
+
+def test_inactive_user_is_not_matched(app):
+    from app.brain.meetings.owner_match import resolve_name_to_user
+    make_user("gone@mhmw.com", first_name="Gone", last_name="Away", is_active=False)
+    assert resolve_name_to_user("Gone") is None
+    assert resolve_name_to_user("Gone Away") is None
+
+
+def test_run_extraction_job_records_failure(app):
+    """A failing extraction is caught, logged, and recorded — never a silent crash."""
+    with app.app_context():
+        m = Meeting(title="Shop", source="manual", extract_status="extracting",
+                    transcript="(stub)")
+        db.session.add(m)
+        db.session.commit()
+        mid = m.id
+
+    with patch("app.brain.meetings.service.extract", side_effect=RuntimeError("boom")):
+        service._run_extraction_job(app, mid, False)
+
+    with app.app_context():
+        failed = db.session.get(Meeting, mid)
+        assert failed.extract_status == "failed"
+        assert "boom" in (failed.extract_error or "")


### PR DESCRIPTION
…tching

The "Generate to-do list" button (POST /meetings/<id>/generate-checklist) ran extraction synchronously inside the web request — an Opus call plus a Haiku owner-match call. On Render those exceed gunicorn's default 30s worker timeout, so the worker is SIGKILLed mid-call: the request 500s with no app logs (the kill beats both the structlog lines and extract.py's stub-fallback except). It only failed in prod; the dev server has no worker timeout.

Fix: the route now marks meetings.extract_status='extracting', returns 202, and runs extract_into_meeting in an in-process ThreadPoolExecutor (the web dyno has no APScheduler — that's the IS_RENDER_SCHEDULER process). The job always logs and records done/failed + extract_error, so failures are never silent again. The frontend fires the request then polls GET /meetings/<id> until extract_status leaves 'extracting'. New Meeting columns extract_status/extract_error/ extract_started_at via migrations/add_extract_status_to_meetings.py.

Also harden owner matching to never assign an out-of-org owner:
- extract.py prompt: roster is "the ONLY valid owners"; owner_name=null otherwise, never invent a name.
- service._resolve_owner_id now delegates to owner_match.resolve_name_to_user so the org gate + first/last/full-name handling is uniform across both owner sources.
- resolve_name_to_user gains a unique last-name fallback and only ever returns an active User.id or None (out-of-org names, garbled tokens, ambiguous matches → none).

Tests: 16/16 in tests/brain/test_meetings.py (async 202, background job done/failed, out-of-org owner stays unassigned, resolver gate + inference).