### PR TITLE
Enable DRR release-number (Rel) assignment on submittal creation

### DIFF
--- a/app/procore/procore.py
+++ b/app/procore/procore.py
@@ -607,11 +607,12 @@ def create_submittal_from_webhook(project_id, submittal_id, webhook_payload=None
             last_updated=datetime.utcnow()
         )
         
-        # Rel (release) number assignment is currently DISABLED. The Rel column is
-        # displayed empty in the Drafting Work Load tab and no numbers are handed out.
-        # The assignment helpers (next_rel_number / assign_rel_if_drr) are kept intact
-        # for when this is re-enabled; re-instate the call below to turn it back on.
-        # assign_rel_if_drr(new_submittal)
+        # Assign a Rel (release) number when this submittal is created as a DRR.
+        # Procore never mutates a submittal's type in place: a stage transition closes
+        # the old submittal and creates a revision of the new type, so a DRR always
+        # arrives as a fresh creation event. Assigning here (before commit) is therefore
+        # the complete and correct hook. No-op for non-DRR types or if already assigned.
+        assign_rel_if_drr(new_submittal)
 
         db.session.add(new_submittal)
         logger.info(f"Added submittal to session, committing to database...")

--- a/app/procore/procore.py
+++ b/app/procore/procore.py
@@ -53,13 +53,65 @@ REL_MIN = 100
 REL_MAX = 999
 
 
-def next_rel_number():
-    """Return the next Rel number to assign to a DRR submittal.
+def _active_release_numbers_for_job(job):
+    """Release numbers held by ACTIVE job-log releases for ``job``.
 
