### PR TITLE
Add clickable version badge and in-app patch notes modal.

### DIFF
--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -20,6 +20,8 @@ import { ReleasesProvider } from '../context/ReleasesContext';
 import QuickSearch from './QuickSearch';
 import NotificationBell from './NotificationBell';
 import MobileNavDrawer from './MobileNavDrawer';
+import PatchNotesModal from './PatchNotesModal';
+import { CURRENT_VERSION } from '../data/patchNotes';
 
 function AppShellInner({ isAuthenticated }) {
   const navigate = useNavigate();
@@ -30,6 +32,7 @@ function AppShellInner({ isAuthenticated }) {
   const { locationEnabled, locationRequesting, handleLocationToggle } = useLocationContext();
   const [isAdmin, setIsAdmin] = useState(false);
   const [canSeeReport, setCanSeeReport] = useState(false);
+  const [showPatchNotes, setShowPatchNotes] = useState(false);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -80,6 +83,16 @@ function AppShellInner({ isAuthenticated }) {
         <h1 className="shrink-0 text-lg 3xl:text-xl font-bold bg-gradient-to-r from-accent-500 to-accent-600 dark:from-accent-300 dark:to-accent-400 bg-clip-text text-transparent whitespace-nowrap select-none">
           MHMW Brain
         </h1>
+
+        {/* Version badge — opens patch notes */}
+        <button
+          type="button"
+          onClick={() => setShowPatchNotes(true)}
+          className="shrink-0 px-1.5 py-0.5 text-[11px] font-medium rounded-md text-gray-500 dark:text-slate-400 hover:text-accent-600 dark:hover:text-accent-300 hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
+          title="What's new — view patch notes"
+        >
+          {CURRENT_VERSION}
+        </button>
 
         {/* Everything else expands from the right; search is the leftmost item */}
         <div className="ml-auto flex items-center gap-2">
@@ -219,6 +232,8 @@ function AppShellInner({ isAuthenticated }) {
         onLogout={handleLogout}
         onLogin={() => navigate('/login')}
       />
+
+      <PatchNotesModal isOpen={showPatchNotes} onClose={() => setShowPatchNotes(false)} isAdmin={isAdmin} />
 
       {/* Main content */}
       <main className="flex-1 w-full min-h-0 flex flex-col">

--- a/frontend/src/components/PatchNotesModal.jsx
+++ b/frontend/src/components/PatchNotesModal.jsx
@@ -1,0 +1,127 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: Read-only modal that renders the in-app changelog (PATCH_NOTES), grouped by release with new/improved/fixed badges.
+ * exports:
+ *   PatchNotesModal: Portal modal listing release entries newest-first
+ * imports_from: [react, react-dom, ../data/patchNotes]
+ * imported_by: [frontend/src/components/AppShell.jsx]
+ * invariants:
+ *   - Renders via createPortal to document.body to escape header/overflow clipping
+ *   - No-op render when isOpen is false; Escape and backdrop click both close
+ */
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { PATCH_NOTES } from '../data/patchNotes';
+
+const TYPE_META = {
+  new: { label: 'New', className: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' },
+  improved: { label: 'Improved', className: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' },
+  fixed: { label: 'Fixed', className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300' },
+};
+
+export function PatchNotesModal({ isOpen, onClose, isAdmin = false }) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  // Non-admins never see admin-only changes; releases left empty are dropped.
+  const visibleReleases = PATCH_NOTES
+    .map((release) => ({
+      ...release,
+      changes: release.changes.filter((c) => isAdmin || !c.adminOnly),
+    }))
+    .filter((release) => release.changes.length > 0);
+
+  const modalContent = (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-slate-800 rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[85vh] flex flex-col transform transition-all"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="bg-gradient-to-r from-accent-500 to-accent-600 px-5 py-3 rounded-t-xl">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-base font-semibold text-white leading-tight">What's New</h2>
+              <p className="text-xs text-white text-opacity-90 mt-0.5">
+                MHMW Brain — release notes
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              className="text-white hover:text-gray-200 transition-colors text-2xl font-bold leading-none"
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
+        <div className="px-5 py-4 overflow-y-auto flex-1 space-y-6">
+          {visibleReleases.map((release) => (
+            <section key={release.version}>
+              <div className="flex flex-wrap items-baseline gap-x-2 mb-1">
+                <span className="text-sm font-bold text-gray-900 dark:text-slate-100">
+                  {release.version}
+                </span>
+                <span className="text-xs text-gray-500 dark:text-slate-400">
+                  {release.date}
+                </span>
+              </div>
+              {release.summary && (
+                <p className="text-sm text-gray-600 dark:text-slate-300 mb-3">
+                  {release.summary}
+                </p>
+              )}
+              <ul className="space-y-3">
+                {release.changes.map((change, idx) => {
+                  const meta = TYPE_META[change.type] || TYPE_META.improved;
+                  return (
+                    <li key={idx} className="border-l-2 border-accent-500 pl-3">
+                      <div className="flex flex-wrap items-baseline gap-x-2 mb-0.5">
+                        <span
+                          className={`text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${meta.className}`}
+                        >
+                          {meta.label}
+                        </span>
+                        <span className="text-sm font-semibold text-gray-800 dark:text-slate-200">
+                          {change.title}
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-700 dark:text-slate-300">
+                        {change.detail}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ))}
+        </div>
+
+        <div className="bg-gray-50 dark:bg-slate-700 px-5 py-3 rounded-b-xl border-t border-gray-200 dark:border-slate-600 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-1.5 bg-gray-200 dark:bg-slate-600 text-gray-700 dark:text-slate-200 rounded-md text-sm font-medium hover:bg-gray-300 dark:hover:bg-slate-500 transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+}
+
+export default PatchNotesModal;

--- a/frontend/src/data/patchNotes.js
+++ b/frontend/src/data/patchNotes.js
@@ -1,0 +1,72 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: Static, human-curated changelog feeding the in-app version badge and Patch Notes modal. Newest release first.
+ * exports:
+ *   PATCH_NOTES: ordered list of release entries
+ *   CURRENT_VERSION: convenience accessor for PATCH_NOTES[0].version
+ * imports_from: []
+ * imported_by: [frontend/src/components/PatchNotesModal.jsx, frontend/src/components/AppShell.jsx]
+ * invariants:
+ *   - PATCH_NOTES[0] is always the latest release; the version badge renders its `version`.
+ *   - Version scheme: v2.0.<pr> where <pr> is the highest merged PR number in the release.
+ *   - Each entry's `version` is unique.
+ *   - `type` on a change is one of: 'new' | 'improved' | 'fixed'.
+ *   - `adminOnly: true` on a change hides it from non-admin users in the modal.
+ */
+
+export const PATCH_NOTES = [
+  {
+    version: 'v2.0.255',
+    date: 'June 14, 2026',
+    summary:
+      'New Sunbelt rental tracking, cleaner release assignment from the Drafting Work Load, and a batch of search, notification, and styling fixes.',
+    changes: [
+      {
+        type: 'new',
+        title: 'In-app patch notes',
+        detail:
+          'The version number next to "MHMW Brain" in the top-left is now clickable — it opens this What\'s New panel so you can see what shipped in each release.',
+      },
+      {
+        type: 'new',
+        title: 'Sunbelt rental reports',
+        adminOnly: true,
+        detail:
+          'A new Rentals page tracks Sunbelt equipment-on-rent. For now the rental list is loaded manually; automatic ingestion is targeted for later this week.',
+      },
+      {
+        type: 'improved',
+        title: 'Release assignment from the Drafting Work Load',
+        detail:
+          'Reworked how release numbers are assigned out of the Drafting Work Load so they stay unique and consistent.',
+      },
+      {
+        type: 'improved',
+        title: 'Drafting Work Load & Job Log styling',
+        detail:
+          'Cleaner column filters, project filter dropdown, table rows, and view toggles across both boards for easier scanning.',
+      },
+      {
+        type: 'improved',
+        title: 'Navigation bar refresh',
+        detail:
+          'Tidied up the top navigation — MHMW Brain pinned at the far left with the menu rolling out to the right.',
+      },
+      {
+        type: 'fixed',
+        title: 'Global search closes cleanly',
+        detail:
+          'The quick/global search no longer gets stuck open; it now closes reliably when you click away or finish a search.',
+      },
+      {
+        type: 'fixed',
+        title: 'Repeat to-do notifications',
+        detail:
+          'Overdue to-dos stop firing duplicate reminder notifications. (Foundational fix — more notification controls to come.)',
+      },
+    ],
+  },
+];
+
+export const CURRENT_VERSION = PATCH_NOTES[0].version;


### PR DESCRIPTION
Adds a curated changelog (frontend/src/data/patchNotes.js) surfaced via a clickable version badge next to the MHMW Brain brand. Opens a What's New modal listing releases newest-first with new/improved/fixed tags. Admin-only notes are hidden from non-admin users. Version scheme: v2.0.<highest PR #>.