### PR TITLE
Fix per-poll Opus re-scan of non-order mail; move extractor to Sonnet

### DIFF
--- a/app/brain/material_orders/extractors/llm.py
+++ b/app/brain/material_orders/extractors/llm.py
@@ -7,9 +7,13 @@ Claude reads PDFs directly, sidestepping the scrambled-text problem — and asks
 strict-JSON line items. Deterministic header fields (supplier, PO, orderer) are
 trusted over the model; only the line items + supplier order # come from the LLM.
 
-Mirrors app/brain/meetings/extract.py: raw `requests`, ANTHROPIC_API_KEY, model
-claude-opus-4-8, and a graceful return of None on a missing key or ANY failure, so
-the pipeline (and tests) stay hermetic without a key.
+Mirrors app/brain/meetings/extract.py: raw `requests`, ANTHROPIC_API_KEY, and a
+graceful return of None on a missing key or ANY failure, so the pipeline (and
+tests) stay hermetic without a key. The model defaults to claude-sonnet-5 — this
+is a structured-extraction task, so Sonnet gives near-Opus quality at a fraction
+of the cost; override with MATERIAL_ORDER_EXTRACT_MODEL. Thinking is disabled so
+this stays a fast, deterministic extractor: Sonnet 5 runs *adaptive* thinking when
+the field is omitted, which would add billed thinking tokens on every call.
 """
 import base64
 import json
@@ -27,7 +31,7 @@ logger = get_logger(__name__)
 
 NAME = "llm"
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
-EXTRACT_MODEL = os.environ.get("MATERIAL_ORDER_EXTRACT_MODEL", "claude-opus-4-8")
+EXTRACT_MODEL = os.environ.get("MATERIAL_ORDER_EXTRACT_MODEL", "claude-sonnet-5")
 MAX_PDF_BYTES = 20 * 1024 * 1024  # Anthropic document-block ceiling guard
 
 _SYSTEM = (
@@ -86,6 +90,10 @@ def _call_anthropic(record):
         json={
             "model": EXTRACT_MODEL,
             "max_tokens": 4096,
+            # Keep this a pure extractor. Opus omits thinking when the field is
+            # absent, but Sonnet 5 defaults to adaptive thinking — disable it
+            # explicitly so we don't pay for thinking tokens on every call.
+            "thinking": {"type": "disabled"},
             "system": _SYSTEM,
             "messages": [{"role": "user", "content": _content_blocks(record)}],
         },

--- a/app/brain/material_orders/service.py
+++ b/app/brain/material_orders/service.py
@@ -5,7 +5,7 @@ rows (idempotent via the (source_record_id, line_index) unique key); the bb mail
 poll calls ingest_unprocessed() after landing new mail, and the fixture loader
 calls it directly. list_for_release / mark_received back the modal.
 """
-from datetime import date
+from datetime import date, datetime
 
 from app.logging_config import get_logger
 from app.models import MaterialOrder, RawSourceRecord, db
@@ -88,10 +88,15 @@ def ingest_record(record):
 
 
 def ingest_unprocessed(limit=200):
-    """Scan recent email RawSourceRecords with no MaterialOrder yet; ingest them.
+    """Scan not-yet-scanned email RawSourceRecords once each; ingest any orders.
 