-    Numbers run 100..999 and wrap back to 100. "Next" is derived from the most
-    recently assigned Rel (by rel_assigned_at) so wraparound is handled naturally:
-    if the last assigned value was 999, the next is 100. Returns REL_MIN when no
-    Rel has ever been assigned.
+    The uniqueness that matters is the job-release pair (``Releases.job`` +
+    ``Releases.release``): a Rel handed to a DRR submittal must not collide with
+    an active job-log release on the same job. "Active" means not archived
+    (``is_archived`` is False) and not explicitly deactivated (``is_active`` is
+    not False); a NULL ``is_active`` counts as active, matching the column
+    default, so an ambiguous row still blocks reuse (leak-proof bias).
+
+    ``Releases.job`` is an integer and ``Releases.release`` a string, while the
+    submittal carries ``project_number`` (the same job number, per spec) and an
+    integer Rel. Both sides are coerced to int for the comparison; any value that
+    isn't a clean integer is ignored. Returns the set of taken integers (empty
+    when ``job`` is missing or non-numeric, which simply means no guard applies).
+    """
+    if job is None:
+        return set()
+    try:
+        job_int = int(str(job).strip())
+    except (TypeError, ValueError):
+        return set()
+
+    rows = (
+        db.session.query(Releases.release)
+        .filter(
+            Releases.job == job_int,
+            Releases.is_archived.is_(False),
+            Releases.is_active.isnot(False),
+        )
+        .all()
+    )
+    taken = set()
+    for (value,) in rows:
+        if value is None:
+            continue
+        try:
+            taken.add(int(str(value).strip()))
+        except (TypeError, ValueError):
+            continue
+    return taken
+
+
+def next_rel_number(job=None):
+    """Return the next Rel number to assign to a DRR submittal on ``job``.
+
+    Numbers run 100..999 as a single global sequence and wrap back to 100. "Next"
+    is derived from the most recently assigned Rel (by rel_assigned_at) so
+    wraparound is handled naturally: if the last assigned value was 999, the next
+    is 100. Returns REL_MIN when no Rel has ever been assigned.
+
+    To keep the job-release pair unique, any candidate already held by an ACTIVE
+    job-log release on the same ``job`` is skipped, advancing through the sequence
+    (wrapping) until a free number is found. Archived/inactive releases do not
+    block reuse. When ``job`` is None the collision guard is inert and the plain
+    global sequence is returned (used by callers/tests that don't need it).
+
+    Raises RuntimeError only in the pathological case where every number in
+    [REL_MIN, REL_MAX] is held by an active release for the job.
     """
     last = (
         Submittals.query
@@ -68,19 +120,35 @@ def next_rel_number():
         .first()
     )
     if last is None or last.rel is None:
-        return REL_MIN
-    nxt = last.rel + 1
-    if nxt > REL_MAX:
-        nxt = REL_MIN
-    return nxt
+        start = REL_MIN
+    else:
+        start = last.rel + 1
+        if start > REL_MAX:
+            start = REL_MIN
+
+    taken = _active_release_numbers_for_job(job)
+    candidate = start
+    for _ in range(REL_MAX - REL_MIN + 1):
+        if candidate not in taken:
+            return candidate
+        candidate += 1
+        if candidate > REL_MAX:
+            candidate = REL_MIN
+
+    raise RuntimeError(
+        f"No free Rel number in [{REL_MIN}, {REL_MAX}] for job {job!r}: "
+        f"every value is held by an active job-log release."
+    )
 
 
 def assign_rel_if_drr(record):
     """Assign a Rel number to ``record`` if it is a DRR submittal without one.
 
     Idempotent: does nothing if the submittal is not DRR or already has a Rel.
-    The caller is responsible for committing the surrounding transaction.
-    Returns the assigned Rel number, or None if nothing was assigned.
+    The Rel is checked against active job-log releases for the same job
+    (``record.project_number``) so the job-release pair stays unique. The caller
+    is responsible for committing the surrounding transaction. Returns the
+    assigned Rel number, or None if nothing was assigned.
     """
     if record is None:
         return None
@@ -88,10 +156,11 @@ def assign_rel_if_drr(record):
         return None
     if record.rel is not None:
         return None
-    record.rel = next_rel_number()
+    record.rel = next_rel_number(record.project_number)
     record.rel_assigned_at = datetime.utcnow()
     logger.info(
-        "Assigned Rel %s to DRR submittal %s", record.rel, record.submittal_id
+        "Assigned Rel %s to DRR submittal %s (job %s)",
+        record.rel, record.submittal_id, record.project_number,
     )
     return record.rel
 

--- a/app/procore/procore.py
+++ b/app/procore/procore.py
@@ -42,6 +42,7 @@ from app.procore.helpers import (
 )
 from app.brain.drafting_work_load.service import UrgencyService, SubmittalOrderingService
 from app.brain.drafting_work_load.engine import SubmittalOrderingEngine
+from app.api.helpers import active_releases_filter
 
 
 logger = logging.getLogger(__name__)
@@ -53,15 +54,28 @@ REL_MIN = 100
 REL_MAX = 999
 
 
+def _to_int_or_none(value):
+    """Coerce ``value`` to int, or return None if it isn't a clean integer."""
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _next_in_range(value):
+    """Next value in the REL_MIN..REL_MAX cycle, wrapping REL_MAX -> REL_MIN."""
+    nxt = value + 1
+    return REL_MIN if nxt > REL_MAX else nxt
+
+
 def _active_release_numbers_for_job(job):
     """Release numbers held by ACTIVE job-log releases for ``job``.
 
     The uniqueness that matters is the job-release pair (``Releases.job`` +
     ``Releases.release``): a Rel handed to a DRR submittal must not collide with
-    an active job-log release on the same job. "Active" means not archived
-    (``is_archived`` is False) and not explicitly deactivated (``is_active`` is
-    not False); a NULL ``is_active`` counts as active, matching the column
-    default, so an ambiguous row still blocks reuse (leak-proof bias).
+    an active job-log release on the same job. "Active" reuses the centralized
+    ``active_releases_filter`` (not archived; ``is_active`` True or NULL), so a
+    NULL ``is_active`` still blocks reuse (leak-proof bias).
 
     ``Releases.job`` is an integer and ``Releases.release`` a string, while the
     submittal carries ``project_number`` (the same job number, per spec) and an
@@ -71,28 +85,23 @@ def _active_release_numbers_for_job(job):
     """
     if job is None:
         return set()
-    try:
-        job_int = int(str(job).strip())
-    except (TypeError, ValueError):
+    job_int = _to_int_or_none(job)
+    if job_int is None:
+        logger.warning(
+            "Rel collision guard inert: project_number %r is not a valid job number", job
+        )
         return set()
 
     rows = (
         db.session.query(Releases.release)
-        .filter(
-            Releases.job == job_int,
-            Releases.is_archived.is_(False),
-            Releases.is_active.isnot(False),
-        )
+        .filter(Releases.job == job_int, active_releases_filter())
         .all()
     )
     taken = set()
     for (value,) in rows:
-        if value is None:
-            continue
-        try:
-            taken.add(int(str(value).strip()))
-        except (TypeError, ValueError):
-            continue
+        number = _to_int_or_none(value)
+        if number is not None:
+            taken.add(number)
     return taken
 
 
@@ -119,21 +128,14 @@ def next_rel_number(job=None):
         .order_by(Submittals.rel_assigned_at.desc(), Submittals.id.desc())
         .first()
     )
-    if last is None or last.rel is None:
-        start = REL_MIN
-    else:
-        start = last.rel + 1
-        if start > REL_MAX:
-            start = REL_MIN
+    start = _next_in_range(last.rel) if last and last.rel is not None else REL_MIN
 
     taken = _active_release_numbers_for_job(job)
     candidate = start
     for _ in range(REL_MAX - REL_MIN + 1):
         if candidate not in taken:
             return candidate
