### PR TITLE
Refactor release parsing and improve code clarity

### DIFF
--- a/app/brain/meetings/brain_delta.py
+++ b/app/brain/meetings/brain_delta.py
@@ -214,11 +214,8 @@ def sanitize_drift(raw):
     ref = (str(raw.get("ref") or "")).strip()
     if not ref or not field:
         return None
-    if target == "release" and field in RELEASE_FIELDS:
-        pass
-    elif target == "submittal" and field in SUBMITTAL_FIELDS:
-        pass
-    else:
+    allowed = {"release": RELEASE_FIELDS, "submittal": SUBMITTAL_FIELDS}.get(target, ())
+    if field not in allowed:
         return None
     # The model sometimes reports a "drift" whose stated value equals the Brain value.
     if _is_noop(raw.get("stated_value"), raw.get("brain_value")):

--- a/app/brain/meetings/context.py
+++ b/app/brain/meetings/context.py
@@ -30,7 +30,7 @@ from app.logging_config import get_logger
 logger = get_logger(__name__)
 
 # Bounds that keep context from crowding out the transcript or ballooning cost.
-MAX_ENTITIES = 15          # cap submittals brought into context
+MAX_SUBMITTALS = 15          # cap submittals brought into context
 # A multi-job production standup touches many jobs and drift detection needs the SPECIFIC
 # release the room named in context, so releases get a larger budget than submittals and a
 # per-job cap keeps one big job (480 has 40+ releases) from flooding the set.
@@ -163,7 +163,7 @@ def relevant_entities(meeting):
             seen_sub.add(s.submittal_id)
             submittals.append(s)
 
-    return releases[:MAX_RELEASES], submittals[:MAX_ENTITIES]
+    return releases[:MAX_RELEASES], submittals[:MAX_SUBMITTALS]
 
 
 # --- state-line rendering (shared) ------------------------------------------- #
@@ -227,7 +227,7 @@ def assemble_extraction_context(meeting):
     state = _light_state_lines(meeting)
     guidance = learned_guidance()
 
-    # State and guidance are small and bounded (MAX_ENTITIES / MAX_GUIDANCE); the agenda
+    # State and guidance are small and bounded (MAX_SUBMITTALS / MAX_GUIDANCE); the agenda
     # is unbounded user input. Budget the agenda against what remains under the
     # extractor's context cap so a long agenda truncates ITSELF — the extractor's own
     # tail-truncation would silently evict the state and guidance sections instead.

--- a/app/brain/meetings/service.py
+++ b/app/brain/meetings/service.py
@@ -115,16 +115,21 @@ def _end_of_week(today=None):
     return today + timedelta(days=(4 - today.weekday()) % 7)  # Mon=0 … Fri=4
 
 
-def _resolve_release(ref):
-    """'480-146' -> (Releases.id, job_number_str); best-effort."""
+def _release_row(ref):
+    """'480-625' -> the Releases row (or None). The single release-token parser; both
+    _resolve_release (id + job label) and drift anchoring read off the row it returns."""
     if not ref:
-        return None, None
+        return None
     m = re.match(r"\s*(\d+)\s*-\s*(\w+)\s*$", str(ref))
     if not m:
-        return None, None
-    job, rel = int(m.group(1)), m.group(2)
-    row = Releases.query.filter_by(job=job, release=rel).first()
-    return (row.id, str(job)) if row else (None, None)
+        return None
+    return Releases.query.filter_by(job=int(m.group(1)), release=m.group(2)).first()
+
+
+def _resolve_release(ref):
+    """'480-146' -> (Releases.id, job_number_str); best-effort."""
+    row = _release_row(ref)
+    return (row.id, str(row.job)) if row else (None, None)
 
 
 def _resolve_submittal(ref):
@@ -132,16 +137,6 @@ def _resolve_submittal(ref):
         return None
     row = Submittals.query.filter_by(submittal_id=str(ref)).first()
     return row.submittal_id if row else None
-
-
-def _release_row(ref):
-    """'480-625' -> the Releases row (or None) — used to anchor a drift + label it."""
-    if not ref:
-        return None
-    m = re.match(r"\s*(\d+)\s*-\s*(\w+)\s*$", str(ref))
-    if not m:
-        return None
-    return Releases.query.filter_by(job=int(m.group(1)), release=m.group(2)).first()
 
 
 def _detect_and_store_drifts(meeting):
@@ -174,7 +169,7 @@ def _detect_and_store_drifts(meeting):
             meeting_id=meeting.id,
             target=d["target"],
             ref=d["ref"],
-            entity_name=(entity_name or None) and entity_name[:255],
+            entity_name=entity_name[:255] if entity_name else None,
             field=d["field"],
             stated_value=d["stated_value"],
             brain_value=d["brain_value"],


### PR DESCRIPTION
## Summary
This PR refactors the release token parsing logic and improves code clarity across the meetings module. The main change extracts the core parsing logic into a dedicated `_release_row()` function that both `_resolve_release()` and drift anchoring can use, eliminating duplication and making the single source of truth explicit.

## Key Changes

- **Extracted `_release_row()` as the canonical release-token parser**: Moved the regex parsing and database query into a single function that returns the `Releases` row (or `None`). This function is now called by `_resolve_release()` and used for drift anchoring, eliminating duplicate parsing logic.

- **Simplified `_resolve_release()`**: Now delegates to `_release_row()` and extracts the `id` and `job` from the returned row, making the function's intent clearer.

- **Improved conditional logic in `brain_delta.py`**: Replaced nested if-elif-else blocks with a dictionary lookup pattern for checking allowed drift fields by target type. This is more maintainable and easier to extend.

- **Fixed entity name truncation logic in `service.py`**: Changed `(entity_name or None) and entity_name[:255]` to the clearer `entity_name[:255] if entity_name else None`, improving readability without changing behavior.

- **Renamed constant for clarity in `context.py`**: Changed `MAX_ENTITIES` to `MAX_SUBMITTALS` to better reflect what the constant actually limits, and updated all references and comments accordingly.

## Implementation Details

The refactoring maintains backward compatibility—all existing behavior is preserved. The `_release_row()` function is positioned early in the file (before `_resolve_release()`) to serve as the documented single source of truth for release token parsing, with a clear docstring explaining its role in both release resolution and drift anchoring.

https://claude.ai/code/session_01R1zRRVRn6QRsGoMcxHc75b