-    Returns the count of orders created. Idempotent — records already turned into
-    orders are skipped via a NOT-EXISTS check on source_record_id.
+    Returns the count of orders created. Each record is attempted AT MOST ONCE:
+    `material_order_scanned_at` is stamped after the attempt regardless of outcome,
+    so a non-order email (which yields no MaterialOrder rows) is not re-sent to the
+    LLM extractor on every poll — the previous "skip only records that produced an
+    order" logic re-ran the Opus fallback on all non-order mail every 15 minutes.
+    The marker is reset to NULL by the mail connector when a record's content
+    changes (late-arriving attachment), so a changed record is scanned once more.
     """
     already = {
         rid for (rid,) in db.session.query(MaterialOrder.source_record_id)
@@ -100,14 +105,19 @@ def ingest_unprocessed(limit=200):
     q = (
         RawSourceRecord.query
         .filter_by(record_type=EMAIL_RECORD_TYPE)
+        .filter(RawSourceRecord.material_order_scanned_at.is_(None))
         .order_by(RawSourceRecord.id.desc())
         .limit(limit)
     )
     created = 0
+    scanned_at = datetime.utcnow()
     for record in q:
-        if record.id in already:
-            continue
-        created += len(ingest_record(record))
+        # Records that already produced orders (e.g. before this column existed)
+        # are complete — mark them scanned without re-running the extractor.
+        if record.id not in already:
+            created += len(ingest_record(record))
+        record.material_order_scanned_at = scanned_at
+    db.session.commit()
     if created:
         logger.info("material_orders_backfill", created=created)
     return created

--- a/app/lake/ingest/m365_mail.py
+++ b/app/lake/ingest/m365_mail.py
@@ -171,6 +171,9 @@ def _land(message, mailbox):
         existing.occurred_at = occurred_at
         existing.payload = payload
         existing.external_pointer = external_pointer
+        # Content changed (e.g. a late-arriving attachment) — let the material-order
+        # extractor look at it once more rather than trusting the prior scan.
+        existing.material_order_scanned_at = None
         return "updated"
 
     return "unchanged"

--- a/app/models.py
+++ b/app/models.py
@@ -1147,6 +1147,11 @@ class RawSourceRecord(db.Model):
     ingested_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     payload = db.Column(db.JSON, nullable=False)              # normalized record
     external_pointer = db.Column(db.JSON, nullable=True)      # refs kept in M365 (webLink, attachments)
+    # Processing metadata (not content): set once the material-order extractor has
+    # attempted this record, regardless of outcome, so a non-order email is never
+    # re-sent to the LLM on every poll. Reset to NULL when content_hash changes
+    # (re-pull with a late attachment) so the changed record is scanned once more.
+    material_order_scanned_at = db.Column(db.DateTime, nullable=True)
 
     def to_dict(self):
         return {

--- a/migrations/add_material_order_scanned_at.py
+++ b/migrations/add_material_order_scanned_at.py
@@ -1,0 +1,218 @@
+"""
+Add `material_order_scanned_at` to raw_source_records.
+
+The material-order extractor scans not-yet-scanned email records after each BB mail
+poll. Before this column, "scanned" was inferred from "produced a MaterialOrder row",
+so every NON-order email (the majority of a mailbox) was re-sent to the Claude LLM
+fallback on every 15-minute poll — a large, silent Opus spend that returned no line
+items. This nullable timestamp marks a record as attempted regardless of outcome, so
+each email hits the LLM at most once. The mail connector resets it to NULL when a
+record's content changes, so a changed record is scanned once more.
+
+This migration only adds the column; nothing is backfilled (existing records have
+NULL and will each be scanned one final time on the next poll, then stay marked).
+
+Usage:
+    python migrations/add_material_order_scanned_at.py
+    python migrations/add_material_order_scanned_at.py --database-url postgresql://...
+
+Safety properties (Postgres) — mirrors migrations/add_start_install_to_dwl.py:
+  - Idempotent `ADD COLUMN IF NOT EXISTS`, so NO schema reflection is needed.
+  - One AUTOCOMMIT connection: the ACCESS EXCLUSIVE lock is held only for the instant
+    the metadata-only ADD COLUMN runs, never across the migration.
+  - `lock_timeout` makes a blocked ALTER FAIL FAST and auto-retry with backoff instead
+    of queueing behind live traffic.
+  - The column is nullable with no default, so ADD COLUMN is metadata-only (instant).
+"""
+
+import argparse
+import os
+import sys
+import time
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_SQLITE_PATH = os.path.join(ROOT_DIR, "instance", "jobs.sqlite")
+
+LOCK_TIMEOUT = "5s"
+STATEMENT_TIMEOUT = "30s"
+LOCK_RETRIES = 4
+RETRY_BASE_SECONDS = 3
+
+load_dotenv()
+
+TABLE = "raw_source_records"
+COLUMN = "material_order_scanned_at"
+
+
+def normalize_sqlite_path(path: str) -> str:
+    if not os.path.isabs(path):
+        path = os.path.join(ROOT_DIR, path)
+    return f"sqlite:///{path}"
+
+
+def _coerce_url(value: str) -> str:
+    value = value.strip()
+    if value.startswith("postgres://"):
+        return value.replace("postgres://", "postgresql://", 1)
+    if value.startswith(("postgresql://", "mysql://", "mariadb://", "sqlite://")):
+        return value
+    return normalize_sqlite_path(value)
+
+
+def infer_database_url(cli_url: str = None) -> str:
+    """Figure out which database to hit, honoring CLI and ENVIRONMENT (mirrors db_config.py)."""
+    if cli_url:
+        return _coerce_url(cli_url)
+
+    environment = (os.environ.get("ENVIRONMENT") or "local").strip().lower()
+
+    if environment == "production":
+        value = os.environ.get("PRODUCTION_DATABASE_URL") or os.environ.get("DATABASE_URL")
+        if not value:
+            raise ValueError(
+                "ENVIRONMENT=production but neither PRODUCTION_DATABASE_URL nor "
+                "DATABASE_URL is set (refusing to guess; pass --database-url)."
+            )
+        return _coerce_url(value)
+
+    if environment == "sandbox":
+        value = os.environ.get("SANDBOX_DATABASE_URL") or os.environ.get("DATABASE_URL")
+        if not value:
+            raise ValueError(
+                "ENVIRONMENT=sandbox but neither SANDBOX_DATABASE_URL nor "
+                "DATABASE_URL is set (refusing to guess; pass --database-url)."
+            )
+        return _coerce_url(value)
+
+    candidates = [
+        os.environ.get("LOCAL_DATABASE_URL"),
+        os.environ.get("DATABASE_URL"),
+        os.environ.get("SQLALCHEMY_DATABASE_URI"),
+        os.environ.get("JOBS_DB_URL"),
+        os.environ.get("JOBS_SQLITE_PATH"),
+    ]
+    for value in candidates:
+        if value:
+            return _coerce_url(value)
+
+    return normalize_sqlite_path(DEFAULT_SQLITE_PATH)
+
+
+def _mask(url: str) -> str:
+    """Render a connection URL for logging without leaking the password."""
+    try:
+        u = urlparse(url)
+        if u.hostname:
+            user = f"{u.username}@" if u.username else ""
+            return f"{u.scheme}://{user}{u.hostname}/{u.path.lstrip('/')}"
+    except Exception:
+        pass
+    return url.split("@")[-1] if "@" in url else url
+
+
+def _is_lock_timeout(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "lock" in msg and ("timeout" in msg or "not available" in msg or "55p03" in msg)
+
+
+def _run_with_retry(conn, sql: str, label: str) -> None:
+    """Execute one idempotent DDL statement, retrying on lock_timeout with backoff."""
+    for attempt in range(1, LOCK_RETRIES + 1):
+        try:
+            conn.execute(text(sql))
+            print(f"✓ {label}")
+            return
+        except OperationalError as exc:
+            if _is_lock_timeout(exc) and attempt < LOCK_RETRIES:
+                delay = RETRY_BASE_SECONDS * attempt
+                print(
+                    f"  ⏳ '{label}' couldn't get the lock (attempt {attempt}/{LOCK_RETRIES}); "
+                    f"retrying in {delay}s — nothing committed, app keeps running"
+                )
+                time.sleep(delay)
+                continue
+            raise
+
+
+def _migrate_postgres(engine) -> bool:
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        conn.execute(text(f"SET lock_timeout = '{LOCK_TIMEOUT}'"))
+        conn.execute(text(f"SET statement_timeout = '{STATEMENT_TIMEOUT}'"))
+
+        if conn.execute(text(f"SELECT to_regclass('{TABLE}')")).scalar() is None:
+            print(f"✗ Table '{TABLE}' does not exist. Run the base schema first.")
+            return False
+
+        try:
+            _run_with_retry(
+                conn,
+                f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS {COLUMN} TIMESTAMP",
+                f"{TABLE}.{COLUMN}",
+            )
+        except OperationalError as exc:
+            if _is_lock_timeout(exc):
+                print(
+                    f"✗ Gave up after {LOCK_RETRIES} attempts: could not get the lock on "
+                    f"'{TABLE}' — the table is under sustained load. Nothing was committed.\n"
+                    "  Re-run during a quieter window, or find an idle-in-transaction blocker:\n"
+                    "    SELECT pid, pg_blocking_pids(pid), state, left(query,80) "
+                    "FROM pg_stat_activity WHERE cardinality(pg_blocking_pids(pid)) > 0;"
+                )
+                return False
+            raise
+    return True
+
+
+def _migrate_sqlite(engine) -> bool:
+    inspector = inspect(engine)
+    if TABLE not in inspector.get_table_names():
+        print(f"✗ Table '{TABLE}' does not exist. Run the base schema first.")
+        return False
+    existing = {c["name"] for c in inspector.get_columns(TABLE)}
+
+    with engine.begin() as conn:
+        if COLUMN not in existing:
+            conn.execute(text(f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} TIMESTAMP"))
+            print(f"✓ {TABLE}.{COLUMN}")
+        else:
+            print(f"{TABLE}.{COLUMN} already exists, skipping")
+    return True
+
+
+def migrate(database_url: str = None) -> bool:
+    db_url = infer_database_url(database_url)
+    print(f"Connecting to database: {_mask(db_url)}")
+
+    engine = create_engine(db_url)
+    try:
+        if engine.dialect.name == "sqlite":
+            return _migrate_sqlite(engine)
+        return _migrate_postgres(engine)
+    except ProgrammingError as exc:
+        print(f"✗ Database error during migration: {exc}")
+        return False
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"✗ Unexpected error: {exc}")
+        return False
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Add material_order_scanned_at column to raw_source_records."
+    )
+    parser.add_argument(
+        "--database-url",
+        help="Override database URL (otherwise inferred from env or defaults).",
+    )
+    args = parser.parse_args()
+
+    success = migrate(args.database_url)
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Problem

The BB mail poll (`bb_mail_poll`, every 15 min) calls `material_orders.ingest_unprocessed()` after landing mail. That function only skipped emails that had **produced** a `MaterialOrder` row — so every **non-order** email (the majority of a mailbox) never qualified and fell through to the Claude **Opus** LLM fallback (`extractors/llm.py`) **on every poll**, returning no line items each time.

Net effect: a large, silent Opus spend — roughly *(non-order emails in the last-200 window)* × one Opus call each × ~96 polls/day. The API console showed pages of `claude-opus-4-8` requests with ~30 output tokens (empty `{"lines":[]}`) each. The docstring's "no-op for non-order mail; idempotent" was exactly backwards — non-order mail was the expensive, non-idempotent case.

## Fix

1. **Scan each email at most once.** Add `RawSourceRecord.material_order_scanned_at`. `ingest_unprocessed()` now selects only records where the marker is `NULL` and stamps it after each attempt **regardless of outcome**, so a non-order email is never re-sent to the LLM on subsequent polls. Records that already produced orders are marked without re-running the extractor.
2. **Re-scan on content change.** The mail connector resets the marker to `NULL` when a record's `content_hash` changes (late-arriving attachment), preserving the existing "attachment lands late → re-ingest" guarantee.
3. **Cheaper extractor.** Default the LLM fallback to `claude-sonnet-5` (still overridable via `MATERIAL_ORDER_EXTRACT_MODEL`) and set `thinking: {type: "disabled"}` — near-Opus quality on structured extraction at ~40% of the cost, without Sonnet's adaptive-thinking-by-default silently adding billed thinking tokens.
4. **Migration.** `migrations/add_material_order_scanned_at.py` — idempotent `ADD COLUMN IF NOT EXISTS`, single AUTOCOMMIT connection, `lock_timeout` fast-fail + retry, masked URL. Cloned from `add_start_install_to_dwl.py`.

## Deploy

Run per environment that has `BB_MAIL_INGEST_ENABLED=1`:

```
python migrations/add_material_order_scanned_at.py
```

Until the column exists, `ingest_unprocessed` errors on the missing column (no LLM calls happen before the query), so the burn stops immediately; run the migration promptly so ingestion resumes cleanly.

## Tests

`tests/material_orders/` + `tests/lake/` — 40 passed.

## Follow-up (not in this PR)

Optional pre-LLM heuristic gate in `classify.py` (PDF attachment / known-supplier sender / order keywords) so obvious non-orders never cost even the first Sonnet call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)