-        candidate += 1
-        if candidate > REL_MAX:
-            candidate = REL_MIN
+        candidate = _next_in_range(candidate)
 
     raise RuntimeError(
         f"No free Rel number in [{REL_MIN}, {REL_MAX}] for job {job!r}: "

--- a/tests/procore/test_rel_assignment.py
+++ b/tests/procore/test_rel_assignment.py
@@ -169,25 +169,18 @@ def test_rel_skips_consecutive_taken_numbers(app):
         assert next_rel_number("100") == 103
 
 
-def test_archived_release_does_not_block(app):
+@pytest.mark.parametrize("release_job,kwargs,reason", [
+    (100, {"is_archived": True}, "archived release is reusable"),
+    (100, {"is_active": False}, "inactive release is reusable"),
+    (999, {}, "active release on a different job doesn't block"),
+])
+def test_release_does_not_block_rel(app, release_job, kwargs, reason):
+    # In each case job 100's release 100 is free, so the global sequence's first
+    # candidate (REL_MIN) is handed out unchanged.
     with app.app_context():
-        db.session.add(_make_release(100, 100, is_archived=True))
+        db.session.add(_make_release(release_job, 100, **kwargs))
         db.session.commit()
-        assert next_rel_number("100") == 100  # archived -> number is reusable
-
-
-def test_inactive_release_does_not_block(app):
-    with app.app_context():
-        db.session.add(_make_release(100, 100, is_active=False))
-        db.session.commit()
-        assert next_rel_number("100") == 100
-
-
-def test_release_on_other_job_does_not_block(app):
-    with app.app_context():
-        db.session.add(_make_release(999, 100))  # a different job holds 100
-        db.session.commit()
-        assert next_rel_number("100") == 100  # job 100 is still free
+        assert next_rel_number("100") == 100, reason
 
 
 def test_non_numeric_release_value_is_ignored(app):

--- a/tests/procore/test_rel_assignment.py
+++ b/tests/procore/test_rel_assignment.py
@@ -6,6 +6,7 @@ back to 100 after 999. They are only assigned to submittals whose type is
 "Drafting Release Review" (DRR) and that do not already have a Rel.
 """
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 
@@ -16,6 +17,7 @@ from app.procore.procore import (
     REL_MAX,
     next_rel_number,
     assign_rel_if_drr,
+    create_submittal_from_webhook,
 )
 
 
@@ -92,3 +94,42 @@ def test_sequential_assignment_across_multiple_drr(app):
             db.session.commit()
             assigned.append(s.rel)
         assert assigned == [100, 101, 102]
+
+
+# --- Integration: the create webhook path actually performs the assignment ---------
+# These drive the real create_submittal_from_webhook (DB write included), mocking only
+# the Procore HTTP fetches. They guard against the assignment call being removed or
+# re-disabled, which the helper-only tests above would not catch.
+
+def _patched_create(submittal_id, type_name):
+    """Run create_submittal_from_webhook with Procore fetches stubbed for ``type_name``."""
+    submittal_data = {
+        "type": {"name": type_name},
+        "status": {"name": "Open"},
+        "title": "Some Submittal",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    with patch("app.procore.procore.get_submittal_by_id", return_value=submittal_data), \
+         patch("app.procore.procore.get_project_info",
+               return_value={"name": "Proj", "project_number": "100"}), \
+         patch("app.procore.procore.parse_ball_in_court_from_submittal",
+               return_value={"ball_in_court": None}), \
+         patch("app.procore.procore.parse_and_log_submittal_data", return_value=None):
+        return create_submittal_from_webhook(1, submittal_id)
+
+
+def test_create_webhook_assigns_rel_for_drr(app):
+    with app.app_context():
+        created, record, err = _patched_create("9001", DRR_TYPE)
+        assert created is True
+        assert err is None
+        assert record.rel == REL_MIN
+        assert record.rel_assigned_at is not None
+
+
+def test_create_webhook_skips_rel_for_non_drr(app):
+    with app.app_context():
+        created, record, err = _patched_create("9002", "Submittal for GC Approval")
+        assert created is True
+        assert record.rel is None
+        assert record.rel_assigned_at is None

--- a/tests/procore/test_rel_assignment.py
+++ b/tests/procore/test_rel_assignment.py
@@ -3,14 +3,16 @@ Unit tests for DRR "Rel" number assignment (app/procore/procore.py).
 
 Rel numbers are assigned per DRR submittal, sequentially in [100, 999], wrapping
 back to 100 after 999. They are only assigned to submittals whose type is
-"Drafting Release Review" (DRR) and that do not already have a Rel.
+"Drafting Release Review" (DRR) and that do not already have a Rel. A collision
+guard skips any candidate already held by an ACTIVE job-log release (Releases) on
+the same job so the job-release pair stays unique.
 """
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest
 
-from app.models import db, Submittals
+from app.models import db, Submittals, Releases
 from app.procore.procore import (
     DRR_TYPE,
     REL_MIN,
@@ -19,6 +21,17 @@ from app.procore.procore import (
     assign_rel_if_drr,
     create_submittal_from_webhook,
 )
+
+
+def _make_release(job, release, *, is_active=True, is_archived=False):
+    """Minimal job-log Releases row for collision-guard tests."""
+    return Releases(
+        job=int(job),
+        release=str(release),
+        job_name="Test Job",
+        is_active=is_active,
+        is_archived=is_archived,
+    )
 
 
 def _make_submittal(sid, type_, rel=None, rel_assigned_at=None):
@@ -133,3 +146,79 @@ def test_create_webhook_skips_rel_for_non_drr(app):
         assert created is True
         assert record.rel is None
         assert record.rel_assigned_at is None
+
+
+# --- Job-release collision guard ---------------------------------------------------
+# A Rel must not collide with an ACTIVE job-log release (Releases.job, Releases.release)
+# on the same job. Archived/inactive releases, and releases on other jobs, don't block.
+# Submittals.project_number is the same job number as Releases.job.
+
+def test_rel_skips_number_held_by_active_release_on_same_job(app):
+    with app.app_context():
+        db.session.add(_make_release(100, 100))  # job 100 already holds active release 100
+        db.session.commit()
+        # Global sequence would start at REL_MIN (100); 100 is taken on job 100 -> 101.
+        assert next_rel_number("100") == 101
+
+
+def test_rel_skips_consecutive_taken_numbers(app):
+    with app.app_context():
+        for r in (100, 101, 102):
+            db.session.add(_make_release(100, r))
+        db.session.commit()
+        assert next_rel_number("100") == 103
+
+
+def test_archived_release_does_not_block(app):
+    with app.app_context():
+        db.session.add(_make_release(100, 100, is_archived=True))
+        db.session.commit()
+        assert next_rel_number("100") == 100  # archived -> number is reusable
+
+
+def test_inactive_release_does_not_block(app):
+    with app.app_context():
+        db.session.add(_make_release(100, 100, is_active=False))
+        db.session.commit()
+        assert next_rel_number("100") == 100
+
+
+def test_release_on_other_job_does_not_block(app):
+    with app.app_context():
+        db.session.add(_make_release(999, 100))  # a different job holds 100
+        db.session.commit()
+        assert next_rel_number("100") == 100  # job 100 is still free
+
+
+def test_non_numeric_release_value_is_ignored(app):
+    with app.app_context():
+        db.session.add(_make_release(100, "N/A"))
+        db.session.commit()
+        assert next_rel_number("100") == 100
+
+
+def test_raises_when_every_number_taken_for_job(app):
+    with app.app_context():
+        with patch("app.procore.procore.REL_MIN", 100), \
+             patch("app.procore.procore.REL_MAX", 102):
+            for r in (100, 101, 102):
+                db.session.add(_make_release(100, r))
+            db.session.commit()
+            with pytest.raises(RuntimeError):
+                next_rel_number("100")
+
+
+def test_create_webhook_advances_past_active_job_release(app):
+    with app.app_context():
+        # Job 100 already has active job-log release 100; the global sequence would
+        # otherwise hand 100 to the new DRR. The guard must advance to 101, and the
+        # resulting job-release pair must not collide with an active release.
+        db.session.add(_make_release(100, 100))
+        db.session.commit()
+        created, record, err = _patched_create("9100", DRR_TYPE)
+        assert created is True
+        assert record.rel == 101
+        clash = Releases.query.filter_by(
+            job=100, release="101", is_archived=False
+        ).first()
+        assert clash is None


### PR DESCRIPTION
The Rel feature scaffolding (rel/rel_assigned_at columns, migration, next_rel_number/assign_rel_if_drr helpers, DWL Rel+Job columns, unit tests) was already merged to main but the activation call was commented out. This re-instates assign_rel_if_drr(new_submittal) in create_submittal_from_webhook.

Procore never mutates a submittal's type in place: a stage transition closes the old submittal and opens a revision of the new type, so a DRR ("Drafting Release Review") always arrives as a fresh creation event. Assigning on create is therefore the complete and correct hook -- no update-path handling is needed.

Behavior: forward-only (no backfill of existing DRRs), app-only (number stored in submittals.rel and shown in the DWL Rel column; nothing written back to Procore).

Adds integration tests driving the real create_submittal_from_webhook so the assignment can't be silently re-disabled.