### PR TITLE
Logging cleanup + emission standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,16 @@ The `/brain/events/<id>/undo` endpoint (in `app/brain/job_log/routes.py`) revers
 `/brain/renumber-fabrication-fab-orders` (admin-only POST) compresses FABRICATION-group `fab_order` values to a contiguous block starting at 3, preserving relative order. Supports `?dry_run=true`. Implementation: `app/brain/job_log/features/fab_order/renumber_fabrication.py`. `DEFAULT_FAB_ORDER` (80.555) rows are preserved as-is. Rows sharing the same current fab_order share the same new value.
 
 ### Logging
-Structured logging via `structlog` (`app/logging_config.py`). Use `get_logger(__name__)` in every module. `SyncContext` context manager wraps sync operations with correlation IDs and timing. Output is JSON-structured; also writes to rotating file (`logs/app.log`, 10MB max, 5 backups).
+The full emission standard is `docs/logging-standard.md` — read it before adding any logging. The hard rules, always in force:
+
+- One idiom: `get_logger(__name__)` from `app/logging_config.py`. Never stdlib `logging.getLogger`, never `app.logger`/`current_app.logger`, never `print()` on a runtime path (CLI scripts under `scripts/` may print), never `logging.basicConfig()`.
+- Events, not sentences: `logger.info("stage_updated", release_id=rid, from_stage=a, to_stage=b)`. F-strings are banned in logger calls; data goes in kwargs using the canonical field names from the standard's registry (`request_id`, `user_id`, `job`, `release`, `submittal_id`, `duration_ms`, `status`, `error`, `error_type`, …).
+- Levels: DEBUG = narrative; INFO = a state actually changed (one line, owned by the layer making the change — reads/polls/no-ops never log at INFO); WARNING = unexpected but handled; ERROR = always with `exc_info=True`, never sampled or swallowed. Every external call (Trello/Procore/Graph/Anthropic) and background-job entry must emit an ERROR with traceback on failure. A lost outbound update (outbox delivery exhausted) is an ERROR, not a warning.
+- Prefer one wide completion event per unit of work (request/webhook/job) over many thin progress lines; play-by-play is DEBUG.
+- Durability rule: if losing the record would matter next week it's a DB event row (`ReleaseEvents`/`SubmittalEvents`/ledger), not a log line. Never log secrets, tokens, or connection strings (log the host, never the URI).
+- Migration is a ratchet: new code complies fully; migrate logging in any file you touch; never mass-rewrite cold paths for style.
+
+Output is single-rendered JSON via structlog on both stdout and the rotating file (`logs/app.log`, 10MB max, 5 backups); level is set by the `LOG_LEVEL` env var (default INFO). Note: `SyncContext` in `logging_config.py` is currently dead code (never called) — don't model new work on it; correlation is a planned follow-up (bind `request_id` via `structlog.contextvars`).
 
 ### Frontend structure
 React pages under `frontend/src/pages/`, reusable components under `frontend/src/components/`, API calls in `frontend/src/services/`, custom hooks in `frontend/src/hooks/`. Uses Tailwind CSS, react-router-dom, axios, @dnd-kit for drag-drop, maplibre-gl for maps.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -41,7 +41,7 @@ from app.models import db
 from app.logging_config import configure_logging, get_logger
 
 # Configure logging
-logger = configure_logging(log_level="INFO", log_file="logs/app.log")
+logger = configure_logging(log_level=os.environ.get("LOG_LEVEL", "INFO"), log_file="logs/app.log")
 
 
 def init_scheduler(app):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -300,9 +300,24 @@ def create_app():
 
     # Log the environment being used
     logger.info(f"Starting application in {config_class.ENV} environment")
-    logger.info(
-        f"Database URI: {app.config.get('SQLALCHEMY_DATABASE_URI', 'Not set')[:50]}..."
-    )
+    # Log only the DB host — never the username, password, or the raw URI
+    # (even truncated), which would leak Postgres credentials into Render
+    # stdout and logs/app.log.
+    from urllib.parse import urlsplit
+
+    db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
+    if db_uri:
+        try:
+            parsed = urlsplit(db_uri)
+            db_host = parsed.hostname or "unknown"
+            db_name = parsed.path.lstrip("/") or "unknown"
+        except ValueError:
+            db_host = "unparseable"
+            db_name = "unparseable"
+    else:
+        db_host = "not set"
+        db_name = "not set"
+    logger.info(f"Database host: {db_host} (db: {db_name})")
     if app.config.get("TRELLO_MOCK"):
         logger.info("TRELLO_MOCK enabled — outbound move_card calls will be simulated and inbound webhooks dropped")
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -86,7 +86,7 @@ def init_scheduler(app):
 
     # --- Optional heartbeat job to confirm scheduler alive ---
     scheduler.add_job(
-        func=lambda: logger.info("Scheduler heartbeat: alive"),
+        func=lambda: logger.info("scheduler_heartbeat"),
         trigger="interval",
         minutes=30,
         id="heartbeat",
@@ -299,7 +299,7 @@ def create_app():
     configure_database(app)
 
     # Log the environment being used
-    logger.info(f"Starting application in {config_class.ENV} environment")
+    logger.info("app_starting", environment=config_class.ENV)
     # Log only the DB host — never the username, password, or the raw URI
     # (even truncated), which would leak Postgres credentials into Render
     # stdout and logs/app.log.
@@ -317,7 +317,7 @@ def create_app():
     else:
         db_host = "not set"
         db_name = "not set"
-    logger.info(f"Database host: {db_host} (db: {db_name})")
+    logger.info("database_configured", host=db_host, database=db_name)
     if app.config.get("TRELLO_MOCK"):
         logger.info("TRELLO_MOCK enabled — outbound move_card calls will be simulated and inbound webhooks dropped")
 
@@ -418,7 +418,12 @@ def create_app():
                             # Processed some items, check again soon for more
                             time.sleep(0.5)
                 except Exception as e:
-                    logger.error(f"Error in outbox retry worker: {e}", exc_info=True)
+                    logger.error(
+                        "outbox_retry_worker_failed",
+                        error=str(e),
+                        error_type=type(e).__name__,
+                        exc_info=True,
+                    )
                     # Wait longer on error before retrying
                     time.sleep(5)
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -45,16 +45,16 @@ def login():
         user = User.query.filter_by(username=username).first()
         
         if not user:
-            logger.warning(f"Login attempt with non-existent username: {username}")
+            logger.warning("login_failed", username=username, reason="user_not_found")
             return jsonify({'error': 'Invalid username or password'}), 401
-        
+
         if not user.is_active:
-            logger.warning(f"Login attempt for inactive user: {username}")
+            logger.warning("login_failed", username=username, reason="account_inactive")
             return jsonify({'error': 'Account is inactive'}), 403
-        
+
         # Verify password
         if not verify_password(user.password_hash, password):
-            logger.warning(f"Failed login attempt for user: {username}")
+            logger.warning("login_failed", username=username, reason="invalid_password")
             return jsonify({'error': 'Invalid username or password'}), 401
         
         # Update last login
@@ -66,7 +66,7 @@ def login():
         session['username'] = user.username
         session.permanent = True
         
-        logger.info(f"User {username} logged in successfully")
+        logger.info("user_logged_in", user_id=user.id, username=user.username)
         
         return jsonify({
             'status': 'success',
@@ -79,7 +79,7 @@ def login():
         }), 200
 
     except Exception as e:
-        logger.error(f"Error during login: {e}", exc_info=True)
+        logger.error("login_request_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': 'An error occurred during login'}), 500
 
 
@@ -88,11 +88,12 @@ def logout():
     """Logout endpoint that clears the session."""
     try:
         username = session.get('username', 'Unknown')
+        user_id = session.get('user_id')
         session.clear()
-        logger.info(f"User {username} logged out")
+        logger.info("user_logged_out", user_id=user_id, username=username)
         return jsonify({'status': 'success', 'message': 'Logged out successfully'}), 200
     except Exception as e:
-        logger.error(f"Error during logout: {e}", exc_info=True)
+        logger.error("logout_request_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': 'An error occurred during logout'}), 500
 
 
@@ -113,7 +114,7 @@ def get_current_user_info():
             'last_login': user.last_login.isoformat() if user.last_login else None
         }), 200
     except Exception as e:
-        logger.error(f"Error getting current user info: {e}", exc_info=True)
+        logger.error("current_user_info_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': 'An error occurred'}), 500
 
 
@@ -138,15 +139,15 @@ def check_user():
         user = User.query.filter_by(username=username).first()
 
         if not user:
-            logger.info(f"Check user: account not found for {username}")
+            logger.debug("user_check_not_found", username=username)
             return jsonify({'exists': False}), 200
 
         if not user.is_active:
-            logger.info(f"Check user: account inactive for {username}")
+            logger.debug("user_check_inactive", username=username)
             return jsonify({'exists': True, 'needs_password_setup': False}), 200
 
         needs_setup = not user.password_set
-        logger.info(f"Check user: {username} exists, needs_password_setup={needs_setup}")
+        logger.debug("user_checked", username=username, needs_password_setup=needs_setup)
 
         return jsonify({
             'exists': True,
@@ -154,7 +155,7 @@ def check_user():
         }), 200
 
     except Exception as e:
-        logger.error(f"Error during check user: {e}", exc_info=True)
+        logger.error("user_check_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': 'An error occurred'}), 500
 
 
@@ -193,16 +194,16 @@ def set_password():
         user = User.query.filter_by(username=username).first()
 
         if not user:
-            logger.warning(f"Set password attempt for non-existent user: {username}")
+            logger.warning("password_set_denied", username=username, reason="user_not_found")
             return jsonify({'error': 'User not found'}), 404
 
         if not user.is_active:
-            logger.warning(f"Set password attempt for inactive user: {username}")
+            logger.warning("password_set_denied", username=username, reason="account_inactive")
             return jsonify({'error': 'Account is inactive'}), 403
 
         # Check if password has already been set
         if user.password_set:
-            logger.warning(f"Set password attempt for user with password already set: {username}")
+            logger.warning("password_set_denied", username=username, reason="already_set")
             return jsonify({'error': 'Password has already been set for this account'}), 400
 
         # Validate password match
@@ -224,7 +225,7 @@ def set_password():
         session['username'] = user.username
         session.permanent = True
 
-        logger.info(f"User {username} set password and logged in successfully")
+        logger.info("password_set", user_id=user.id, username=user.username)
 
         return jsonify({
             'status': 'success',
@@ -237,7 +238,7 @@ def set_password():
         }), 200
 
     except Exception as e:
-        logger.error(f"Error during set password: {e}", exc_info=True)
+        logger.error("password_set_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': 'An error occurred'}), 500
 
 

--- a/app/auth/utils.py
+++ b/app/auth/utils.py
@@ -62,7 +62,7 @@ def get_current_user():
             return user
         return None
     except Exception as e:
-        logger.error(f"Error getting current user: {e}", exc_info=True)
+        logger.error("current_user_lookup_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return None
 
 
@@ -129,7 +129,7 @@ def admin_required(f):
         if not user:
             return jsonify({'error': 'Authentication required'}), 401
         if not user.is_admin:
-            logger.warning(f"Non-admin user {user.username} attempted to access admin-only route")
+            logger.warning("admin_access_denied", user_id=user.id, username=user.username)
             return jsonify({'error': 'Admin privileges required'}), 403
         return f(*args, **kwargs)
     return decorated_function
@@ -148,7 +148,7 @@ def drafter_or_admin_required(f):
         if not user:
             return jsonify({'error': 'Authentication required'}), 401
         if not user.is_admin and not user.is_drafter:
-            logger.warning(f"User {user.username} attempted to access drafter/admin route without privileges")
+            logger.warning("drafter_or_admin_access_denied", user_id=user.id, username=user.username)
             return jsonify({'error': 'Drafter or admin privileges required'}), 403
         return f(*args, **kwargs)
     return decorated_function
@@ -173,7 +173,7 @@ def invoicing_report_access_required(f):
             return jsonify({'error': 'Authentication required'}), 401
         if user.is_admin or (user.username or '').lower() == INVOICING_REPORT_USER:
             return f(*args, **kwargs)
-        logger.warning(f"User {user.username} attempted to access the invoicing report without privileges")
+        logger.warning("invoicing_report_access_denied", user_id=user.id, username=user.username)
         return jsonify({'error': 'Access denied'}), 403
     return decorated_function
 

--- a/app/brain/board/routes.py
+++ b/app/brain/board/routes.py
@@ -121,7 +121,7 @@ def reorder_board_items():
         item.position = id_to_pos[item.id]
 
     db.session.commit()
-    logger.info(f"Reordered {len(ordered_ids)} items in column '{status_value}'")
+    logger.info("board_items_reordered", count=len(ordered_ids), column=status_value)
     return jsonify({'ok': True, 'updated': len(ordered_ids)})
 
 
@@ -152,7 +152,7 @@ def create_board_item():
     db.session.add(item)
     db.session.commit()
 
-    logger.info(f"Board item #{item.id} created by {user.username}: {title}")
+    logger.info("board_item_created", item_id=item.id, user_id=user.id, title=title)
     return jsonify(item.to_dict(include_activity=True)), 201
 
 
@@ -206,9 +206,10 @@ def update_board_item(item_id):
 def delete_board_item(item_id):
     """Delete a board item and all its activity."""
     item = BoardItem.query.get_or_404(item_id)
+    title = item.title
     db.session.delete(item)
     db.session.commit()
-    logger.info(f"Board item #{item_id} deleted by {get_current_user().username}")
+    logger.info("board_item_deleted", item_id=item_id, user_id=get_current_user().id, title=title)
     return jsonify({'ok': True})
 
 

--- a/app/brain/drafting_work_load/engine.py
+++ b/app/brain/drafting_work_load/engine.py
@@ -8,7 +8,7 @@ exports:
   SubmittalOrderingEngine: Ordering math — cascading updates, step/swap, drag-drop, and resort.
   UrgencyEngine: Urgency ladder bump calculations (0.1-0.9 slots with overflow to regular).
   LocationEngine: Point-in-polygon and buffer constants for geofence matching.
-imports_from: [typing, dataclasses, logging]
+imports_from: [typing, dataclasses, app.logging_config]
 imported_by: [app/brain/drafting_work_load/service.py, app/procore/procore.py]
 invariants:
   - No database or ORM imports — operates only on plain dicts and dataclasses.
@@ -21,9 +21,9 @@ Contains no database dependencies - works with plain data structures.
 """
 from typing import Optional, List, Tuple, Dict
 from dataclasses import dataclass
-import logging
+from app.logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -809,7 +809,12 @@ class UrgencyEngine:
                             
                             if new_order < 0.1:
                                 # This shouldn't happen if we're managing slots correctly, but handle edge case
-                                logger.error(f"calculate_bump_updates: new_order {new_order} < 0.1, capping at 0.1")
+                                logger.warning(
+                                    "bump_order_floor_capped",
+                                    submittal_id=submittal_data.get('submittal_id'),
+                                    old=old_order,
+                                    new=0.1,
+                                )
                                 new_order = 0.1
                             else:
                                 # Round to nearest tenth place to ensure exact values (0.1, 0.2, ..., 0.9)

--- a/app/brain/drafting_work_load/service.py
+++ b/app/brain/drafting_work_load/service.py
@@ -8,7 +8,7 @@ exports:
   UrgencyService: Executes bump workflows (ordered-to-urgent and unordered-to-ordered) against the database.
   LocationService: Resolves lat/lng to job numbers via PostGIS or Python fallback.
   SubmittalOrderUpdate: Re-exported from engine for backward compatibility.
-imports_from: [datetime, typing, logging, sqlalchemy, app.models, app.brain.drafting_work_load.engine]
+imports_from: [datetime, typing, sqlalchemy, app.logging_config, app.models, app.brain.drafting_work_load.engine]
 imported_by: [app/brain/drafting_work_load/routes.py, app/procore/procore.py]
 invariants:
   - Service methods never commit the session — callers are responsible for db.session.commit().
@@ -20,8 +20,8 @@ Handles database operations and coordinates with engine for business logic.
 """
 from datetime import datetime
 from typing import Optional, List, Tuple
-import logging
 from sqlalchemy import text
+from app.logging_config import get_logger
 from app.models import db, Submittals, Projects, PendingStartInstall
 from app.brain.drafting_work_load.engine import (
     DraftingWorkLoadEngine,
@@ -40,7 +40,7 @@ __all__ = [
     'SubmittalOrderUpdate',
 ]
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class DraftingWorkLoadService:
@@ -124,7 +124,7 @@ class DraftingWorkLoadService:
         validated_notes = DraftingWorkLoadEngine.validate_notes(notes)
         submittal.notes = validated_notes
         submittal.last_updated = datetime.utcnow()
-        logger.info(f"Updated notes for submittal {submittal.submittal_id}")
+        logger.info("submittal_notes_updated", submittal_id=submittal.submittal_id)
     
     @staticmethod
     def update_drafting_status(submittal, status: Optional[str]) -> Tuple[bool, Optional[str]]:
@@ -141,12 +141,12 @@ class DraftingWorkLoadService:
         is_valid, normalized_status, error = DraftingWorkLoadEngine.validate_drafting_status(status)
         
         if not is_valid:
-            logger.warning(f"Invalid drafting status for submittal {submittal.submittal_id}: {error}")
+            logger.debug("drafting_status_rejected", submittal_id=submittal.submittal_id, error=error)
             return False, error
-        
+
         submittal.submittal_drafting_status = normalized_status
         submittal.last_updated = datetime.utcnow()
-        logger.info(f"Updated drafting status for submittal {submittal.submittal_id} to '{normalized_status}'")
+        logger.info("drafting_status_updated", submittal_id=submittal.submittal_id, drafting_status=normalized_status)
         return True, None
     
     @staticmethod
@@ -190,7 +190,7 @@ class DraftingWorkLoadService:
         if gc_jobsite_schedule_date:
             is_valid, normalized_anchor, error = DraftingWorkLoadEngine.validate_due_date(gc_jobsite_schedule_date)
             if not is_valid or not normalized_anchor:
-                logger.warning(f"Invalid GC jobsite schedule date for submittal {submittal.submittal_id}: {error}")
+                logger.debug("gc_schedule_date_rejected", submittal_id=submittal.submittal_id, error=error)
                 return False, error
 
             from app.trello.utils import calculate_business_days_before
@@ -202,16 +202,18 @@ class DraftingWorkLoadService:
             )
             submittal.last_updated = datetime.utcnow()
             logger.info(
-                f"Backdated due date for submittal {submittal.submittal_id} to "
-                f"{submittal.due_date} ({DraftingWorkLoadService.GC_SCHEDULE_LEAD_BUSINESS_DAYS} "
-                f"business days before GC jobsite schedule date {normalized_anchor})"
+                "due_date_backdated",
+                submittal_id=submittal.submittal_id,
+                due_date=str(submittal.due_date),
+                gc_jobsite_schedule_date=normalized_anchor,
+                lead_business_days=DraftingWorkLoadService.GC_SCHEDULE_LEAD_BUSINESS_DAYS,
             )
             return True, None
 
         is_valid, normalized_date, error = DraftingWorkLoadEngine.validate_due_date(due_date)
 
         if not is_valid:
-            logger.warning(f"Invalid due date for submittal {submittal.submittal_id}: {error}")
+            logger.debug("due_date_rejected", submittal_id=submittal.submittal_id, error=error)
             return False, error
 
         # Convert string to date object if provided
@@ -221,7 +223,7 @@ class DraftingWorkLoadService:
             submittal.due_date = None
 
         submittal.last_updated = datetime.utcnow()
-        logger.info(f"Updated due date for submittal {submittal.submittal_id} to '{normalized_date}'")
+        logger.info("due_date_updated", submittal_id=submittal.submittal_id, due_date=normalized_date)
         return True, None
 
     # When a start install is set, the due date is overwritten to this many business days
@@ -278,7 +280,7 @@ class DraftingWorkLoadService:
         # Reuse the same date validation as due_date (ISO YYYY-MM-DD or blank).
         is_valid, normalized_date, error = DraftingWorkLoadEngine.validate_due_date(start_install)
         if not is_valid:
-            logger.warning(f"Invalid start install for submittal {submittal.submittal_id}: {error}")
+            logger.debug("start_install_rejected", submittal_id=submittal.submittal_id, error=error)
             return False, error
 
         from app.trello.utils import calculate_business_days_before
@@ -306,8 +308,10 @@ class DraftingWorkLoadService:
         DraftingWorkLoadService.sync_pending_start_install(submittal)
 
         logger.info(
-            f"Updated start_install for submittal {submittal.submittal_id} (rel {submittal.rel}) "
-            f"to '{normalized_date}'"
+            "start_install_updated",
+            submittal_id=submittal.submittal_id,
+            rel=submittal.rel,
+            start_install=normalized_date,
         )
         return True, None
 
@@ -500,7 +504,7 @@ class UrgencyService:
         """
         result = UrgencyEngine.check_submitter_pending_in_workflow(approvers)
         if result:
-            logger.info("Submitter found as pending in next workflow group")
+            logger.debug("submitter_pending_in_workflow")
         return result
     
     @staticmethod
@@ -523,19 +527,24 @@ class UrgencyService:
         Returns:
             bool: True if order number was bumped, False otherwise
         """
-        logger.info(f"Starting ladder bump check for submittal {submittal_id}")
-        
+        logger.debug("ladder_bump_check_started", submittal_id=submittal_id)
+
         if record.order_number is None:
-            logger.warning(f"Order number is None for submittal {submittal_id}, cannot bump")
+            logger.debug("ladder_bump_skipped", submittal_id=submittal_id, reason="no_order_number")
             return False
-        
+
         current_order = record.order_number
-        
+
         # Check if order_number is an integer >= 1
         is_integer = isinstance(current_order, (int, float)) and current_order >= 1 and current_order == int(current_order)
-        
+
         if not is_integer:
-            logger.warning(f"Order number {current_order} is not an integer >= 1 for submittal {submittal_id}, cannot bump")
+            logger.debug(
+                "ladder_bump_skipped",
+                submittal_id=submittal_id,
+                reason="order_not_integer",
+                old=current_order,
+            )
             return False
         
         # Find all existing urgent submittals (0 < order < 1) for this ball_in_court
@@ -577,31 +586,34 @@ class UrgencyService:
         
         # Apply urgent updates
         urgent_map = {s.submittal_id: s for s in existing_urgent_submittals}
-        for submittal_id, new_order_val in urgent_updates:
-            if submittal_id in urgent_map:
+        for shifted_id, new_order_val in urgent_updates:
+            if shifted_id in urgent_map:
                 # If it's an urgency slot (0 < order < 1), round to nearest tenth
                 if new_order_val is not None and 0 < new_order_val < 1:
                     new_order_val = round(new_order_val, 1)
-                urgent_map[submittal_id].order_number = new_order_val
-                logger.info(f"Ladder shift DOWN: submittal {submittal_id} -> {new_order_val} (toward 0.1 = most urgent)")
-        
+                old_order_val = urgent_map[shifted_id].order_number
+                urgent_map[shifted_id].order_number = new_order_val
+                logger.debug("urgent_ladder_shifted", submittal_id=shifted_id, old=old_order_val, new=new_order_val)
+
         # Apply regular updates
         regular_map = {s.submittal_id: s for s in existing_regular_submittals}
-        for submittal_id, new_order_val in regular_updates:
-            if submittal_id in regular_map:
-                regular_map[submittal_id].order_number = new_order_val
-                logger.info(f"Regular shift UP: submittal {submittal_id} -> {new_order_val}")
-        
+        for shifted_id, new_order_val in regular_updates:
+            if shifted_id in regular_map:
+                old_order_val = regular_map[shifted_id].order_number
+                regular_map[shifted_id].order_number = new_order_val
+                logger.debug("regular_order_shifted", submittal_id=shifted_id, old=old_order_val, new=new_order_val)
+
         # Assign order number to the new submittal
         record.order_number = new_order_for_bumped
-        
-        if new_order_for_bumped == 1.0:
-            logger.info(f"BUMPED: {int(current_order)} -> 1.0 for submittal {submittal_id} (all slots filled, assigned to regular)")
-            logger.info(f"Shifted {len(regular_updates)} regular orders UP to make room")
-        else:
-            logger.info(f"BUMPED: {int(current_order)} -> {new_order_for_bumped} for submittal {submittal_id} (ladder system - newest at 0.9)")
-            if urgent_updates:
-                logger.info(f"Shifted {len(urgent_updates)} existing urgent submittals DOWN the ladder (toward 0.1 = most urgent)")
+
+        logger.info(
+            "submittal_order_bumped",
+            submittal_id=submittal_id,
+            old=current_order,
+            new=new_order_for_bumped,
+            urgent_shifted=len(urgent_updates),
+            regular_shifted=len(regular_updates),
+        )
 
         return True
 
@@ -619,10 +631,15 @@ class UrgencyService:
         Returns:
             bool: True if successfully bumped, False otherwise
         """
-        logger.info(f"Bumping unordered submittal {submittal_id} to end of ordered list")
+        logger.debug("unordered_bump_started", submittal_id=submittal_id)
 
         if record.order_number is not None:
-            logger.warning(f"Submittal {submittal_id} already has order_number {record.order_number}, not unordered")
+            logger.debug(
+                "unordered_bump_skipped",
+                submittal_id=submittal_id,
+                reason="already_ordered",
+                old=record.order_number,
+            )
             return False
 
         # Find all ordered submittals (>= 1) for this ball_in_court
@@ -640,7 +657,7 @@ class UrgencyService:
 
         new_order = UrgencyEngine.calculate_bump_unordered_updates(regular_data)
         record.order_number = new_order
-        logger.info(f"Bumped unordered submittal {submittal_id} to ordered position {new_order}")
+        logger.info("submittal_bumped_to_ordered", submittal_id=submittal_id, old=None, new=new_order)
         return True
 
 
@@ -680,7 +697,12 @@ class LocationService:
                 if rows is not None:
                     return [r[0] for r in rows]
             except Exception as e:
-                logger.warning("PostGIS location check failed, using Python fallback: %s", e)
+                logger.warning(
+                    "postgis_location_check_failed",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
                 db.session.rollback()
 
         # Fallback: strict point-in-polygon (SQLite or PostGIS unavailable)

--- a/app/brain/job_log/features/fab_order/command.py
+++ b/app/brain/job_log/features/fab_order/command.py
@@ -67,7 +67,7 @@ class UpdateFabOrderCommand:
         # 1️⃣ Fetch job record
         job_record: Releases = Releases.query.filter_by(job=self.job_id, release=self.release).first()
         if not job_record:
-            logger.warning(f"Job not found: {self.job_id}-{self.release}")
+            logger.debug("job_not_found", job=self.job_id, release=self.release)
             raise ValueError(f"Job {self.job_id}-{self.release} not found")
 
         # Capture old state for payload
@@ -76,7 +76,7 @@ class UpdateFabOrderCommand:
 
         # Ensure old_fab_order is not NaN for JSON serialization
         if isinstance(old_fab_order, float) and math.isnan(old_fab_order):
-            logger.warning(f"Job {self.job_id}-{self.release} has NaN fab_order, converting to None")
+            logger.warning("fab_order_nan_coerced", job=self.job_id, release=self.release)
             old_fab_order = None
 
         # 1b. Fixed-tier guard: stages with auto-assigned fab_order
@@ -84,17 +84,22 @@ class UpdateFabOrderCommand:
         tier = get_fixed_tier(job_record.stage)
         if tier is not None:
             self.fab_order = tier
-            logger.info(
-                f"Job {self.job_id}-{self.release} is fixed tier {tier} "
-                f"(stage={job_record.stage}), overriding fab_order to {tier}"
+            logger.debug(
+                "fab_order_fixed_tier_override",
+                job=self.job_id,
+                release=self.release,
+                stage=job_record.stage,
+                tier=tier,
             )
 
         # 1c. Complete is terminal — no ordering. Always force fab_order to None.
         if (job_record.stage or "").strip().lower() == "complete":
             if self.fab_order is not None:
-                logger.info(
-                    f"Job {self.job_id}-{self.release} is Complete; "
-                    f"forcing fab_order to NULL (was {self.fab_order})"
+                logger.debug(
+                    "fab_order_forced_null_complete",
+                    job=self.job_id,
+                    release=self.release,
+                    old=self.fab_order,
                 )
             self.fab_order = None
 
@@ -117,7 +122,11 @@ class UpdateFabOrderCommand:
 
         # Check if event was deduplicated
         if event is None:
-            logger.info(f"Event already exists for job {self.job_id}-{self.release} fab_order update")
+            logger.debug(
+                "fab_order_update_deduplicated",
+                job=self.job_id,
+                release=self.release,
+            )
             raise ValueError("Event already exists")
         
         # 4️⃣ Update job fields
@@ -145,13 +154,23 @@ class UpdateFabOrderCommand:
                 from app.brain.job_log.scheduling.service import recalculate_all_jobs_scheduling
                 recalculate_all_jobs_scheduling(stage_group='FABRICATION')
             except Exception as e:
-                logger.error(f"Scheduling recalculation failed after fab_order update: {e}", exc_info=True)
+                logger.error(
+                    "scheduling_recalc_failed",
+                    job=self.job_id,
+                    release=self.release,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
 
-        logger.info(f"update_fab_order completed successfully", extra={
-            'job': self.job_id,
-            'release': self.release,
-            'event_id': event.id
-        })
+        logger.info(
+            "fab_order_updated",
+            release_id=job_record.id,
+            job=self.job_id,
+            release=self.release,
+            event_id=event.id,
+            fab_order=self.fab_order,
+        )
         
         # 8️⃣ Return structured result
         return FabOrderUpdateResult(

--- a/app/brain/job_log/features/fab_order/fix_null_fab_orders.py
+++ b/app/brain/job_log/features/fab_order/fix_null_fab_orders.py
@@ -23,6 +23,9 @@ import argparse
 from app import create_app
 from app.models import Releases, db
 from app.api.helpers import DEFAULT_FAB_ORDER, _get_all_variants_for_stages
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def fix_null_fab_orders(dry_run=True):
@@ -43,17 +46,27 @@ def fix_null_fab_orders(dry_run=True):
         Releases.is_archived != True,              # noqa: E712
     ).all()
 
-    print(f"\nFound {len(releases)} releases with NULL fab_order\n")
+    logger.debug("null_fab_orders_found", count=len(releases))
     for r in releases:
-        print(f"  {r.job}-{r.release}  stage={r.stage!r}  fab_order={r.fab_order!r}")
+        logger.debug(
+            "null_fab_order_row",
+            job=r.job,
+            release=r.release,
+            stage=r.stage,
+            fab_order=r.fab_order,
+        )
 
     if not releases:
-        print("Nothing to fix.")
+        logger.debug("null_fab_orders_none")
         return
 
     if dry_run:
-        print(f"\nWould set fab_order={DEFAULT_FAB_ORDER}, stage='Released', stage_group='FABRICATION'")
-        print("DRY RUN -- no changes made. Use --commit to apply.")
+        logger.debug(
+            "null_fab_orders_dry_run",
+            count=len(releases),
+            fab_order=DEFAULT_FAB_ORDER,
+        )
+        logger.debug("null_fab_orders_dry_run_no_changes")
     else:
         for r in releases:
             r.fab_order = DEFAULT_FAB_ORDER
@@ -61,7 +74,11 @@ def fix_null_fab_orders(dry_run=True):
                 r.stage = 'Released'
                 r.stage_group = 'FABRICATION'
         db.session.commit()
-        print(f"\nUpdated {len(releases)} records: fab_order={DEFAULT_FAB_ORDER}, stage defaults applied")
+        logger.info(
+            "null_fab_orders_fixed",
+            count=len(releases),
+            fab_order=DEFAULT_FAB_ORDER,
+        )
 
 
 if __name__ == "__main__":

--- a/app/brain/job_log/features/fab_order/migrate_unified.py
+++ b/app/brain/job_log/features/fab_order/migrate_unified.py
@@ -69,7 +69,14 @@ def renumber_fab_orders(dry_run=False):
     complete_releases = Releases.query.filter(active_filter, Releases.stage.in_(complete_variants)).all()
     for r in complete_releases:
         if r.fab_order is not None:
-            logger.info(f"Complete: {r.job}-{r.release} ({r.stage}) fab_order {r.fab_order} -> NULL")
+            logger.debug(
+                "fab_order_cleared",
+                job=r.job,
+                release=r.release,
+                stage=r.stage,
+                from_fab_order=r.fab_order,
+                to_fab_order=None,
+            )
             r.fab_order = None
             stats['complete_cleared'] += 1
 
@@ -79,7 +86,15 @@ def renumber_fab_orders(dry_run=False):
     tier_0_releases = Releases.query.filter(active_filter, Releases.stage.in_(tier_0_variants)).all()
     for r in tier_0_releases:
         if r.fab_order != 0:
-            logger.info(f"Tier 0: {r.job}-{r.release} ({r.stage}) fab_order {r.fab_order} -> 0")
+            logger.debug(
+                "fab_order_assigned",
+                tier=0,
+                job=r.job,
+                release=r.release,
+                stage=r.stage,
+                from_fab_order=r.fab_order,
+                to_fab_order=0,
+            )
             r.fab_order = 0
             stats['fixed_tier_0'] += 1
 
@@ -89,7 +104,15 @@ def renumber_fab_orders(dry_run=False):
     tier_1_releases = Releases.query.filter(active_filter, Releases.stage.in_(tier_1_variants)).all()
     for r in tier_1_releases:
         if r.fab_order != 1:
-            logger.info(f"Tier 1: {r.job}-{r.release} ({r.stage}) fab_order {r.fab_order} -> 1")
+            logger.debug(
+                "fab_order_assigned",
+                tier=1,
+                job=r.job,
+                release=r.release,
+                stage=r.stage,
+                from_fab_order=r.fab_order,
+                to_fab_order=1,
+            )
             r.fab_order = 1
             stats['fixed_tier_1'] += 1
 
@@ -99,7 +122,15 @@ def renumber_fab_orders(dry_run=False):
     tier_2_releases = Releases.query.filter(active_filter, Releases.stage.in_(tier_2_variants)).all()
     for r in tier_2_releases:
         if r.fab_order != 2:
-            logger.info(f"Tier 2: {r.job}-{r.release} ({r.stage}) fab_order {r.fab_order} -> 2")
+            logger.debug(
+                "fab_order_assigned",
+                tier=2,
+                job=r.job,
+                release=r.release,
+                stage=r.stage,
+                from_fab_order=r.fab_order,
+                to_fab_order=2,
+            )
             r.fab_order = 2
             stats['fixed_tier_2'] += 1
 
@@ -115,9 +146,13 @@ def renumber_fab_orders(dry_run=False):
 
         for r in stage_releases:
             if r.fab_order != next_fab_order:
-                logger.info(
-                    f"Dynamic: {r.job}-{r.release} ({r.stage}) "
-                    f"fab_order {r.fab_order} -> {next_fab_order}"
+                logger.debug(
+                    "fab_order_assigned",
+                    job=r.job,
+                    release=r.release,
+                    stage=r.stage,
+                    from_fab_order=r.fab_order,
+                    to_fab_order=next_fab_order,
                 )
                 r.fab_order = next_fab_order
                 stats['dynamic'] += 1
@@ -132,10 +167,26 @@ def renumber_fab_orders(dry_run=False):
     )
 
     if dry_run:
-        logger.info(f"DRY RUN — rolling back. Stats: {stats}")
+        logger.debug(
+            "fab_order_migration_dry_run",
+            count=stats['total'],
+            complete_cleared=stats['complete_cleared'],
+            fixed_tier_0=stats['fixed_tier_0'],
+            fixed_tier_1=stats['fixed_tier_1'],
+            fixed_tier_2=stats['fixed_tier_2'],
+            dynamic=stats['dynamic'],
+        )
         db.session.rollback()
     else:
         db.session.commit()
-        logger.info(f"Migration complete. Stats: {stats}")
+        logger.info(
+            "fab_order_migration_complete",
+            count=stats['total'],
+            complete_cleared=stats['complete_cleared'],
+            fixed_tier_0=stats['fixed_tier_0'],
+            fixed_tier_1=stats['fixed_tier_1'],
+            fixed_tier_2=stats['fixed_tier_2'],
+            dynamic=stats['dynamic'],
+        )
 
     return stats

--- a/app/brain/job_log/features/notes/command.py
+++ b/app/brain/job_log/features/notes/command.py
@@ -68,7 +68,7 @@ class UpdateNotesCommand:
             job=self.job_id, release=self.release
         ).first()
         if not job_record:
-            logger.warning(f"Job not found: {self.job_id}-{self.release}")
+            logger.debug("job_not_found", job=self.job_id, release=self.release)
             raise ValueError(f"Job {self.job_id}-{self.release} not found")
 
         old_notes = job_record.notes
@@ -85,8 +85,10 @@ class UpdateNotesCommand:
             payload=event_payload,
         )
         if event is None:
-            logger.info(
-                f"Event already exists for job {self.job_id}-{self.release} notes update"
+            logger.debug(
+                "notes_update_deduplicated",
+                job=self.job_id,
+                release=self.release,
             )
             raise ValueError("Event already exists")
 
@@ -103,26 +105,34 @@ class UpdateNotesCommand:
                     event_id=event.id,
                 )
                 outbox_item_created = True
-                logger.info(
-                    f"Outbox item created for Trello notes update "
-                    f"(job {self.job_id}-{self.release})"
+                logger.debug(
+                    "notes_outbox_queued",
+                    job=self.job_id,
+                    release=self.release,
+                    event_id=event.id,
                 )
             except Exception as outbox_error:
                 logger.error(
-                    f"Failed to create outbox for event {event.id}: {outbox_error}",
+                    "notes_outbox_failed",
+                    job=self.job_id,
+                    release=self.release,
+                    event_id=event.id,
+                    error=str(outbox_error),
+                    error_type=type(outbox_error).__name__,
                     exc_info=True,
                 )
         else:
             if not job_record.trello_card_id:
-                logger.warning(
-                    f"Job {self.job_id}-{self.release} has no trello_card_id, "
-                    f"skipping Trello update",
-                    extra={'job': self.job_id, 'release': self.release},
+                logger.debug(
+                    "trello_push_skipped_no_card",
+                    job=self.job_id,
+                    release=self.release,
                 )
             elif not notes:
-                logger.info(
-                    f"Notes is empty for job {self.job_id}-{self.release}, "
-                    f"skipping Trello comment"
+                logger.debug(
+                    "notes_trello_skipped_empty",
+                    job=self.job_id,
+                    release=self.release,
                 )
 
         if not outbox_item_created:
@@ -131,8 +141,11 @@ class UpdateNotesCommand:
         db.session.commit()
 
         logger.info(
-            "update_notes completed successfully",
-            extra={'job': self.job_id, 'release': self.release, 'event_id': event.id},
+            "notes_updated",
+            release_id=job_record.id,
+            job=self.job_id,
+            release=self.release,
+            event_id=event.id,
         )
 
         return NotesUpdateResult(

--- a/app/brain/job_log/features/stage/command.py
+++ b/app/brain/job_log/features/stage/command.py
@@ -108,7 +108,7 @@ class UpdateStageCommand:
             job=self.job_id, release=self.release
         ).first()
         if not job_record:
-            logger.warning(f"Job not found: {self.job_id}-{self.release}")
+            logger.debug("job_not_found", job=self.job_id, release=self.release)
             raise ValueError(f"Job {self.job_id}-{self.release} not found")
 
         old_stage = job_record.stage if job_record.stage else 'Released'
@@ -131,9 +131,11 @@ class UpdateStageCommand:
                 ReleasePhoto.is_deleted.is_(False),
             ).first() is not None
             if not has_photo:
-                logger.info(
-                    f"Stage gate blocked {self.job_id}-{self.release} -> {self.stage}: "
-                    f"no photo tagged '{self.stage}'"
+                logger.debug(
+                    "stage_gate_blocked",
+                    job=self.job_id,
+                    release=self.release,
+                    stage=self.stage,
                 )
                 raise StagePhotoRequiredError(self.stage)
 
@@ -167,17 +169,24 @@ class UpdateStageCommand:
             payload=event_payload,
         )
         if event is None:
-            logger.info(
-                f"Event already exists for job {self.job_id}-{self.release} to stage {self.stage}"
+            logger.debug(
+                "stage_update_deduplicated",
+                job=self.job_id,
+                release=self.release,
+                to_stage=self.stage,
             )
             raise ValueError("Event already exists")
 
         old_stage_group = job_record.stage_group
         new_stage_group = get_stage_group_from_stage(self.stage)
-        logger.info(
-            f"Stage change for job {self.job_id}-{self.release}: "
-            f"old_stage_group={old_stage_group}, new_stage_group={new_stage_group}, "
-            f"old_stage={old_stage}, new_stage={self.stage}"
+        logger.debug(
+            "stage_group_resolved",
+            job=self.job_id,
+            release=self.release,
+            old_stage_group=old_stage_group,
+            new_stage_group=new_stage_group,
+            from_stage=old_stage,
+            to_stage=self.stage,
         )
 
         fab_order_to_set = None
@@ -185,10 +194,14 @@ class UpdateStageCommand:
         tier = get_fixed_tier(self.stage)
         if tier is not None:
             fab_order_to_set = tier
-            logger.info(
-                f"Job {self.job_id}-{self.release} moving to fixed tier {tier} "
-                f"stage '{self.stage}'. Will set fab_order from "
-                f"{old_fab_order_for_update} to {fab_order_to_set}"
+            logger.debug(
+                "fab_order_fixed_tier_planned",
+                job=self.job_id,
+                release=self.release,
+                stage=self.stage,
+                tier=tier,
+                old=old_fab_order_for_update,
+                new=fab_order_to_set,
             )
         elif self.stage == "Welded QC" and old_stage_group != "READY_TO_SHIP":
             # Department handoff: Fab → Paint. Land at the back of the paint
@@ -207,10 +220,13 @@ class UpdateStageCommand:
             ).scalar()
             base = current_max if current_max is not None and current_max >= 2 else 2
             fab_order_to_set = base + 1
-            logger.info(
-                f"Job {self.job_id}-{self.release} crossing Fab→R2S into Welded QC. "
-                f"Will set fab_order from {old_fab_order_for_update} to {fab_order_to_set} "
-                f"(max(WQC+PaintStart)={current_max})"
+            logger.debug(
+                "fab_order_paint_handoff_planned",
+                job=self.job_id,
+                release=self.release,
+                old=old_fab_order_for_update,
+                new=fab_order_to_set,
+                current_max=current_max,
             )
 
         # Apply stage + stage_group
@@ -334,9 +350,10 @@ class UpdateStageCommand:
                 },
             )
             if fab_order_event is None:
-                logger.warning(
-                    f"Event already exists for fab_order clear on job "
-                    f"{self.job_id}-{self.release}"
+                logger.debug(
+                    "fab_order_clear_deduplicated",
+                    job=self.job_id,
+                    release=self.release,
                 )
             else:
                 job_record.fab_order = None
@@ -366,9 +383,10 @@ class UpdateStageCommand:
                 },
             )
             if fab_order_event is None:
-                logger.warning(
-                    f"Event already exists for fab_order update on job "
-                    f"{self.job_id}-{self.release}"
+                logger.debug(
+                    "fab_order_update_deduplicated",
+                    job=self.job_id,
+                    release=self.release,
                 )
             else:
                 job_record.fab_order = fab_order_to_set
@@ -410,48 +428,59 @@ class UpdateStageCommand:
                     event_id=event.id,
                 )
                 outbox_item_created = True
-                logger.info(
-                    f"Outbox item created for Trello list move "
-                    f"(job {self.job_id}-{self.release}, stage={self.stage}, "
-                    f"target_list={target_list})"
+                logger.debug(
+                    "stage_outbox_queued",
+                    job=self.job_id,
+                    release=self.release,
+                    stage=self.stage,
+                    target_list=target_list,
                 )
             except Exception as outbox_error:
                 logger.error(
-                    f"Failed to create outbox for event {event.id}: {outbox_error}",
+                    "stage_outbox_failed",
+                    job=self.job_id,
+                    release=self.release,
+                    event_id=event.id,
+                    error=str(outbox_error),
+                    error_type=type(outbox_error).__name__,
                     exc_info=True,
                 )
         else:
             if is_hold:
-                logger.info(
-                    "Skipping Trello push for Hold transition — card stays on its current list",
-                    extra={'job': self.job_id, 'release': self.release},
+                logger.debug(
+                    "stage_trello_skipped_hold",
+                    job=self.job_id,
+                    release=self.release,
                 )
             elif target_list is None:
-                logger.info(
-                    "Skipping Trello push — stage has no forward-mapped Trello list",
-                    extra={'job': self.job_id, 'release': self.release, 'stage': self.stage},
+                logger.debug(
+                    "stage_trello_skipped_no_mapping",
+                    job=self.job_id,
+                    release=self.release,
+                    stage=self.stage,
                 )
             elif not should_push:
-                logger.info(
-                    "Skipping Trello push — target list matches current list",
-                    extra={
-                        'job': self.job_id, 'release': self.release,
-                        'stage': self.stage,
-                        'current_list': job_record.trello_list_name,
-                        'target_list': target_list,
-                    },
+                logger.debug(
+                    "stage_trello_skipped_same_list",
+                    job=self.job_id,
+                    release=self.release,
+                    stage=self.stage,
+                    current_list=job_record.trello_list_name,
+                    target_list=target_list,
                 )
             elif not new_list_id:
                 logger.warning(
-                    f"Could not resolve Trello list ID for stage '{self.stage}' "
-                    f"(target_list={target_list}), skipping Trello update",
-                    extra={'job': self.job_id, 'release': self.release, 'stage': self.stage},
+                    "stage_trello_list_unresolved",
+                    job=self.job_id,
+                    release=self.release,
+                    stage=self.stage,
+                    target_list=target_list,
                 )
             elif not job_record.trello_card_id:
-                logger.warning(
-                    f"Job {self.job_id}-{self.release} has no trello_card_id, "
-                    f"skipping Trello update",
-                    extra={'job': self.job_id, 'release': self.release},
+                logger.debug(
+                    "trello_push_skipped_no_card",
+                    job=self.job_id,
+                    release=self.release,
                 )
 
         if not outbox_item_created:
@@ -465,14 +494,22 @@ class UpdateStageCommand:
                 recalculate_all_jobs_scheduling(stage_group='FABRICATION')
             except Exception as cascade_err:
                 logger.error(
-                    f"Scheduling cascade failed after stage change for "
-                    f"{self.job_id}-{self.release}: {cascade_err}",
+                    "scheduling_recalc_failed",
+                    job=self.job_id,
+                    release=self.release,
+                    error=str(cascade_err),
+                    error_type=type(cascade_err).__name__,
                     exc_info=True,
                 )
 
         logger.info(
-            "update_stage completed successfully",
-            extra={'job': self.job_id, 'release': self.release, 'event_id': event.id},
+            "stage_updated",
+            release_id=job_record.id,
+            job=self.job_id,
+            release=self.release,
+            event_id=event.id,
+            from_stage=old_stage,
+            to_stage=self.stage,
         )
 
         return StageUpdateResult(

--- a/app/brain/job_log/features/start_install/assign_installer.py
+++ b/app/brain/job_log/features/start_install/assign_installer.py
@@ -59,7 +59,7 @@ class AssignInstallerCommand:
             job=self.job_id, release=self.release
         ).first()
         if not job_record:
-            logger.warning(f"Job not found: {self.job_id}-{self.release}")
+            logger.debug("job_not_found", job=self.job_id, release=self.release)
             raise ValueError(f"Job {self.job_id}-{self.release} not found")
 
         new_installer = self.installer.strip() if self.installer and self.installer.strip() else None
@@ -77,8 +77,10 @@ class AssignInstallerCommand:
             payload=event_payload,
         )
         if event is None:
-            logger.info(
-                f"Event already exists for job {self.job_id}-{self.release} installer update"
+            logger.debug(
+                "installer_update_deduplicated",
+                job=self.job_id,
+                release=self.release,
             )
             raise ValueError("Event already exists")
 
@@ -92,8 +94,10 @@ class AssignInstallerCommand:
             target_list_id = entry["id"] if entry else None
             if not target_list_id:
                 logger.warning(
-                    f"No Trello list found matching installer '{new_installer}'; "
-                    f"skipping mirror move for job {self.job_id}-{self.release}"
+                    "installer_list_not_found",
+                    installer=new_installer,
+                    job=self.job_id,
+                    release=self.release,
                 )
         else:
             target_list_id = Config.UNASSIGNED_CARDS_LIST_ID
@@ -101,19 +105,26 @@ class AssignInstallerCommand:
         if job_record.trello_card_id and target_list_id:
             try:
                 move_mirror_card(job_record.trello_card_id, target_list_id)
-                logger.info(
-                    f"Mirror card moved for job {self.job_id}-{self.release} "
-                    f"(installer={new_installer or 'Unassigned'})"
+                logger.debug(
+                    "mirror_card_moved",
+                    job=self.job_id,
+                    release=self.release,
+                    installer=new_installer or 'Unassigned',
                 )
             except Exception as trello_error:
                 logger.error(
-                    f"Failed to move mirror card for job {self.job_id}-{self.release}: {trello_error}",
+                    "mirror_card_move_failed",
+                    job=self.job_id,
+                    release=self.release,
+                    error=str(trello_error),
+                    error_type=type(trello_error).__name__,
                     exc_info=True,
                 )
         elif not job_record.trello_card_id:
-            logger.warning(
-                f"Job {self.job_id}-{self.release} has no trello_card_id, skipping mirror move",
-                extra={'job': self.job_id, 'release': self.release},
+            logger.debug(
+                "mirror_move_skipped_no_card",
+                job=self.job_id,
+                release=self.release,
             )
 
         # When assigning to a team (not clearing), seed the mirror card's date bar to
@@ -132,18 +143,27 @@ class AssignInstallerCommand:
                     mirror_id = range_result.get("mirror_card_id")
                     if mirror_id:
                         job_record.mirror_trello_card_id = mirror_id
-                    logger.info(
-                        f"Mirror date range set for job {self.job_id}-{self.release} "
-                        f"[{job_record.start_install} -> {comp_eta}]"
+                    logger.debug(
+                        "mirror_date_range_set",
+                        job=self.job_id,
+                        release=self.release,
+                        start_install=job_record.start_install.isoformat() if job_record.start_install else None,
+                        comp_eta=comp_eta.isoformat() if comp_eta else None,
                     )
                 else:
                     logger.warning(
-                        f"Could not set mirror date range for job {self.job_id}-{self.release}: "
-                        f"{range_result.get('error')}"
+                        "mirror_date_range_failed",
+                        job=self.job_id,
+                        release=self.release,
+                        error=range_result.get('error'),
                     )
             except Exception as range_error:
                 logger.error(
-                    f"Failed to set mirror date range for job {self.job_id}-{self.release}: {range_error}",
+                    "mirror_date_range_error",
+                    job=self.job_id,
+                    release=self.release,
+                    error=str(range_error),
+                    error_type=type(range_error).__name__,
                     exc_info=True,
                 )
 
@@ -151,8 +171,12 @@ class AssignInstallerCommand:
         db.session.commit()
 
         logger.info(
-            "update_installer completed successfully",
-            extra={'job': self.job_id, 'release': self.release, 'event_id': event.id},
+            "installer_assigned",
+            release_id=job_record.id,
+            job=self.job_id,
+            release=self.release,
+            event_id=event.id,
+            installer=new_installer,
         )
 
         return AssignInstallerResult(

--- a/app/brain/job_log/features/start_install/command.py
+++ b/app/brain/job_log/features/start_install/command.py
@@ -71,7 +71,7 @@ class UpdateStartInstallCommand:
             job=self.job_id, release=self.release
         ).first()
         if not job_record:
-            logger.warning(f"Job not found: {self.job_id}-{self.release}")
+            logger.debug("job_not_found", job=self.job_id, release=self.release)
             raise ValueError(f"Job {self.job_id}-{self.release} not found")
 
         old_start_install = job_record.start_install
@@ -96,8 +96,10 @@ class UpdateStartInstallCommand:
             payload=event_payload,
         )
         if event is None:
-            logger.info(
-                f"Event already exists for job {self.job_id}-{self.release} start_install update"
+            logger.debug(
+                "start_install_update_deduplicated",
+                job=self.job_id,
+                release=self.release,
             )
             raise ValueError("Event already exists")
 
@@ -125,20 +127,25 @@ class UpdateStartInstallCommand:
                     new_due_date=self.start_install,
                     clear_due_date=(self.start_install is None),
                 )
-                logger.info(
-                    f"Trello card due date updated for job {self.job_id}-{self.release} "
-                    f"(start_install sent as due date)"
+                logger.debug(
+                    "trello_due_date_pushed",
+                    job=self.job_id,
+                    release=self.release,
                 )
             except Exception as trello_error:
                 logger.error(
-                    f"Failed to update Trello card due date for job "
-                    f"{self.job_id}-{self.release}: {trello_error}",
+                    "trello_due_date_push_failed",
+                    job=self.job_id,
+                    release=self.release,
+                    error=str(trello_error),
+                    error_type=type(trello_error).__name__,
                     exc_info=True,
                 )
         else:
-            logger.warning(
-                f"Job {self.job_id}-{self.release} has no trello_card_id, skipping Trello update",
-                extra={'job': self.job_id, 'release': self.release},
+            logger.debug(
+                "trello_push_skipped_no_card",
+                job=self.job_id,
+                release=self.release,
             )
 
         JobEventService.close(event.id)
@@ -149,13 +156,22 @@ class UpdateStartInstallCommand:
             recalculate_all_jobs_scheduling(stage_group='FABRICATION')
         except Exception as cascade_error:
             logger.error(
-                f"Scheduling cascade failed after hard-date update: {cascade_error}",
+                "scheduling_recalc_failed",
+                job=self.job_id,
+                release=self.release,
+                error=str(cascade_error),
+                error_type=type(cascade_error).__name__,
                 exc_info=True,
             )
 
         logger.info(
-            "update_start_install completed successfully",
-            extra={'job': self.job_id, 'release': self.release, 'event_id': event.id},
+            "start_install_updated",
+            release_id=job_record.id,
+            job=self.job_id,
+            release=self.release,
+            event_id=event.id,
+            start_install=self.start_install.isoformat() if self.start_install else None,
+            is_hard_date=self.is_hard_date,
         )
 
         return StartInstallUpdateResult(

--- a/app/brain/job_log/routes.py
+++ b/app/brain/job_log/routes.py
@@ -68,7 +68,7 @@ def get_list_id_by_stage(stage):
 
     trello_list_name = TrelloListMapper.get_trello_list_for_stage(stage)
     if trello_list_name is None:
-        logger.info(f"Stage '{stage}' has no Trello list mapping, skipping outbox creation")
+        logger.debug("trello_outbox_creation_skipped", stage=stage, reason="no_list_mapping")
         return None
 
     from flask import current_app
@@ -83,20 +83,20 @@ def get_list_id_by_stage(stage):
         if list_info and 'id' in list_info:
             return list_info['id']
         else:
-            logger.warning(f"Could not get list ID for stage '{stage}' → list '{trello_list_name}' (list_info: {list_info})")
+            logger.warning("trello_list_id_missing", stage=stage, trello_list=trello_list_name, list_info=list_info)
             return None
     except Exception as e:
-        logger.error(f"Error getting list ID for stage '{stage}': {e}", exc_info=True)
+        logger.error("trello_list_id_lookup_failed", stage=stage, error=str(e), error_type=type(e).__name__, exc_info=True)
         return None
 
 def update_job_stage_fields(job_record, stage):
     """Apply stage update to job record - sets the stage field directly and updates stage_group."""
     from app.api.helpers import get_stage_group_from_stage
     
-    logger.info(f"Updating job {job_record.job}-{job_record.release} stage to: {stage}")
+    logger.info("stage_fields_updated", job=job_record.job, release=job_record.release, stage=stage)
     job_record.stage = stage
     job_record.stage_group = get_stage_group_from_stage(stage)
-    logger.debug(f"Job stage updated to: {stage}, stage_group updated to: {job_record.stage_group}")
+    logger.debug("stage_group_recalculated", stage=stage, stage_group=job_record.stage_group)
 
 def create_trello_card_for_job(job, excel_data_dict, idempotency_check=False):
     """
@@ -118,7 +118,7 @@ def create_trello_card_for_job(job, excel_data_dict, idempotency_check=False):
     try:
         # Skip if job already has a Trello card
         if job.trello_card_id:
-            logger.info(f"Job {job.job}-{job.release} already has Trello card {job.trello_card_id}, skipping creation")
+            logger.debug("trello_card_creation_skipped", job=job.job, release=job.release, card_id=job.trello_card_id, reason="card_exists")
             return None
         
         # Import Trello functions
@@ -137,7 +137,7 @@ def create_trello_card_for_job(job, excel_data_dict, idempotency_check=False):
         if not target_list:
             # Fall back to configured new-card list
             list_id = cfg.NEW_TRELLO_CARD_LIST_ID
-            logger.warning(f"List '{list_name}' not found, using default list")
+            logger.warning("trello_list_not_found", trello_list=list_name, fallback="default_list")
         else:
             list_id = target_list["id"]
         
@@ -199,18 +199,15 @@ def create_trello_card_for_job(job, excel_data_dict, idempotency_check=False):
         success = update_job_record_with_trello_data(job, card_data)
 
         if success:
-            logger.info(f"Successfully updated database record with Trello data")
+            logger.info("release_trello_fields_updated", job=job.job, release=job.release, card_id=card_id)
         else:
-            logger.error(f"Failed to update database record with Trello data")
+            logger.error("release_trello_fields_update_failed", job=job.job, release=job.release, card_id=card_id)
 
         if adopted:
             # Skip Fab Order / FC Drawing / notes / mirror — these aren't
             # idempotent and were applied by the original attempt that
             # produced this card.
-            logger.warning(
-                f"Adopted existing Trello card {card_id} for job {job.job}-{job.release}; "
-                f"skipping post-creation features"
-            )
+            logger.warning("trello_card_adopted", job=job.job, release=job.release, card_id=card_id)
             mirror_card_id = None
         else:
             fab_order_value = excel_data_dict.get('Fab Order') or job.fab_order
@@ -237,7 +234,7 @@ def create_trello_card_for_job(job, excel_data_dict, idempotency_check=False):
         }
         
     except Exception as e:
-        logger.error(f"Error creating Trello card for job {job.job}-{job.release}: {str(e)}", exc_info=True)
+        logger.error("trello_card_creation_failed", job=job.job, release=job.release, error=str(e), error_type=type(e).__name__, exc_info=True)
         return {
             "success": False,
             "error": str(e)
@@ -479,28 +476,28 @@ def get_jobs():
             try:
                 since_timestamp = datetime.fromisoformat(since_param.replace('Z', '+00:00'))
                 query = query.filter(Releases.last_updated_at > since_timestamp)
-                logger.debug(f"[CURSOR] Filtering jobs updated after: {since_timestamp}")
+                logger.debug("cursor_filter_applied", since=str(since_timestamp))
                 # Cursor polls skip the archive filter so soft-deleted rows always propagate
             except (ValueError, TypeError) as e:
-                logger.warning(f"[CURSOR] Invalid since parameter: {since_param}, error: {e}. Fetching all jobs.")
+                logger.warning("cursor_since_param_invalid", since=since_param, error=str(e), error_type=type(e).__name__)
                 since_param = None  # fall through to full-load path
 
         if not since_param:
-            logger.info(f"[CURSOR] No since parameter provided - fetching all jobs (initial load)")
+            logger.debug("cursor_full_load", archived=archived)
             # Apply archive filter only on full loads
             if archived:
                 query = query.filter(Releases.is_archived == True)
-                logger.info("[ARCHIVE] Filtering to archived jobs (is_archived=True)")
+                logger.info("archive_filter_applied", archived=True)
             else:
                 query = query.filter(db.or_(Releases.is_archived == False, Releases.is_archived == None))
-                logger.info("[ARCHIVE] Excluding archived jobs")
+                logger.info("archive_filter_applied", archived=False)
             # Exclude soft-deleted rows on full loads
             query = query.filter(db.or_(Releases.is_active == True, Releases.is_active == None))
 
         # Order by last_updated_at, id for deterministic results
         query = query.order_by(Releases.last_updated_at.asc(), Releases.id.asc())
         jobs = query.limit(limit).all()
-        logger.debug(f"[CURSOR] Query returned {len(jobs)} jobs (limit={limit})")
+        logger.debug("cursor_query_returned", count=len(jobs), limit=limit)
 
         job_list = []
         warnings = []
@@ -558,14 +555,13 @@ def get_jobs():
             except Exception as record_error:
                 # Log the problematic record but continue processing
                 job_id = f"{job.job}-{job.release}" if hasattr(job, 'job') else f"id:{job.id}"
-                error_msg = f"Error serializing record {idx} ({job_id}): {str(record_error)}"
                 warnings.append({
                     'record_index': idx,
                     'job_id': job_id,
                     'error': str(record_error),
                     'error_type': type(record_error).__name__
                 })
-                logger.warning(error_msg, exc_info=True)
+                logger.warning("release_serialize_failed", record_index=idx, job_release=job_id, error=str(record_error), error_type=type(record_error).__name__, exc_info=True)
                 continue
 
         # Patch has_drawing in one batched query (avoids N+1)
@@ -575,7 +571,9 @@ def get_jobs():
                 j['has_drawing'] = j['id'] in ids_with_drawings
         except Exception as drawing_lookup_error:
             logger.warning(
-                f"Error batching has_drawing flags: {drawing_lookup_error}",
+                "has_drawing_batch_failed",
+                error=str(drawing_lookup_error),
+                error_type=type(drawing_lookup_error).__name__,
                 exc_info=True,
             )
 
@@ -594,7 +592,9 @@ def get_jobs():
                 j['procore_project_id'] = ref['procore_project_id'] if ref else None
         except Exception as procore_ref_error:
             logger.warning(
-                f"Error batching procore submittal refs: {procore_ref_error}",
+                "procore_submittal_refs_batch_failed",
+                error=str(procore_ref_error),
+                error_type=type(procore_ref_error).__name__,
                 exc_info=True,
             )
 
@@ -625,7 +625,9 @@ def get_jobs():
                     job['Start install'] = job['install_start_date']
         except Exception as scheduling_error:
             logger.warning(
-                f"Error calculating scheduling fields: {scheduling_error}",
+                "scheduling_fields_calc_failed",
+                error=str(scheduling_error),
+                error_type=type(scheduling_error).__name__,
                 exc_info=True
             )
             # Continue without scheduling fields if calculation fails
@@ -635,12 +637,12 @@ def get_jobs():
         if jobs:
             latest_job = jobs[-1]
             latest_timestamp = latest_job.last_updated_at.isoformat() if latest_job.last_updated_at else None
-            logger.debug(f"[CURSOR] Latest job timestamp: {latest_timestamp}")
+            logger.debug("cursor_latest_timestamp", latest=latest_timestamp)
 
         # Delta polls that returned rows leave exactly one INFO breadcrumb; zero-row
         # delta polls stay silent so steady-state polling doesn't flood the logs.
         if since_param and len(jobs) > 0:
-            logger.info(f"[CURSOR] Delta poll returned {len(jobs)} changed jobs (latest={latest_timestamp})")
+            logger.info("cursor_delta_returned", count=len(jobs), latest=latest_timestamp)
 
         # Build response
         response_data = {
@@ -654,7 +656,7 @@ def get_jobs():
         return jsonify(response_data), 200
         
     except Exception as e:
-        logger.error("Error in /jobs endpoint", error=str(e), exc_info=True)
+        logger.error("jobs_fetch_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e), 'error_type': type(e).__name__}), 500
 
 
@@ -726,7 +728,7 @@ def job_search():
         }), 200
 
     except Exception as e:
-        logger.error("Error in /job-search endpoint", error=str(e), exc_info=True)
+        logger.error("job_search_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e), 'error_type': type(e).__name__}), 500
 
 
@@ -845,10 +847,10 @@ def get_all_jobs():
         # Apply archive filter
         if archived:
             query = query.filter(Releases.is_archived == True)
-            logger.info("[ARCHIVE] Filtering to archived jobs (is_archived=True)")
+            logger.info("archive_filter_applied", archived=True)
         else:
             query = query.filter(db.or_(Releases.is_archived == False, Releases.is_archived == None))
-            logger.info("[ARCHIVE] Excluding archived jobs")
+            logger.info("archive_filter_applied", archived=False)
 
         # Exclude soft-deleted rows
         query = query.filter(db.or_(Releases.is_active == True, Releases.is_active == None))
@@ -917,14 +919,13 @@ def get_all_jobs():
             except Exception as record_error:
                 # Log the problematic record but continue processing
                 job_id = f"{job.job}-{job.release}" if hasattr(job, 'job') else f"id:{job.id}"
-                error_msg = f"Error serializing record {idx} ({job_id}): {str(record_error)}"
                 warnings.append({
                     'record_index': idx,
                     'job_id': job_id,
                     'error': str(record_error),
                     'error_type': type(record_error).__name__
                 })
-                logger.warning(error_msg, exc_info=True)
+                logger.warning("release_serialize_failed", record_index=idx, job_release=job_id, error=str(record_error), error_type=type(record_error).__name__, exc_info=True)
                 continue
 
         # Patch has_drawing in one batched query (avoids N+1)
@@ -934,7 +935,9 @@ def get_all_jobs():
                 j['has_drawing'] = j['id'] in ids_with_drawings
         except Exception as drawing_lookup_error:
             logger.warning(
-                f"Error batching has_drawing flags: {drawing_lookup_error}",
+                "has_drawing_batch_failed",
+                error=str(drawing_lookup_error),
+                error_type=type(drawing_lookup_error).__name__,
                 exc_info=True,
             )
 
@@ -953,7 +956,9 @@ def get_all_jobs():
                 j['procore_project_id'] = ref['procore_project_id'] if ref else None
         except Exception as procore_ref_error:
             logger.warning(
-                f"Error batching procore submittal refs: {procore_ref_error}",
+                "procore_submittal_refs_batch_failed",
+                error=str(procore_ref_error),
+                error_type=type(procore_ref_error).__name__,
                 exc_info=True,
             )
 
@@ -992,7 +997,9 @@ def get_all_jobs():
                     job['Start install'] = job['install_start_date']
         except Exception as scheduling_error:
             logger.warning(
-                f"Error calculating scheduling fields: {scheduling_error}",
+                "scheduling_fields_calc_failed",
+                error=str(scheduling_error),
+                error_type=type(scheduling_error).__name__,
                 exc_info=True
             )
             # Continue without scheduling fields if calculation fails
@@ -1014,7 +1021,7 @@ def get_all_jobs():
         return jsonify(response_data), 200
         
     except Exception as e:
-        logger.error("Error in /get-all-jobs endpoint", error=str(e), exc_info=True)
+        logger.error("all_jobs_fetch_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e), 'error_type': type(e).__name__}), 500
 
 @brain_bp.route("/gantt-data")
@@ -1143,7 +1150,7 @@ def get_gantt_data():
         }), 200
         
     except Exception as e:
-        logger.error("Error in /gantt-data endpoint", error=str(e), exc_info=True)
+        logger.error("gantt_data_fetch_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e), 'error_type': type(e).__name__}), 500
 
 @brain_bp.route("/update-stage/<int:job>/<release>", methods=["PATCH"])
@@ -1162,9 +1169,7 @@ def update_stage(job, release):
         StagePhotoRequiredError,
     )
 
-    logger.info("update_stage called", extra={
-        'job': job, 'release': release, 'stage': request.json.get('stage'),
-    })
+    logger.debug("stage_update_received", job=job, release=release, stage=request.json.get('stage'))
 
     try:
         stage = request.json.get('stage')
@@ -1195,10 +1200,8 @@ def update_stage(job, release):
         return jsonify({'error': msg}), 400
 
     except Exception as e:
-        logger.error("update_stage failed catastrophically", exc_info=True, extra={
-            'job': job, 'release': release,
-            'error': str(e), 'error_type': type(e).__name__,
-        })
+        logger.error("stage_update_failed", job=job, release=release,
+                     error=str(e), error_type=type(e).__name__, exc_info=True)
         try:
             from app.services.system_log_service import SystemLogService
             SystemLogService.log_error(
@@ -1235,11 +1238,8 @@ def update_fab_order(job, release):
     from app.services.system_log_service import SystemLogService
     from app.models import db
     
-    logger.info(f"update_fab_order called", extra={
-        'job': job,
-        'release': release,
-        'fab_order': request.json.get('fab_order')
-    })
+    logger.debug("fab_order_update_received", job=job, release=release,
+                 fab_order=request.json.get('fab_order'))
 
     try:
         # Extract and validate fab_order from request
@@ -1274,10 +1274,7 @@ def update_fab_order(job, release):
         error_msg = str(e)
         status_code = 404 if 'not found' in error_msg.lower() else 400
         
-        logger.warning(f"update_fab_order validation error: {error_msg}", extra={
-            'job': job,
-            'release': release
-        })
+        logger.warning("fab_order_update_rejected", job=job, release=release, error=error_msg)
         
         return jsonify({
             'error': error_msg,
@@ -1285,12 +1282,8 @@ def update_fab_order(job, release):
         }), status_code
         
     except Exception as e:
-        logger.error(f"update_fab_order failed", exc_info=True, extra={
-            'job': job,
-            'release': release,
-            'error': str(e),
-            'error_type': type(e).__name__
-        })
+        logger.error("fab_order_update_failed", job=job, release=release,
+                     error=str(e), error_type=type(e).__name__, exc_info=True)
         
         try:
             SystemLogService.log_error(
@@ -1334,11 +1327,8 @@ def update_notes(job, release):
     from app.models import db
     from app.brain.job_log.features.notes.command import UpdateNotesCommand
 
-    logger.info(f"update_notes called", extra={
-        'job': job,
-        'release': release,
-        'has_notes': bool(request.json.get('notes'))
-    })
+    logger.debug("notes_update_received", job=job, release=release,
+                 has_notes=bool(request.json.get('notes')))
 
     try:
         notes = request.json.get('notes', '')
@@ -1346,7 +1336,7 @@ def update_notes(job, release):
         # Pre-flight: 404 vs 400 distinction matches the original route contract.
         from app.models import Releases
         if not Releases.query.filter_by(job=job, release=release).first():
-            logger.warning(f"Job not found: {job}-{release}")
+            logger.warning("release_not_found", job=job, release=release)
             return jsonify({'error': 'Job not found'}), 404
 
         try:
@@ -1363,12 +1353,8 @@ def update_notes(job, release):
             'event_id': result.event_id,
         }), 200
     except Exception as e:
-        logger.error(f"update_notes failed", exc_info=True, extra={
-            'job': job,
-            'release': release,
-            'error': str(e),
-            'error_type': type(e).__name__
-        })
+        logger.error("notes_update_failed", job=job, release=release,
+                     error=str(e), error_type=type(e).__name__, exc_info=True)
 
         try:
             from app.services.system_log_service import SystemLogService
@@ -1583,11 +1569,8 @@ def update_start_install(job, release):
     from app.models import Releases, db
     from datetime import datetime, date
     
-    logger.info(f"update_start_install called", extra={
-        'job': job,
-        'release': release,
-        'start_install': request.json.get('start_install')
-    })
+    logger.debug("start_install_update_received", job=job, release=release,
+                 start_install=request.json.get('start_install'))
 
     try:
         start_install_str = request.json.get('start_install')
@@ -1677,7 +1660,12 @@ def update_start_install(job, release):
                         )
                     except Exception as trello_error:
                         logger.error(
-                            f"Failed to push ASAP start_install to Trello due for job {job}-{release}: {trello_error}",
+                            "trello_due_push_failed",
+                            job=job,
+                            release=release,
+                            card_id=job_record.trello_card_id,
+                            error=str(trello_error),
+                            error_type=type(trello_error).__name__,
                             exc_info=True,
                         )
             job_record.last_updated_at = datetime.utcnow()
@@ -1694,11 +1682,13 @@ def update_start_install(job, release):
                     from app.brain.job_log.scheduling.service import recalculate_all_jobs_scheduling
                     recalculate_all_jobs_scheduling(stage_group='FABRICATION')
                 except Exception as cascade_error:
-                    logger.error(f"Scheduling cascade failed after ASAP set: {cascade_error}", exc_info=True)
+                    logger.error("scheduling_cascade_failed", trigger="asap_set", error=str(cascade_error), error_type=type(cascade_error).__name__, exc_info=True)
 
             logger.info(
-                f"ASAP {'set' if new_asap else 'cleared'} for job {job}-{release}",
-                extra={'event_id': event.id},
+                "asap_set" if new_asap else "asap_cleared",
+                job=job,
+                release=release,
+                event_id=event.id,
             )
             return jsonify({
                 'status': 'success',
@@ -1731,7 +1721,7 @@ def update_start_install(job, release):
             if event is None:
                 # Clearing is idempotent — a duplicate within the 30s dedup window means
                 # a prior clear already applied the state change, so report success.
-                logger.info(f"Duplicate clear_hard_date for job {job}-{release}; returning success")
+                logger.debug("clear_hard_date_deduplicated", job=job, release=release)
                 return jsonify({'status': 'success', 'deduplicated': True}), 200
 
             job_record.start_install_formulaTF = True
@@ -1750,7 +1740,7 @@ def update_start_install(job, release):
                         clear_due_date=True
                     )
                 except Exception as trello_error:
-                    logger.error(f"Failed to clear Trello due date for job {job}-{release}: {trello_error}", exc_info=True)
+                    logger.error("trello_due_clear_failed", job=job, release=release, card_id=job_record.trello_card_id, error=str(trello_error), error_type=type(trello_error).__name__, exc_info=True)
 
             JobEventService.close(event.id)
             db.session.commit()
@@ -1760,9 +1750,9 @@ def update_start_install(job, release):
                 from app.brain.job_log.scheduling.service import recalculate_all_jobs_scheduling
                 recalculate_all_jobs_scheduling(stage_group='FABRICATION')
             except Exception as cascade_error:
-                logger.error(f"Scheduling cascade failed after clear hard date: {cascade_error}", exc_info=True)
+                logger.error("scheduling_cascade_failed", trigger="clear_hard_date", error=str(cascade_error), error_type=type(cascade_error).__name__, exc_info=True)
 
-            logger.info(f"Cleared hard date for job {job}-{release}", extra={'event_id': event.id})
+            logger.info("hard_date_cleared", job=job, release=release, event_id=event.id)
             return jsonify({'status': 'success', 'event_id': event.id}), 200
 
         # Parse date string if provided
@@ -1775,7 +1765,7 @@ def update_start_install(job, release):
 
         # Only proceed if it's a hard date
         if not is_hard_date:
-            logger.info(f"Skipping update for job {job}-{release} - not a hard date")
+            logger.debug("start_install_update_skipped", job=job, release=release, reason="not_hard_date")
             return jsonify({
                 'status': 'skipped',
                 'message': 'Not a hard date - formula-driven dates are not updated manually'
@@ -1784,7 +1774,7 @@ def update_start_install(job, release):
         # Pre-flight 404 check — preserves the route's original 404 vs 400 distinction
         # before we delegate to the command.
         if not Releases.query.filter_by(job=job, release=release).first():
-            logger.warning(f"Job not found: {job}-{release}")
+            logger.warning("release_not_found", job=job, release=release)
             return jsonify({'error': 'Job not found'}), 404
 
         has_date = bool(start_install_str and start_install_str.strip())
@@ -1839,12 +1829,8 @@ def update_start_install(job, release):
         }), 200
         
     except Exception as e:
-        logger.error(f"update_start_install failed", exc_info=True, extra={
-            'job': job,
-            'release': release,
-            'error': str(e),
-            'error_type': type(e).__name__
-        })
+        logger.error("start_install_update_failed", job=job, release=release,
+                     error=str(e), error_type=type(e).__name__, exc_info=True)
         
         try:
             from app.services.system_log_service import SystemLogService
@@ -2075,9 +2061,11 @@ def release_job_data():
                 )
                 if pending_si and str(pending_si.job_number or '').strip() != str(job_number):
                     logger.warning(
-                        "PendingStartInstall rel=%s belongs to job %s, not job %s -- skipping "
-                        "start_install handoff for release %s-%s (stale or reused rel?)",
-                        rel_int, pending_si.job_number, job_number, job_number, release_number,
+                        "pending_start_install_job_mismatch",
+                        rel=rel_int,
+                        pending_job=pending_si.job_number,
+                        job=job_number,
+                        release=release_number,
                     )
                     pending_si = None
                 if pending_si and pending_si.start_install:
@@ -2111,8 +2099,11 @@ def release_job_data():
                             JobEventService.close(si_event.id)
                     except Exception as si_event_err:
                         logger.warning(
-                            "Failed to record start_install transfer event for %s-%s: %s",
-                            job_number, release_number, si_event_err,
+                            "start_install_transfer_event_failed",
+                            job=job_number,
+                            release=release_number,
+                            error=str(si_event_err),
+                            error_type=type(si_event_err).__name__,
                         )
                     pending_si.consumed_at = datetime.utcnow()
                     pending_si.consumed_job = job_number
@@ -2137,7 +2128,7 @@ def release_job_data():
                 processed.append(processed_record)
                 
             except Exception as e:
-                logger.error(f"Error processing row {row_idx}: {str(e)}", exc_info=True)
+                logger.error("release_row_process_failed", row=row_idx, error=str(e), error_type=type(e).__name__, exc_info=True)
                 errors.append({
                     'row': row_idx,
                     'error': f'Unexpected error: {str(e)}',
@@ -2157,7 +2148,7 @@ def release_job_data():
         }), 200
         
     except Exception as e:
-        logger.error("Error in /job-log/release endpoint", error=str(e), exc_info=True)
+        logger.error("release_paste_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         db.session.rollback()
         return jsonify({
             'error': str(e),
@@ -2198,7 +2189,7 @@ def get_operation_filters():
 
         return jsonify({'dates': dates, 'types': types, 'total': len(dates)}), 200
     except Exception as e:
-        logger.error("Error in /operations/filters endpoint", error=str(e), exc_info=True)
+        logger.error("operation_filters_fetch_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e), 'error_type': type(e).__name__}), 500
 
 @brain_bp.route("/operations/types")
@@ -2220,7 +2211,7 @@ def get_operation_types():
         
         return jsonify({'types': types, 'total': len(types)}), 200
     except Exception as e:
-        logger.error("Error in /operations/types endpoint", error=str(e), exc_info=True)
+        logger.error("operation_types_fetch_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e), 'error_type': type(e).__name__}), 500
 
 @brain_bp.route("/operations")
@@ -2268,7 +2259,7 @@ def sync_operations():
                 }
             }), 200
         except Exception as e:
-            logger.error("Error getting sync operations", error=str(e))
+            logger.error("sync_operations_query_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
             return jsonify({"error": str(e)}), 500
 
 @brain_bp.route("/operations/<operation_id>/logs")
@@ -2292,7 +2283,7 @@ def sync_operation_logs(operation_id):
             }), 200
             
         except Exception as e:
-            logger.error("Error getting sync operation logs", operation_id=operation_id, error=str(e))
+            logger.error("sync_operation_logs_query_failed", operation_id=operation_id, error=str(e), error_type=type(e).__name__, exc_info=True)
             return jsonify({"error": str(e)}), 500
 
 # ==============================================================================
@@ -2375,7 +2366,7 @@ def get_event_filters():
 
         return jsonify({'dates': dates, 'sources': sources, 'users': users, 'total': len(dates)}), 200
     except Exception as e:
-        logger.error("Error in /events/filters endpoint", error=str(e), exc_info=True)
+        logger.error("event_filters_fetch_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e), 'error_type': type(e).__name__}), 500
 
 def _resolve_event_user_names(all_events):
@@ -2628,7 +2619,7 @@ def get_events():
             }
         }), 200
     except Exception as e:
-        logger.error("Error getting job events", error=str(e))
+        logger.error("job_events_query_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 
@@ -2747,7 +2738,7 @@ def _dispatch_undo(event, *, source, defer_cascade):
                         clear_due_date=(job_record.start_install is None),
                     )
                 except Exception:
-                    logger.error("Failed to realign Trello due on set_asap undo", exc_info=True)
+                    logger.error("trello_due_realign_failed", trigger="set_asap_undo", card_id=job_record.trello_card_id, exc_info=True)
         job_record.last_updated_at = _dt.utcnow()
         job_record.source_of_update = source
         JobEventService.close(new_event.id)
@@ -2863,7 +2854,7 @@ def undo_event(event_id):
             child_result = _dispatch_undo(child, source=source, defer_cascade=True)
             linked_event_ids.append(child_result.event_id)
     except ValueError as ve:
-        logger.warning(f"Undo failed for event {event_id}: {ve}")
+        logger.warning("undo_failed", event_id=event_id, error=str(ve))
         return jsonify({'error': str(ve)}), 400
 
     if has_children:
@@ -2872,7 +2863,11 @@ def undo_event(event_id):
             recalculate_all_jobs_scheduling(stage_group='FABRICATION')
         except Exception as cascade_err:
             logger.error(
-                f"Scheduling cascade failed after bundled undo of event {event_id}: {cascade_err}",
+                "scheduling_cascade_failed",
+                trigger="bundled_undo",
+                event_id=event_id,
+                error=str(cascade_err),
+                error_type=type(cascade_err).__name__,
                 exc_info=True,
             )
 
@@ -3120,12 +3115,12 @@ def trello_scanner():
     try:
         from app.trello.scanner import scan_trello_db_comparison
         
-        logger.info("Trello scanner endpoint called")
+        logger.debug("trello_scan_requested")
         results = scan_trello_db_comparison()
-        
+
         return jsonify(results), 200
     except Exception as e:
-        logger.error(f"Error in Trello scanner: {e}", exc_info=True)
+        logger.error("trello_scan_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 @brain_bp.route("/preview-scheduling", methods=["GET"])
@@ -3165,9 +3160,9 @@ def preview_scheduling():
             try:
                 reference_date = datetime.fromisoformat(reference_date_str.replace('Z', '+00:00')).date()
             except (ValueError, TypeError) as e:
-                logger.warning(f"Invalid reference_date parameter: {reference_date_str}, using today")
-        
-        logger.info(f"Preview scheduling endpoint called (reference_date={reference_date}, show_all={show_all})")
+                logger.warning("reference_date_param_invalid", reference_date=reference_date_str, error=str(e), error_type=type(e).__name__)
+
+        logger.debug("preview_scheduling_requested", reference_date=str(reference_date) if reference_date else None, show_all=show_all)
         
         preview_results = preview_scheduling_changes(
             reference_date=reference_date,
@@ -3187,7 +3182,7 @@ def preview_scheduling():
         return jsonify(preview_results), 200
         
     except Exception as e:
-        logger.error(f"Error in preview scheduling: {e}", exc_info=True)
+        logger.error("preview_scheduling_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({"error": str(e), "error_type": type(e).__name__}), 500
 
 @brain_bp.route("/trello-sync", methods=["POST"])
@@ -3215,12 +3210,12 @@ def trello_sync():
         # Check for dry_run parameter
         dry_run = request.args.get('dry_run', 'false').lower() == 'true'
         
-        logger.info(f"Trello sync endpoint called (dry_run={dry_run})")
+        logger.debug("trello_sync_requested", dry_run=dry_run)
         results = sync_trello_with_db(dry_run=dry_run)
-        
+
         return jsonify(results), 200
     except Exception as e:
-        logger.error(f"Error in Trello sync: {e}", exc_info=True)
+        logger.error("trello_sync_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 @brain_bp.route("/renumber-fab-orders", methods=["POST"])
@@ -3239,12 +3234,12 @@ def renumber_fab_orders_route():
         from app.brain.job_log.features.fab_order.migrate_unified import renumber_fab_orders
 
         dry_run = request.args.get('dry_run', 'false').lower() == 'true'
-        logger.info(f"Renumber fab_orders endpoint called (dry_run={dry_run})")
+        logger.debug("fab_order_renumber_requested", dry_run=dry_run)
 
         stats = renumber_fab_orders(dry_run=dry_run)
         return jsonify({"status": "success", "stats": stats, "dry_run": dry_run}), 200
     except Exception as e:
-        logger.error(f"Error in renumber fab_orders: {e}", exc_info=True)
+        logger.error("fab_order_renumber_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 
@@ -3267,12 +3262,12 @@ def renumber_fabrication_fab_orders_route():
         )
 
         dry_run = request.args.get('dry_run', 'false').lower() == 'true'
-        logger.info(f"Renumber fabrication fab_orders endpoint called (dry_run={dry_run})")
+        logger.debug("fabrication_fab_order_renumber_requested", dry_run=dry_run)
 
         result = renumber_fabrication_fab_orders(dry_run=dry_run)
         return jsonify({"status": "success", "dry_run": dry_run, **result}), 200
     except Exception as e:
-        logger.error(f"Error in renumber fabrication fab_orders: {e}", exc_info=True)
+        logger.error("fabrication_fab_order_renumber_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 
@@ -3309,12 +3304,12 @@ def trello_scan_create():
         # Check for limit parameter
         limit = request.args.get('limit', type=int)
         
-        logger.info(f"Trello scan and create endpoint called (dry_run={dry_run}, limit={limit})")
+        logger.debug("trello_scan_create_requested", dry_run=dry_run, limit=limit)
         results = scan_and_create_cards_for_all_jobs(dry_run=dry_run, limit=limit)
-        
+
         return jsonify(results), 200
     except Exception as e:
-        logger.error(f"Error in Trello scan and create: {e}", exc_info=True)
+        logger.error("trello_scan_create_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 
@@ -3356,7 +3351,7 @@ def delete_job(job, release):
     if err:
         return err
 
-    logger.info(f"Soft-deleting job {job}-{release}")
+    logger.info("release_soft_deleted", job=job, release=release)
     job_record.is_active = False
     job_record.last_updated_at = datetime.utcnow()
     job_record.source_of_update = 'Admin'
@@ -3470,7 +3465,7 @@ def update_job_fields(job, release):
 
     db.session.commit()
 
-    logger.info(f"Updated job {job}-{release} fields: {list(coerced.keys())}")
+    logger.info("release_fields_updated", job=job, release=release, fields=list(coerced.keys()), count=len(coerced))
 
     job_data = {
         'id': serialize_value(job_record.id),
@@ -3522,7 +3517,7 @@ def archive_preview():
             })
         return jsonify({'count': len(items), 'releases': items}), 200
     except Exception as e:
-        logger.error("archive_preview failed", exc_info=True)
+        logger.error("archive_preview_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e)}), 500
 
 
@@ -3549,7 +3544,7 @@ def unarchive_release(job, release):
         payload={'reason': 'admin_unarchive'},
     )
     db.session.commit()
-    logger.info(f"Unarchived release {job}-{release} via admin action")
+    logger.info("release_unarchived", job=job, release=release, source="user")
     return jsonify({'status': 'success'}), 200
 
 
@@ -3576,7 +3571,7 @@ def archive_confirm():
         )
         count += 1
     db.session.commit()
-    logger.info(f"Archived {count} releases via admin action")
+    logger.info("releases_archived", count=count, source="user")
     return jsonify({'status': 'success', 'count': count}), 200
 
 
@@ -3661,5 +3656,5 @@ def sync_health():
             },
         }), 200
     except Exception as e:
-        logger.error("sync_health failed", exc_info=True)
+        logger.error("sync_health_check_failed", error=str(e), error_type=type(e).__name__, exc_info=True)
         return jsonify({'error': str(e)}), 500

--- a/app/brain/job_log/routes.py
+++ b/app/brain/job_log/routes.py
@@ -479,7 +479,7 @@ def get_jobs():
             try:
                 since_timestamp = datetime.fromisoformat(since_param.replace('Z', '+00:00'))
                 query = query.filter(Releases.last_updated_at > since_timestamp)
-                logger.info(f"[CURSOR] Filtering jobs updated after: {since_timestamp}")
+                logger.debug(f"[CURSOR] Filtering jobs updated after: {since_timestamp}")
                 # Cursor polls skip the archive filter so soft-deleted rows always propagate
             except (ValueError, TypeError) as e:
                 logger.warning(f"[CURSOR] Invalid since parameter: {since_param}, error: {e}. Fetching all jobs.")
@@ -500,7 +500,7 @@ def get_jobs():
         # Order by last_updated_at, id for deterministic results
         query = query.order_by(Releases.last_updated_at.asc(), Releases.id.asc())
         jobs = query.limit(limit).all()
-        logger.info(f"[CURSOR] Query returned {len(jobs)} jobs (limit={limit})")
+        logger.debug(f"[CURSOR] Query returned {len(jobs)} jobs (limit={limit})")
 
         job_list = []
         warnings = []
@@ -635,7 +635,12 @@ def get_jobs():
         if jobs:
             latest_job = jobs[-1]
             latest_timestamp = latest_job.last_updated_at.isoformat() if latest_job.last_updated_at else None
-            logger.info(f"[CURSOR] Latest job timestamp: {latest_timestamp}")
+            logger.debug(f"[CURSOR] Latest job timestamp: {latest_timestamp}")
+
+        # Delta polls that returned rows leave exactly one INFO breadcrumb; zero-row
+        # delta polls stay silent so steady-state polling doesn't flood the logs.
+        if since_param and len(jobs) > 0:
+            logger.info(f"[CURSOR] Delta poll returned {len(jobs)} changed jobs (latest={latest_timestamp})")
 
         # Build response
         response_data = {

--- a/app/brain/job_log/scheduling/preview.py
+++ b/app/brain/job_log/scheduling/preview.py
@@ -4,7 +4,7 @@ schema_version: 1
 purpose: Generate a read-only diff of current vs. computed scheduling dates so admins can review before applying recalculation.
 exports:
   preview_scheduling_changes: Compare DB dates against computed values, return structured diff
-  print_preview: Pretty-print the diff to stdout
+  print_preview: Emit the diff as structured debug log events
   run_preview_script: CLI entry point for running the preview
 imports_from: [app.models, app.brain.job_log.scheduling.calculator, app.logging_config]
 imported_by: [app/brain/job_log/routes.py]
@@ -54,14 +54,18 @@ def preview_scheduling_changes(
     if reference_date is None:
         reference_date = date.today()
     
-    logger.info(f"Previewing scheduling changes (reference_date={reference_date})")
+    logger.debug(
+        "scheduling_preview_started",
+        reference_date=reference_date.isoformat(),
+        show_all=show_all,
+    )
     
     # Fetch all jobs
     all_jobs = Releases.query.order_by(Releases.job.asc(), Releases.release.asc()).all()
     total_jobs = len(all_jobs)
     
     if total_jobs == 0:
-        logger.warning("No jobs found in database")
+        logger.debug("scheduling_preview_no_jobs", count=0)
         return {
             'total_jobs': 0,
             'jobs_with_changes': 0,
@@ -148,85 +152,70 @@ def preview_scheduling_changes(
 
 def print_preview(preview_results: Dict[str, Any], detailed: bool = True):
     """
-    Print a formatted preview of scheduling changes.
-    
+    Emit a structured debug trace of scheduling changes.
+
     Args:
         preview_results: Results from preview_scheduling_changes()
-        detailed: If True, show detailed diff for each job. If False, only show summary.
+        detailed: If True, emit a detailed diff event for each job. If False, only emit the summary.
     """
     summary = preview_results.get('summary', {})
     jobs = preview_results.get('jobs', [])
-    
-    print("\n" + "=" * 80)
-    print("SCHEDULING PREVIEW - Changes Summary")
-    print("=" * 80)
-    
+
     if summary:
-        print(f"\nTotal Jobs: {summary.get('total_jobs', 0)}")
-        print(f"Jobs with Changes: {summary.get('jobs_with_changes', 0)}")
-        print(f"Jobs without Changes: {summary.get('jobs_without_changes', 0)}")
-        print(f"Start Install Changes: {summary.get('start_install_changes', 0)}")
-        print(f"Comp ETA Changes: {summary.get('comp_eta_changes', 0)}")
-        print(f"Reference Date: {summary.get('reference_date', 'N/A')}")
-    
+        logger.debug(
+            "scheduling_preview_summary",
+            total_jobs=summary.get('total_jobs', 0),
+            jobs_with_changes=summary.get('jobs_with_changes', 0),
+            jobs_without_changes=summary.get('jobs_without_changes', 0),
+            start_install_changes=summary.get('start_install_changes', 0),
+            comp_eta_changes=summary.get('comp_eta_changes', 0),
+            reference_date=summary.get('reference_date', 'N/A'),
+        )
+
     if not detailed or not jobs:
-        print("\n" + "=" * 80)
         return
-    
-    print("\n" + "=" * 80)
-    print("DETAILED CHANGES")
-    print("=" * 80)
-    
+
     for job_data in jobs:
-        job_id = f"{job_data['job']}-{job_data['release']}"
-        job_name = job_data.get('job_name', 'N/A')
-        
-        print(f"\nJob: {job_id} - {job_name}")
-        print(f"  Fab Order: {job_data.get('fab_order', 'None')}")
-        print(f"  Stage: {job_data.get('stage', 'Released')}")
-        print(f"  Fab Hrs: {job_data.get('fab_hrs', 'None')}")
-        print(f"  Install Hrs: {job_data.get('install_hrs', 'None')}")
-        print(f"  Remaining Fab Hrs: {job_data.get('remaining_fab_hours', 0.0):.2f}")
-        print(f"  Hours In Front: {job_data.get('hours_in_front', 0.0):.2f}")
-        print(f"  Days In Front: {job_data.get('days_in_front', 0)}")
-        
-        projected_fab = job_data.get('projected_fab_complete_date')
-        if projected_fab:
-            print(f"  Projected Fab Complete: {format_date(projected_fab)}")
-        
         # Start Install diff
         current_start = job_data.get('current_start_install')
         computed_start = job_data.get('computed_start_install')
         start_changed = job_data.get('start_install_changed', False)
-        
-        if start_changed:
-            # Calculate days difference
-            if current_start and computed_start:
-                days_diff = (computed_start - current_start).days
-                diff_str = f" ({days_diff:+d} days)" if days_diff != 0 else ""
-            else:
-                diff_str = ""
-            print(f"  ⚠️  Start Install: {format_date(current_start)} → {format_date(computed_start)}{diff_str}")
-        else:
-            print(f"  ✓  Start Install: {format_date(current_start)} (no change)")
-        
+
+        start_days_diff = None
+        if start_changed and current_start and computed_start:
+            start_days_diff = (computed_start - current_start).days
+
         # Comp ETA diff
         current_comp = job_data.get('current_comp_eta')
         computed_comp = job_data.get('computed_comp_eta')
         comp_changed = job_data.get('comp_eta_changed', False)
-        
-        if comp_changed:
-            # Calculate days difference
-            if current_comp and computed_comp:
-                days_diff = (computed_comp - current_comp).days
-                diff_str = f" ({days_diff:+d} days)" if days_diff != 0 else ""
-            else:
-                diff_str = ""
-            print(f"  ⚠️  Comp ETA: {format_date(current_comp)} → {format_date(computed_comp)}{diff_str}")
-        else:
-            print(f"  ✓  Comp ETA: {format_date(current_comp)} (no change)")
-    
-    print("\n" + "=" * 80)
+
+        comp_days_diff = None
+        if comp_changed and current_comp and computed_comp:
+            comp_days_diff = (computed_comp - current_comp).days
+
+        logger.debug(
+            "scheduling_preview_job_diff",
+            job=job_data['job'],
+            release=job_data['release'],
+            job_name=job_data.get('job_name', 'N/A'),
+            fab_order=job_data.get('fab_order'),
+            stage=job_data.get('stage', 'Released'),
+            fab_hrs=job_data.get('fab_hrs'),
+            install_hrs=job_data.get('install_hrs'),
+            remaining_fab_hours=job_data.get('remaining_fab_hours', 0.0),
+            hours_in_front=job_data.get('hours_in_front', 0.0),
+            days_in_front=job_data.get('days_in_front', 0),
+            projected_fab_complete_date=format_date(job_data.get('projected_fab_complete_date')),
+            current_start_install=format_date(current_start),
+            computed_start_install=format_date(computed_start),
+            start_install_changed=start_changed,
+            start_install_days_diff=start_days_diff,
+            current_comp_eta=format_date(current_comp),
+            computed_comp_eta=format_date(computed_comp),
+            comp_eta_changed=comp_changed,
+            comp_eta_days_diff=comp_days_diff,
+        )
 
 
 def run_preview_script(
@@ -246,8 +235,14 @@ def run_preview_script(
     if reference_date_str:
         try:
             reference_date = datetime.fromisoformat(reference_date_str).date()
-        except (ValueError, TypeError):
-            print(f"Warning: Invalid reference_date '{reference_date_str}', using today")
+        except (ValueError, TypeError) as e:
+            logger.error(
+                "scheduling_preview_invalid_reference_date",
+                reference_date_str=reference_date_str,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             reference_date = None
     
     try:
@@ -262,7 +257,11 @@ def run_preview_script(
         return preview_results
         
     except Exception as e:
-        logger.error(f"Error in preview script: {e}", exc_info=True)
-        print(f"\nError: {e}")
+        logger.error(
+            "scheduling_preview_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         raise
 

--- a/app/brain/job_log/scheduling/service.py
+++ b/app/brain/job_log/scheduling/service.py
@@ -63,7 +63,7 @@ def update_job_scheduling_fields(
     """
     # Protect hard dates (red dates) — never overwrite user-set dates
     if job.start_install_formulaTF is False:
-        logger.debug(f"Skipping scheduling update for hard-date job {job.job}-{job.release}")
+        logger.debug("scheduling_update_skipped_hard_date", job=job.job, release=job.release)
         return job
 
     if reference_date is None:
@@ -115,9 +115,13 @@ def update_job_scheduling_fields(
     # Log changes
     if old_start_install != job.start_install or old_comp_eta != job.comp_eta:
         logger.info(
-            f"Updated scheduling for job {job.job}-{job.release}: "
-            f"start_install={old_start_install}→{job.start_install}, "
-            f"comp_eta={old_comp_eta}→{job.comp_eta}"
+            "scheduling_updated",
+            job=job.job,
+            release=job.release,
+            from_start_install=old_start_install,
+            to_start_install=job.start_install,
+            from_comp_eta=old_comp_eta,
+            to_comp_eta=job.comp_eta,
         )
     
     if commit:
@@ -151,7 +155,11 @@ def recalculate_all_jobs_scheduling(
     if reference_date is None:
         reference_date = date.today()
 
-    logger.info(f"Starting scheduling recalculation (stage_group={stage_group}, reference_date={reference_date})")
+    logger.debug(
+        "scheduling_recalculation_started",
+        stage_group=stage_group,
+        reference_date=reference_date.isoformat(),
+    )
 
     # Fetch jobs (filtered by stage_group if specified)
     query = Releases.query
@@ -174,14 +182,14 @@ def recalculate_all_jobs_scheduling(
     total_jobs = len(all_jobs)
     
     if total_jobs == 0:
-        logger.warning("No jobs found in database")
+        logger.debug("scheduling_recalculation_no_jobs", stage_group=stage_group, count=0)
         return {
             'total_jobs': 0,
             'updated': 0,
             'errors': []
         }
     
-    logger.info(f"Processing {total_jobs} jobs")
+    logger.debug("scheduling_recalculation_jobs_loaded", count=total_jobs)
     
     # Convert to dictionaries for calculation
     jobs_dicts = []
@@ -225,11 +233,17 @@ def recalculate_all_jobs_scheduling(
             # Commit in batches
             if (i + 1) % batch_size == 0:
                 db.session.commit()
-                logger.debug(f"Committed batch: {i + 1}/{total_jobs} jobs processed")
+                logger.debug("scheduling_batch_committed", count=i + 1, total_jobs=total_jobs)
                 
         except Exception as e:
-            error_msg = f"Error updating job {job.job}-{job.release}: {str(e)}"
-            logger.error(error_msg, exc_info=True)
+            logger.error(
+                "scheduling_job_update_failed",
+                job=job.job,
+                release=job.release,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             errors.append({
                 'job': f"{job.job}-{job.release}",
                 'error': str(e)
@@ -240,15 +254,23 @@ def recalculate_all_jobs_scheduling(
     try:
         db.session.commit()
     except Exception as e:
-        logger.error(f"Error in final commit: {str(e)}", exc_info=True)
+        logger.error(
+            "scheduling_final_commit_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         errors.append({
             'job': 'final_commit',
             'error': str(e)
         })
     
     logger.info(
-        f"Scheduling recalculation complete: {updated_count}/{total_jobs} jobs updated, "
-        f"{len(errors)} errors"
+        "scheduling_recalculation_complete",
+        total_jobs=total_jobs,
+        updated=updated_count,
+        error_count=len(errors),
+        stage_group=stage_group,
     )
     
     return {

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -43,7 +43,9 @@ def configure_logging(log_level: str = "INFO", log_file: Optional[str] = None):
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
             structlog.processors.UnicodeDecoder(),
-            structlog.processors.JSONRenderer()
+            # Hand the event dict off to the stdlib ProcessorFormatter, which
+            # renders it (once) as JSON on every handler.
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
@@ -51,24 +53,36 @@ def configure_logging(log_level: str = "INFO", log_file: Optional[str] = None):
         cache_logger_on_first_use=True,
     )
     
-    # Standard logging configuration
+    # Standard logging configuration.
+    # One shared JSON ProcessorFormatter renders BOTH populations exactly once:
+    # - structlog-origin records arrive as event dicts (via wrap_for_formatter)
+    # - stdlib-origin records (werkzeug, apscheduler, sqlalchemy, ...) are
+    #   normalized by foreign_pre_chain so they carry the same fields.
+    foreign_pre_chain = [
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.ExtraAdder(),
+        # ProcessorFormatter (23.1.0) copies record.exc_info into the event
+        # dict but does not render it; format_exc_info turns it into the
+        # "exception" text field (no-op when exc_info is absent).
+        structlog.processors.format_exc_info,
+    ]
     log_config = {
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
-            "detailed": {
-                "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-            },
             "json": {
                 "()": "structlog.stdlib.ProcessorFormatter",
-                "processor": structlog.processors.JSONRenderer()
+                "processor": structlog.processors.JSONRenderer(),
+                "foreign_pre_chain": foreign_pre_chain,
             }
         },
         "handlers": {
             "console": {
                 "class": "logging.StreamHandler",
                 "level": log_level,
-                "formatter": "detailed",
+                "formatter": "json",
                 "stream": sys.stdout
             }
         },

--- a/app/procore/__init__.py
+++ b/app/procore/__init__.py
@@ -14,11 +14,10 @@ updated_by_agent: 2026-04-14T00:00:00Z (commit e133a47)
 """
 # Package
 import os
-import json
 from datetime import datetime
 from typing import Optional
 
-from flask import Blueprint, request, jsonify, current_app
+from flask import Blueprint, request, jsonify
 from app.models import db, Submittals
 
 from app.procore.procore import (
@@ -67,36 +66,60 @@ def procore_webhook():
         resource_type = payload.get("resource_type") or "unknown"
         external_user_id, internal_user_id = resolve_webhook_user_ids(payload)
         if external_user_id is not None:
-            current_app.logger.debug(
-                "Procore webhook user: external_user_id=%s, internal_user_id=%s",
-                external_user_id, internal_user_id
+            logger.debug(
+                "procore_webhook_user_resolved",
+                external_user_id=external_user_id,
+                user_id=internal_user_id,
             )
-        current_app.logger.debug("Procore webhook payload: %s", json.dumps(payload) if payload else "{}")
+        logger.debug(
+            "procore_webhook_payload_received",
+            payload_keys=sorted(payload.keys()) if payload else [],
+        )
 
         # Validate and convert to int
         if not resource_id_raw:
-            current_app.logger.warning("Webhook payload missing 'id' or 'resource_id'")
+            logger.warning(
+                "procore_webhook_missing_resource_id",
+                resource_type=resource_type,
+                event_type=event_type,
+            )
             return jsonify({"status": "ignored"}), 200
-        
+
         try:
             resource_id = int(resource_id_raw)
         except (ValueError, TypeError):
-            current_app.logger.warning(f"Invalid resource_id format: {resource_id_raw}")
+            logger.warning(
+                "procore_webhook_invalid_resource_id",
+                submittal_id=resource_id_raw,
+                event_type=event_type,
+            )
             return jsonify({"status": "ignored"}), 200
-        
+
         if not project_id_raw:
-            current_app.logger.warning("Webhook payload missing 'project_id'")
+            logger.warning(
+                "procore_webhook_missing_project_id",
+                submittal_id=resource_id,
+                event_type=event_type,
+            )
             return jsonify({"status": "ignored"}), 200
-        
+
         try:
             project_id = int(project_id_raw)
         except (ValueError, TypeError):
-            current_app.logger.warning(f"Invalid project_id format: {project_id_raw}")
+            logger.warning(
+                "procore_webhook_invalid_project_id",
+                project_id=project_id_raw,
+                submittal_id=resource_id,
+                event_type=event_type,
+            )
             return jsonify({"status": "ignored"}), 200
 
-        current_app.logger.debug(
-            "Received Procore webhook: resource=%s, event_type=%s, id=%s, project=%s",
-            resource_type, event_type, resource_id, project_id
+        logger.debug(
+            "procore_webhook_received",
+            resource_type=resource_type,
+            event_type=event_type,
+            submittal_id=resource_id,
+            project_id=project_id,
         )
 
         # Schedule a delayed reconcile re-fetch (~60s out) BEFORE the dedup check, so a
@@ -109,9 +132,11 @@ def procore_webhook():
         # Burst dedup: Procore sends 2-5 identical deliveries within ~7 seconds per update.
         # Write a receipt row for the first delivery in the 15s window; reject the rest.
         if is_duplicate_webhook(resource_id, project_id, event_type):
-            current_app.logger.debug(
-                "Duplicate webhook delivery rejected (burst dedup): id=%s, event=%s",
-                resource_id, event_type,
+            logger.debug(
+                "procore_webhook_dedup_rejected",
+                submittal_id=resource_id,
+                project_id=project_id,
+                event_type=event_type,
             )
             return jsonify({"status": "deduplicated"}), 200
 
@@ -125,16 +150,20 @@ def procore_webhook():
             and str(external_user_id) == str(cfg.PROCORE_CONNECTOR_USER_ID)
         )
         if is_connector:
-            current_app.logger.debug(
-                "Procore webhook from connector account (user %s); id=%s, project=%s — processing for side-effect diffs",
-                external_user_id, resource_id, project_id,
+            logger.debug(
+                "procore_webhook_connector_detected",
+                external_user_id=external_user_id,
+                submittal_id=resource_id,
+                project_id=project_id,
             )
 
         # Process submittal create or update
         try:
             if event_type == "create":
-                current_app.logger.debug(
-                    f"Processing create event for submittal {resource_id} in project {project_id}"
+                logger.debug(
+                    "procore_webhook_create_processing",
+                    submittal_id=resource_id,
+                    project_id=project_id,
                 )
                 try:
                     created, record, error_msg = create_submittal_from_webhook(project_id, resource_id, webhook_payload=payload, source='Procore')
@@ -155,29 +184,47 @@ def procore_webhook():
                                     submittal_title=record.title if record else None,
                                     project_name=record.project_name if record else None
                                 )
-                        current_app.logger.info(
-                            f"✓ Successfully created new submittal {resource_id} from webhook create event"
+                        logger.info(
+                            "submittal_created",
+                            submittal_id=resource_id,
+                            project_id=project_id,
+                            source="procore_webhook",
                         )
                     elif error_msg:
-                        current_app.logger.error(
-                            f"✗ Failed to create submittal {resource_id}: {error_msg}",
-                            exc_info=True
+                        logger.error(
+                            "submittal_create_failed",
+                            submittal_id=resource_id,
+                            project_id=project_id,
+                            error=error_msg,
+                            exc_info=True,
                         )
                     elif record:
-                        current_app.logger.info(
-                            f"Submittal {resource_id} already exists in database, skipped creation"
+                        logger.info(
+                            "submittal_create_skipped",
+                            submittal_id=resource_id,
+                            project_id=project_id,
+                            status="skipped",
+                            reason="already_exists",
                         )
                     else:
                         # This case: created=False, record=None, error_msg=None
                         # Should not happen, but log it
-                        current_app.logger.warning(
-                            f"Create submittal returned unexpected state: created={created}, "
-                            f"record={'exists' if record else 'None'}, error_msg={error_msg}"
+                        logger.warning(
+                            "submittal_create_unexpected_state",
+                            submittal_id=resource_id,
+                            project_id=project_id,
+                            created=created,
+                            record_exists=record is not None,
+                            error=error_msg,
                         )
                 except Exception as create_exception:
-                    current_app.logger.error(
-                        f"✗ Exception while processing create event for submittal {resource_id}: {create_exception}",
-                        exc_info=True
+                    logger.error(
+                        "submittal_create_failed",
+                        submittal_id=resource_id,
+                        project_id=project_id,
+                        error=str(create_exception),
+                        error_type=type(create_exception).__name__,
+                        exc_info=True,
                     )
             
             # Handle update events - update existing submittal
@@ -188,25 +235,38 @@ def procore_webhook():
                 # If record doesn't exist, try to create it (fallback for race conditions)
                 # This handles the case where update events arrive before create events
                 if not old_record:
-                    current_app.logger.warning(
-                        f"Update event received for submittal {resource_id} but record doesn't exist. "
-                        f"Attempting to create it first (fallback for race conditions)..."
+                    logger.warning(
+                        "submittal_update_record_missing",
+                        submittal_id=resource_id,
+                        project_id=project_id,
                     )
                     created, new_record, create_error = create_submittal_from_webhook(project_id, resource_id, webhook_payload=payload, source='Procore')
                     if created and new_record:
-                        current_app.logger.info(
-                            f"Successfully created missing submittal {resource_id} from update event fallback"
+                        logger.info(
+                            "submittal_created",
+                            submittal_id=resource_id,
+                            project_id=project_id,
+                            source="procore_webhook",
+                            fallback=True,
                         )
                         old_record = new_record
                     elif new_record:  # Record exists but wasn't newly created (already existed)
-                        current_app.logger.info(
-                            f"Submittal {resource_id} was already created by another process (likely create event), "
-                            f"using existing record"
+                        logger.info(
+                            "submittal_create_skipped",
+                            submittal_id=resource_id,
+                            project_id=project_id,
+                            status="skipped",
+                            reason="created_by_concurrent_process",
                         )
                         old_record = new_record
                     elif create_error:
-                        current_app.logger.error(
-                            f"Failed to create missing submittal {resource_id} from update event: {create_error}"
+                        logger.error(
+                            "submittal_create_failed",
+                            submittal_id=resource_id,
+                            project_id=project_id,
+                            error=create_error,
+                            fallback=True,
+                            exc_info=True,
                         )
                 
                 old_ball_in_court = old_record.ball_in_court if old_record else None
@@ -303,20 +363,29 @@ def procore_webhook():
 
                 # Log when webhook resulted in no updates (DB already in sync)
                 if not (ball_updated or status_updated or title_updated or manager_updated):
-                    current_app.logger.debug(
-                        "Procore webhook update for submittal id=%s project=%s: no changes applied (DB already in sync%s)",
-                        resource_id, project_id,
-                        ", connector" if is_connector else "",
+                    logger.debug(
+                        "submittal_update_skipped",
+                        submittal_id=resource_id,
+                        project_id=project_id,
+                        status="skipped",
+                        reason="no_changes",
+                        connector=is_connector,
                     )
             else:
-                current_app.logger.warning(
-                    f"Unhandled event type '{event_type}' for submittal {resource_id}, ignoring. "
-                    f"Expected 'create' or 'update'"
+                logger.warning(
+                    "procore_webhook_unhandled_event_type",
+                    event_type=event_type,
+                    submittal_id=resource_id,
+                    project_id=project_id,
                 )
         except Exception as e:
-            current_app.logger.error(
-                f"Error processing submittal {resource_id}: {e}",
-                exc_info=True
+            logger.error(
+                "procore_webhook_processing_failed",
+                submittal_id=resource_id,
+                project_id=project_id,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
             )
 
         return jsonify({"status": "processed"}), 200
@@ -408,7 +477,13 @@ def webhook_deliveries():
             }), 200
             
         except Exception as e:
-            logger.error(f"Error getting webhook deliveries: {str(e)}", exc_info=True)
+            logger.error(
+                "procore_webhook_deliveries_fetch_failed",
+                project_id=project_id,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             return jsonify({
                 "status": "error",
                 "error": str(e),
@@ -416,9 +491,14 @@ def webhook_deliveries():
                 "project_id": project_id,
                 "hook_id": hook_id
             }), 500
-        
+
     except Exception as e:
-        logger.error(f"Error retrieving webhook deliveries: {str(e)}", exc_info=True)
+        logger.error(
+            "procore_webhook_deliveries_request_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return jsonify({
             "status": "error",
             "error": str(e)
@@ -536,14 +616,22 @@ def webhook_test():
             }
 
             logger.info(
-                f"Webhook test endpoint received: resource_type={resource_type}, "
-                f"event_type={event_type}, resource_id={resource_id}, project_id={project_id}"
+                "procore_webhook_test_received",
+                resource_type=resource_type,
+                event_type=event_type,
+                submittal_id=resource_id,
+                project_id=project_id,
             )
-            
+
             return jsonify(response), 200
-            
+
         except Exception as e:
-            logger.error(f"Error in webhook test endpoint: {str(e)}", exc_info=True)
+            logger.error(
+                "procore_webhook_test_failed",
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             return jsonify({
                 "status": "error",
                 "error": str(e),
@@ -565,7 +653,7 @@ def health_scan():
             - webhook_status: Webhook health for orphaned projects
     """
     try:
-        logger.info("Starting comprehensive health scan via API")
+        logger.info("health_scan_started", source="user")
         result = comprehensive_health_scan(skip_user_prompt=True)
         
         # Convert result to JSON-serializable format
@@ -598,7 +686,12 @@ def health_scan():
         return jsonify(response_data), 200
         
     except Exception as exc:
-        logger.error(f"Error running health scan: {exc}", exc_info=True)
+        logger.error(
+            "health_scan_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return jsonify({
             "error": "Failed to run health scan",
             "details": str(exc)
@@ -625,7 +718,7 @@ def health_scan_update():
         submittal_ids = data.get('submittal_ids', [])
         
         # Run health scan to get current sync issues
-        logger.info("Running health scan to identify sync issues for update")
+        logger.info("health_scan_update_started", source="user")
         result = comprehensive_health_scan(skip_user_prompt=True)
         sync_issues = result['differences']['sync_issues']
         
@@ -690,7 +783,13 @@ def health_scan_update():
                             source='HealthScan',
                         )
                     except Exception as event_error:
-                        logger.warning(f"Failed to create SubmittalEvent for submittal {issue['submittal_id']} from health scan: {event_error}", exc_info=True)
+                        logger.warning(
+                            "submittal_event_create_failed",
+                            submittal_id=issue['submittal_id'],
+                            error=str(event_error),
+                            error_type=type(event_error).__name__,
+                            exc_info=True,
+                        )
                 
                 updated_submittals.append({
                     'submittal_id': issue['submittal_id'],
@@ -701,7 +800,14 @@ def health_scan_update():
                 updated_count += 1
                 
             except Exception as e:
-                logger.error(f"Error updating submittal {issue['submittal_id']}: {e}")
+                logger.error(
+                    "submittal_update_failed",
+                    submittal_id=issue['submittal_id'],
+                    project_id=issue['project_id'],
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
                 errors.append({
                     'submittal_id': issue['submittal_id'],
                     'error': str(e)
@@ -710,7 +816,7 @@ def health_scan_update():
         # Commit all changes
         try:
             db.session.commit()
-            logger.info(f"Successfully updated {updated_count} submittal records in database")
+            logger.info("health_scan_updates_committed", count=updated_count)
             
             return jsonify({
                 "success": True,
@@ -721,14 +827,25 @@ def health_scan_update():
             
         except Exception as e:
             db.session.rollback()
-            logger.error(f"Error committing updates to database: {e}")
+            logger.error(
+                "health_scan_commit_failed",
+                count=updated_count,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             return jsonify({
                 "error": "Failed to commit updates to database",
                 "details": str(e)
             }), 500
-        
+
     except Exception as exc:
-        logger.error(f"Error updating records from health scan: {exc}", exc_info=True)
+        logger.error(
+            "health_scan_update_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         db.session.rollback()
         return jsonify({
             "error": "Failed to update records",
@@ -766,7 +883,12 @@ def verify_admin_pin():
             }), 401
             
     except Exception as exc:
-        logger.error(f"Error verifying admin PIN: {exc}", exc_info=True)
+        logger.error(
+            "admin_pin_verify_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return jsonify({
             "error": "Failed to verify PIN",
             "details": str(exc)

--- a/app/procore/__init__.py
+++ b/app/procore/__init__.py
@@ -67,7 +67,7 @@ def procore_webhook():
         resource_type = payload.get("resource_type") or "unknown"
         external_user_id, internal_user_id = resolve_webhook_user_ids(payload)
         if external_user_id is not None:
-            current_app.logger.info(
+            current_app.logger.debug(
                 "Procore webhook user: external_user_id=%s, internal_user_id=%s",
                 external_user_id, internal_user_id
             )
@@ -94,7 +94,7 @@ def procore_webhook():
             current_app.logger.warning(f"Invalid project_id format: {project_id_raw}")
             return jsonify({"status": "ignored"}), 200
 
-        current_app.logger.info(
+        current_app.logger.debug(
             "Received Procore webhook: resource=%s, event_type=%s, id=%s, project=%s",
             resource_type, event_type, resource_id, project_id
         )
@@ -109,7 +109,7 @@ def procore_webhook():
         # Burst dedup: Procore sends 2-5 identical deliveries within ~7 seconds per update.
         # Write a receipt row for the first delivery in the 15s window; reject the rest.
         if is_duplicate_webhook(resource_id, project_id, event_type):
-            current_app.logger.info(
+            current_app.logger.debug(
                 "Duplicate webhook delivery rejected (burst dedup): id=%s, event=%s",
                 resource_id, event_type,
             )
@@ -125,7 +125,7 @@ def procore_webhook():
             and str(external_user_id) == str(cfg.PROCORE_CONNECTOR_USER_ID)
         )
         if is_connector:
-            current_app.logger.info(
+            current_app.logger.debug(
                 "Procore webhook from connector account (user %s); id=%s, project=%s — processing for side-effect diffs",
                 external_user_id, resource_id, project_id,
             )
@@ -133,7 +133,7 @@ def procore_webhook():
         # Process submittal create or update
         try:
             if event_type == "create":
-                current_app.logger.info(
+                current_app.logger.debug(
                     f"Processing create event for submittal {resource_id} in project {project_id}"
                 )
                 try:
@@ -303,7 +303,7 @@ def procore_webhook():
 
                 # Log when webhook resulted in no updates (DB already in sync)
                 if not (ball_updated or status_updated or title_updated or manager_updated):
-                    current_app.logger.info(
+                    current_app.logger.debug(
                         "Procore webhook update for submittal id=%s project=%s: no changes applied (DB already in sync%s)",
                         resource_id, project_id,
                         ", connector" if is_connector else "",

--- a/app/procore/api.py
+++ b/app/procore/api.py
@@ -25,6 +25,8 @@ from app.config import Config as cfg
 from app.procore.procore_auth import get_access_token, get_access_token_force_refresh
 from app.logging_config import get_logger
 
+logger = get_logger(__name__)
+
 # Coded mapping of company submittal statuses (id -> name). Update when company adds new statuses.
 SUBMITTAL_STATUSES = [
     {"id": 203239, "name": "Closed", "status": "Closed", "is_default": True},
@@ -176,7 +178,6 @@ class ProcoreAPI:
         The v2.0 API returns paginated responses in the format:
         {"data": [...], "total": N, "per_page": M, "page": P}
         """
-        logger = get_logger(__name__)
         all_submittals = []
         page = 1
         per_page = 100  # Max items per page
@@ -205,7 +206,9 @@ class ProcoreAPI:
                 else:
                     # Unexpected dict format, log and return empty list
                     logger.error(
-                        f"Unexpected response format from get_submittals: {response}"
+                        "submittals_response_unexpected_format",
+                        project_id=project_id,
+                        response_keys=sorted(response.keys()),
                     )
                     return []
             elif isinstance(response, list):
@@ -215,7 +218,9 @@ class ProcoreAPI:
             else:
                 # Unexpected response type
                 logger.error(
-                    f"Unexpected response type from get_submittals: {type(response)}"
+                    "submittals_response_unexpected_type",
+                    project_id=project_id,
+                    response_type=type(response).__name__,
                 )
                 return []
 
@@ -365,4 +370,5 @@ if __name__ == "__main__":
             cfg.PROD_PROCORE_CLIENT_SECRET,
             cfg.PROCORE_DEV_WEBHOOK_URL,
         )
-        print(procore_client.get_company_users())
+        users = procore_client.get_company_users()
+        logger.info("company_users_fetched", count=len(users) if users else 0)

--- a/app/procore/helpers.py
+++ b/app/procore/helpers.py
@@ -20,7 +20,6 @@ updated_by_agent: 2026-04-14T00:00:00Z (commit e133a47)
 """
 import hashlib
 import json
-import logging
 import time
 import pandas as pd
 import re
@@ -29,12 +28,13 @@ from typing import Optional, Tuple
 from sqlalchemy.exc import IntegrityError
 
 from app.models import SubmittalEvents, WebhookReceipt, db
+from app.logging_config import get_logger
 
 # How long (seconds) to treat repeated Procore webhook deliveries as burst duplicates.
 # Procore bursts arrive within ~7s. Workflow cycles happen minutes/hours apart.
 WEBHOOK_DEDUP_WINDOW_SECONDS = 15
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Helper function to convert pandas NaT/NaN to None
 def clean_value(value):
@@ -310,13 +310,18 @@ def create_submittal_event(
         db.session.rollback()
         if "payload_hash" in str(e) or "unique" in str(e).lower() or "duplicate" in str(e).lower():
             logger.debug(
-                "SubmittalEvent duplicate (payload_hash already exists) for submittal %s %s, skipping",
-                submittal_id, action,
+                "submittal_event_duplicate_skipped",
+                submittal_id=str(submittal_id),
+                action=action,
             )
             return False
         raise
     logger.info(
-        "Created SubmittalEvent for submittal %s %s (external_user_id=%s, internal_user_id=%s, is_system_echo=%s)",
-        submittal_id, action, external_user_id, internal_user_id, is_system_echo,
+        "submittal_event_created",
+        submittal_id=str(submittal_id),
+        action=action,
+        external_user_id=external_user_id,
+        internal_user_id=internal_user_id,
+        is_system_echo=is_system_echo,
     )
     return True

--- a/app/procore/procore.py
+++ b/app/procore/procore.py
@@ -18,7 +18,6 @@ invariants:
   - Connector-originated updates are tagged with is_system_echo=True in submittal events.
 updated_by_agent: 2026-04-14T00:00:00Z (commit e133a47)
 """
-import logging
 import re
 import json
 import os
@@ -30,6 +29,7 @@ from sqlalchemy.exc import IntegrityError
 from requests.exceptions import ConnectionError, Timeout
 from urllib3.exceptions import ProtocolError
 from app.config import Config as cfg
+from app.logging_config import get_logger
 from app.models import db, Releases, Submittals
 from app.trello.api import add_procore_link
 from app.procore.procore_auth import get_access_token
@@ -46,7 +46,7 @@ from app.brain.drafting_work_load.engine import SubmittalOrderingEngine
 from app.api.helpers import active_releases_filter
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Submittal type that triggers a "Rel" (release) number assignment on the DWL tab.
 DRR_TYPE = "Drafting Release Review"
@@ -194,8 +194,10 @@ def assign_rel_manual(submittal, desired_rel):
     submittal.rel = number
     submittal.rel_assigned_at = datetime.utcnow()
     logger.info(
-        "Assigned Rel %s to DRR submittal %s (job %s)",
-        number, submittal.submittal_id, submittal.project_number,
+        "rel_assigned",
+        release=number,
+        submittal_id=submittal.submittal_id,
+        job=submittal.project_number,
     )
     return number
 
@@ -209,17 +211,24 @@ def _request_json(url, headers, params=None):
         response = requests.get(url, headers=headers, params=params, timeout=30)
         response.raise_for_status()
     except requests.RequestException as exc:
-        logger.exception("Procore request failed: url=%s params=%s", url, params)
+        logger.error(
+            "procore_request_failed",
+            url=url,
+            params=params,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return None
 
     try:
         data = response.json()
     except ValueError:
-        logger.error("Procore response is not valid JSON: url=%s params=%s body=%r", url, params, response.text[:500])
+        logger.error("procore_response_not_json", url=url, params=params, exc_info=True)
         return None
 
     if isinstance(data, dict) and data.get("errors"):
-        logger.error("Procore returned errors: url=%s params=%s errors=%s", url, params, data.get("errors"))
+        logger.error("procore_response_errors", url=url, params=params, errors=data.get("errors"))
         return None
 
     return data
@@ -249,7 +258,7 @@ def get_companies_list():
     headers = {"Authorization": f"Bearer {get_access_token()}"}
     companies = _request_json(url, headers=headers) or []
     if not companies:
-        logger.warning("No companies returned from Procore")
+        logger.warning("procore_companies_empty")
         return None
     company_id = companies[0]["id"]
     return company_id
@@ -305,10 +314,15 @@ def get_project_id_by_project_name(project_name):
     # get procore client
     procore = get_procore_client()
     projects = procore.get_projects(cfg.PROD_PROCORE_COMPANY_ID)
-    print(len(projects))
+    logger.debug("projects_fetched", count=len(projects))
     for project in projects:
         if project["name"] == project_name:
-            print(project["project_number"], project["name"], project["id"])
+            logger.debug(
+                "project_matched",
+                project_id=project["id"],
+                project_number=project["project_number"],
+                project_name=project["name"],
+            )
             return project["id"]
     return None
 
@@ -326,7 +340,12 @@ def parse_and_log_submittal_data(submittal_data: dict, project_id: int, submitta
         dict: Parsed submittal data in a structured format
     """
     if not isinstance(submittal_data, dict):
-        logger.warning(f"Cannot parse submittal data - not a dict: {type(submittal_data)}")
+        logger.warning(
+            "submittal_data_not_dict",
+            submittal_id=submittal_id,
+            project_id=project_id,
+            data_type=type(submittal_data).__name__,
+        )
         return None
     
     # Extract key fields in a structured way
@@ -409,7 +428,12 @@ def get_submittals_by_project_id(project_id, identifier):
     headers = {"Authorization": f"Bearer {get_access_token()}"}
     submittals = _request_json(url, headers=headers)
     if not isinstance(submittals, list):
-        logger.warning("Unexpected submittals payload for project_id=%s identifier=%s: %r", project_id, identifier, submittals)
+        logger.warning(
+            "submittals_payload_unexpected",
+            project_id=project_id,
+            identifier=identifier,
+            payload_type=type(submittals).__name__,
+        )
         return []
     normalized_identifier = (identifier or "").strip().lower()
     return [
@@ -426,7 +450,7 @@ def get_workflow_data(project_id, submittal_id):
     headers = {"Authorization": f"Bearer {get_access_token()}"}
     workflow_data = _request_json(url, headers=headers)
     if workflow_data is None:
-        logger.warning("Missing workflow data for project_id=%s submittal_id=%s", project_id, submittal_id)
+        logger.debug("workflow_data_missing", project_id=project_id, submittal_id=submittal_id)
         return {}
     return workflow_data
 
@@ -475,11 +499,11 @@ def get_webhook_deliveries(company_id, project_id):
     # get webhook_id based on project_id assuming 1 hook
     webhooks = procore.list_project_webhooks(project_id, 'mile-high-metal-works')
     if not webhooks:
-        logger.error("No Procore webhooks found for project_id=%s", project_id)
+        logger.warning("project_webhooks_missing", project_id=project_id)
         return None
     webhook_id = webhooks[0]["id"]
     if not webhook_id:
-        logger.error("No Procore webhook_id found for project_id=%s", project_id)
+        logger.warning("project_webhook_id_missing", project_id=project_id)
         return None
     return procore.get_deliveries(company_id, project_id, webhook_id)
 
@@ -510,7 +534,14 @@ def handle_submittal_update(project_id, submittal_id):
     try:
         parse_and_log_submittal_data(submittal, project_id, submittal_id, source="webhook_update")
     except Exception as parse_error:
-        logger.warning(f"Failed to parse/log submittal data (non-fatal): {parse_error}")
+        logger.warning(
+            "submittal_parse_log_failed",
+            submittal_id=submittal_id,
+            project_id=project_id,
+            error=str(parse_error),
+            error_type=type(parse_error).__name__,
+            exc_info=True,
+        )
     
     parsed = parse_ball_in_court_from_submittal(submittal)
     if parsed is None:
@@ -572,10 +603,16 @@ def get_project_info(project_id):
                     "name": project.get("name"),
                     "project_number": project.get("project_number")
                 }
-        logger.warning(f"Project {project_id} not found")
+        logger.debug("project_not_found", project_id=project_id)
         return None
     except Exception as e:
-        logger.error(f"Error getting project info for project {project_id}: {e}", exc_info=True)
+        logger.error(
+            "project_info_fetch_failed",
+            project_id=project_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return None
 
 
@@ -592,37 +629,53 @@ def create_submittal_from_webhook(project_id, submittal_id, webhook_payload=None
         tuple: (created: bool, record: Submittals or None, error_message: str or None)
     """
     try:
-        logger.info(f"Starting create_submittal_from_webhook for submittal {submittal_id}, project {project_id}")
-        
+        logger.debug("submittal_create_started", submittal_id=submittal_id, project_id=project_id)
+
         # Check if submittal already exists
         existing = Submittals.query.filter_by(submittal_id=str(submittal_id)).first()
         if existing:
-            logger.info(f"Submittal {submittal_id} already exists in database, skipping creation")
+            logger.debug("submittal_create_skipped", submittal_id=submittal_id, reason="already_exists")
             return False, existing, None
-        
-        logger.info(f"Fetching submittal data from Procore API for submittal {submittal_id}")
+
+        logger.debug("submittal_fetch_started", submittal_id=submittal_id, project_id=project_id)
         # Get submittal data from Procore API
         submittal_data = get_submittal_by_id(project_id, submittal_id)
         if not isinstance(submittal_data, dict):
             error_msg = f"Failed to fetch submittal data from Procore API - got {type(submittal_data)} instead of dict"
-            logger.error(f"{error_msg} for submittal {submittal_id}")
+            logger.error(
+                "submittal_fetch_failed",
+                submittal_id=submittal_id,
+                project_id=project_id,
+                error=error_msg,
+            )
             return False, None, error_msg
-        
+
         # Parse and log submittal data for visualization
         try:
             parse_and_log_submittal_data(submittal_data, project_id, submittal_id, source="webhook_create")
         except Exception as parse_error:
-            logger.warning(f"Failed to parse/log submittal data (non-fatal): {parse_error}")
-        
-        logger.info(f"Fetching project info for project {project_id}")
+            logger.warning(
+                "submittal_parse_log_failed",
+                submittal_id=submittal_id,
+                project_id=project_id,
+                error=str(parse_error),
+                error_type=type(parse_error).__name__,
+                exc_info=True,
+            )
+
+        logger.debug("project_info_fetch_started", project_id=project_id)
         # Get project information
         project_info = get_project_info(project_id)
         if not project_info:
             error_msg = f"Failed to fetch project info for project {project_id}"
-            logger.error(f"{error_msg}")
+            logger.error("project_info_fetch_failed", project_id=project_id, submittal_id=submittal_id)
             return False, None, error_msg
-        
-        logger.info(f"Successfully fetched project info: {project_info.get('name')} ({project_info.get('project_number')})")
+
+        logger.debug(
+            "project_info_fetched",
+            project_name=project_info.get("name"),
+            project_number=project_info.get("project_number"),
+        )
         
         # Parse ball_in_court from submittal data
         parsed = parse_ball_in_court_from_submittal(submittal_data)
@@ -662,12 +715,12 @@ def create_submittal_from_webhook(project_id, submittal_id, webhook_payload=None
             submittal_manager = None
         submittal_manager = str(submittal_manager).strip() if submittal_manager else None
         
-        logger.info(f"Creating new Submittals record with title: {title}")
+        logger.debug("submittal_record_creating", submittal_id=submittal_id, title=title)
 
         # Extract created_at from Procore API if available
         procore_created_at = None
         created_at_str = submittal_data.get("created_at")
-        logger.info(f"Extracting created_at from API: {created_at_str}")
+        logger.debug("created_at_extracted", submittal_id=submittal_id, created_at=created_at_str)
         if created_at_str:
             try:
                 # Parse ISO format timestamp (handles Z suffix and timezone offsets)
@@ -675,24 +728,28 @@ def create_submittal_from_webhook(project_id, submittal_id, webhook_payload=None
                 # Convert to naive datetime (remove timezone info)
                 if procore_created_at.tzinfo:
                     procore_created_at = procore_created_at.replace(tzinfo=None)
-                logger.info(f"Parsed procore_created_at: {procore_created_at}")
+                logger.debug("created_at_parsed", submittal_id=submittal_id, created_at=str(procore_created_at))
             except (ValueError, AttributeError) as e:
-                logger.warning(f"Could not parse created_at '{created_at_str}' from Procore API: {e}")
+                logger.warning(
+                    "created_at_parse_failed",
+                    submittal_id=submittal_id,
+                    created_at=created_at_str,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
                 procore_created_at = None
-        
+
         # Fallback to current time if not available from API
         if not procore_created_at:
-            logger.warning(f"Using fallback datetime.utcnow() because procore_created_at is None")
+            logger.debug("created_at_fallback_used", submittal_id=submittal_id)
             procore_created_at = datetime.utcnow()
         
         # Double-check it doesn't exist (race condition protection)
         # Another thread/request might have created it between our initial check and now
         existing_check = Submittals.query.filter_by(submittal_id=str(submittal_id)).first()
         if existing_check:
-            logger.info(
-                f"Submittal {submittal_id} was created by another process between initial check and commit. "
-                f"Returning existing record."
-            )
+            logger.debug("submittal_create_skipped", submittal_id=submittal_id, reason="concurrent_create")
             return False, existing_check, None
         
         # Create new Submittals record
@@ -716,31 +773,46 @@ def create_submittal_from_webhook(project_id, submittal_id, webhook_payload=None
         # (assign_rel_manual), so a freshly-created DRR arrives with rel=None.
 
         db.session.add(new_submittal)
-        logger.info(f"Added submittal to session, committing to database...")
+        logger.debug("submittal_commit_started", submittal_id=submittal_id)
 
         try:
             db.session.commit()
-            logger.info(f"Successfully committed submittal to database")
+            logger.debug("submittal_committed", submittal_id=submittal_id)
         except IntegrityError as integrity_error:
             # Handle unique constraint violations (if another thread created it during commit)
             logger.warning(
-                f"Unique constraint violation during commit for submittal {submittal_id}. "
-                f"This likely means another process created it concurrently. Rolling back and fetching existing record."
+                "submittal_commit_conflict",
+                submittal_id=submittal_id,
+                error=str(integrity_error),
+                error_type=type(integrity_error).__name__,
+                exc_info=True,
             )
             db.session.rollback()
             # Fetch the record that was created by the other process
             existing_after_error = Submittals.query.filter_by(submittal_id=str(submittal_id)).first()
             if existing_after_error:
-                logger.info(f"Found existing record created by concurrent process, returning it")
+                logger.debug("submittal_existing_returned", submittal_id=submittal_id)
                 return False, existing_after_error, None
             else:
                 # Unexpected: constraint violation but no record found
                 error_msg = f"Unique constraint violation but no existing record found: {integrity_error}"
-                logger.error(error_msg)
+                logger.error(
+                    "submittal_commit_conflict_unresolved",
+                    submittal_id=submittal_id,
+                    error=str(integrity_error),
+                    error_type=type(integrity_error).__name__,
+                    exc_info=True,
+                )
                 return False, None, error_msg
         except Exception as commit_error:
             # Re-raise other commit errors after logging
-            logger.error(f"Unexpected error during commit: {commit_error}", exc_info=True)
+            logger.error(
+                "submittal_commit_failed",
+                submittal_id=submittal_id,
+                error=str(commit_error),
+                error_type=type(commit_error).__name__,
+                exc_info=True,
+            )
             raise
         
         # Create submittal event for creation (with user attribution from webhook)
@@ -761,15 +833,25 @@ def create_submittal_from_webhook(project_id, submittal_id, webhook_payload=None
                 webhook_payload=webhook_payload, source=source,
             )
         except Exception as event_error:
-            logger.warning("Failed to create SubmittalEvent for submittal %s creation: %s", submittal_id, event_error, exc_info=True)
-        
+            logger.warning(
+                "submittal_event_create_failed",
+                submittal_id=submittal_id,
+                action="created",
+                error=str(event_error),
+                error_type=type(event_error).__name__,
+                exc_info=True,
+            )
+
         logger.info(
-            f"Created new submittal record: submittal_id={submittal_id}, "
-            f"project_id={project_id}, title={title}"
+            "submittal_created",
+            submittal_id=submittal_id,
+            project_id=project_id,
+            title=title,
+            source=source,
         )
-        
+
         return True, new_submittal, None
-        
+
     except (ConnectionError, ProtocolError, Timeout) as e:
         # Connection errors - classify and provide better error message
         # Note: The API client already retries these, so if we get here, all retries failed
@@ -778,21 +860,47 @@ def create_submittal_from_webhook(project_id, submittal_id, webhook_payload=None
             f"Connection error while creating submittal {submittal_id}: {error_type} - {str(e)}. "
             f"This may be a temporary network issue. The webhook will be retried on the next update event."
         )
-        logger.error(error_msg, exc_info=True)
+        logger.error(
+            "submittal_create_failed",
+            submittal_id=submittal_id,
+            project_id=project_id,
+            error=str(e),
+            error_type=error_type,
+            exc_info=True,
+        )
         try:
             db.session.rollback()
         except Exception as rollback_error:
-            logger.error(f"Error during rollback: {rollback_error}", exc_info=True)
+            logger.error(
+                "db_rollback_failed",
+                submittal_id=submittal_id,
+                error=str(rollback_error),
+                error_type=type(rollback_error).__name__,
+                exc_info=True,
+            )
         return False, None, error_msg
     except Exception as e:
         # Other errors - classify and log
         error_type = type(e).__name__
         error_msg = f"Error creating submittal {submittal_id} from webhook: {error_type} - {str(e)}"
-        logger.error(error_msg, exc_info=True)
+        logger.error(
+            "submittal_create_failed",
+            submittal_id=submittal_id,
+            project_id=project_id,
+            error=str(e),
+            error_type=error_type,
+            exc_info=True,
+        )
         try:
             db.session.rollback()
         except Exception as rollback_error:
-            logger.error(f"Error during rollback: {rollback_error}", exc_info=True)
+            logger.error(
+                "db_rollback_failed",
+                submittal_id=submittal_id,
+                error=str(rollback_error),
+                error_type=type(rollback_error).__name__,
+                exc_info=True,
+            )
         return False, None, error_msg
 
 
@@ -816,7 +924,7 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
     try:
         result = handle_submittal_update(project_id, submittal_id)
         if result is None:
-            logger.warning(f"Failed to parse submittal data for submittal {submittal_id}")
+            logger.warning("submittal_parse_failed", submittal_id=submittal_id, project_id=project_id)
             return False, False, False, False, None, None, None
         
         _, ball_in_court, approvers, status, title, submittal_manager = result
@@ -828,7 +936,7 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
         ).with_for_update().first()
 
         if not record:
-            logger.warning(f"No DB record found for submittal {submittal_id}")
+            logger.warning("submittal_record_missing", submittal_id=submittal_id)
             return False, False, False, False, None, ball_in_court, status
 
         ball_updated = False
@@ -842,14 +950,16 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
         webhook_ball_value = ball_in_court if ball_in_court is not None else ""
         
         if db_ball_value != webhook_ball_value:
-            logger.info(
-                f"Ball in court mismatch detected for submittal {submittal_id}: "
-                f"DB='{record.ball_in_court}' vs Procore='{ball_in_court}'"
+            logger.debug(
+                "ball_in_court_mismatch",
+                submittal_id=submittal_id,
+                old=record.ball_in_court,
+                new=ball_in_court,
             )
-            
+
             # Compress the old drafter's list if the old value is a single drafter (not empty, not multiple)
             if db_ball_value and ',' not in db_ball_value:
-                logger.info(f"Compressing orders for old drafter '{db_ball_value}' after submittal {submittal_id} moved")
+                logger.debug("drafter_orders_compressing", drafter=db_ball_value, submittal_id=submittal_id)
                 
                 # Get all submittals for the old ball_in_court (excluding the one being moved)
                 old_drafter_submittals = Submittals.query.filter(
@@ -877,7 +987,12 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
                         for submittal_id, new_order in compression_updates:
                             if submittal_id in submittal_map:
                                 submittal_map[submittal_id].order_number = new_order
-                                logger.info(f"Compressed submittal {submittal_id} to order {new_order} for drafter '{db_ball_value}'")
+                                logger.info(
+                                    "submittal_order_compressed",
+                                    submittal_id=submittal_id,
+                                    order_number=new_order,
+                                    drafter=db_ball_value,
+                                )
             
             # Check if new value is multiple assignees (comma-separated)
             is_new_multiple = webhook_ball_value and ',' in webhook_ball_value
@@ -902,8 +1017,10 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
             if approvers else False
         )
         logger.debug(
-            "Submittal %s submitter_pending_in_workflow=%s (approvers=%s)",
-            submittal_id, submitter_pending, bool(approvers)
+            "submitter_pending_checked",
+            submittal_id=submittal_id,
+            submitter_pending=submitter_pending,
+            has_approvers=bool(approvers),
         )
         if submitter_pending:
             # Only bump if order_number is an integer >= 1 (not already a decimal)
@@ -914,9 +1031,10 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
                     ball_in_court_for_bump = record.ball_in_court if ball_updated else (ball_in_court or "")
                     if UrgencyService.bump_order_number_to_urgent(record, submittal_id, ball_in_court_for_bump):
                         order_bumped = True
-                        logger.info(
-                            "Order number bumped for submittal %s (submitter pending in workflow)",
-                            submittal_id
+                        logger.debug(
+                            "submittal_order_bump_triggered",
+                            submittal_id=submittal_id,
+                            reason="submitter_pending_in_workflow",
                         )
         
         # Check and update status
@@ -924,27 +1042,28 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
         webhook_status_value = status if status is not None else ""
         
         if db_status_value != webhook_status_value:
-            logger.info(
-                f"Status mismatch detected for submittal {submittal_id}: "
-                f"DB='{record.status}' vs Procore='{status}'"
+            logger.debug(
+                "submittal_status_mismatch",
+                submittal_id=submittal_id,
+                old=record.status,
+                new=status,
             )
             record.status = status
             status_updated = True
             if status != 'Open' and record.order_number is not None:
                 record.order_number = None
-                logger.info(
-                    "Cleared order_number for submittal %s (status=%s, not Open)",
-                    submittal_id, status,
-                )
+                logger.info("submittal_order_cleared", submittal_id=submittal_id, status=status)
         
         # Check and update title
         db_title_value = record.title if record.title is not None else ""
         webhook_title_value = title if title is not None else ""
         
         if db_title_value != webhook_title_value:
-            logger.info(
-                f"Title mismatch detected for submittal {submittal_id}: "
-                f"DB='{record.title}' vs Procore='{title}'"
+            logger.debug(
+                "submittal_title_mismatch",
+                submittal_id=submittal_id,
+                old=record.title,
+                new=title,
             )
             record.title = title
             title_updated = True
@@ -954,9 +1073,11 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
         webhook_manager_value = submittal_manager if submittal_manager is not None else ""
         
         if db_manager_value != webhook_manager_value:
-            logger.info(
-                f"Submittal manager mismatch detected for submittal {submittal_id}: "
-                f"DB='{record.submittal_manager}' vs Procore='{submittal_manager}'"
+            logger.debug(
+                "submittal_manager_mismatch",
+                submittal_id=submittal_id,
+                old=record.submittal_manager,
+                new=submittal_manager,
             )
             record.submittal_manager = submittal_manager
             manager_updated = True
@@ -1006,32 +1127,72 @@ def check_and_update_submittal(project_id, submittal_id, webhook_payload=None, s
                             webhook_payload=webhook_payload, source=source,
                         )
                     except Exception as event_error:
-                        logger.warning("Failed to create SubmittalEvent for submittal %s update: %s", submittal_id, event_error, exc_info=True)
+                        logger.warning(
+                            "submittal_event_create_failed",
+                            submittal_id=submittal_id,
+                            action="updated",
+                            error=str(event_error),
+                            error_type=type(event_error).__name__,
+                            exc_info=True,
+                        )
             except Exception as event_error:
-                logger.warning("Failed to build or create SubmittalEvent for submittal %s update: %s", submittal_id, event_error, exc_info=True)
-            
+                logger.warning(
+                    "submittal_event_build_failed",
+                    submittal_id=submittal_id,
+                    action="updated",
+                    error=str(event_error),
+                    error_type=type(event_error).__name__,
+                    exc_info=True,
+                )
+
             if ball_updated:
-                logger.info(f"Updated ball_in_court for submittal {submittal_id} to '{ball_in_court}'")
+                logger.info(
+                    "ball_in_court_updated",
+                    submittal_id=submittal_id,
+                    old=db_ball_value,
+                    new=ball_in_court,
+                )
             if status_updated:
-                logger.info(f"Updated status for submittal {submittal_id} from '{db_status_value}' to '{status}'")
+                logger.info(
+                    "submittal_status_updated",
+                    submittal_id=submittal_id,
+                    old=db_status_value,
+                    new=status,
+                )
             if title_updated:
-                logger.info(f"Updated title for submittal {submittal_id} from '{db_title_value}' to '{title}'")
+                logger.info(
+                    "submittal_title_updated",
+                    submittal_id=submittal_id,
+                    old=db_title_value,
+                    new=title,
+                )
             if manager_updated:
-                logger.info(f"Updated submittal_manager for submittal {submittal_id} from '{db_manager_value}' to '{submittal_manager}'")
+                logger.info(
+                    "submittal_manager_updated",
+                    submittal_id=submittal_id,
+                    old=db_manager_value,
+                    new=submittal_manager,
+                )
             if order_bumped:
-                logger.info(f"Order number bumped for submittal {submittal_id}")
+                logger.info("submittal_order_bumped", submittal_id=submittal_id)
         else:
-            logger.info(
-                "Webhook for submittal %s: no DB updates (already in sync). "
-                "Likely bounce-back from Brain/originated update. ball=%r, status=%r",
-                submittal_id, ball_in_court, status,
+            logger.debug(
+                "submittal_update_skipped",
+                submittal_id=submittal_id,
+                reason="already_in_sync",
+                ball_in_court=ball_in_court,
+                status=status,
             )
         return ball_updated, status_updated, title_updated, manager_updated, record, ball_in_court, status
-            
+
     except Exception as e:
         logger.error(
-            f"Error checking/updating submittal fields for submittal {submittal_id}: {e}",
-            exc_info=True
+            "submittal_update_failed",
+            submittal_id=submittal_id,
+            project_id=project_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
         )
         return False, False, False, False, None, None, None
 
@@ -1103,11 +1264,12 @@ def get_viewer_url_for_job(job_number, release_number):
         }
     except Exception as e:
         logger.error(
-            "Error getting viewer_url for job=%s release=%s: %s",
-            job_number,
-            release_number,
-            str(e),
-            exc_info=True
+            "viewer_url_fetch_failed",
+            job=job_number,
+            release=release_number,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
         )
         return {
             "success": False,
@@ -1122,11 +1284,11 @@ def add_procore_link_to_trello_card(job, release):
     '''
     Function to add procore drafting document link to related trello card
     '''
-    print(job, release)
+    logger.debug("procore_link_lookup_started", job=job, release=release)
     job_record = Releases.query.filter_by(job=job, release=release).first()
     if not job_record:
         return None
-    print(job_record)
+    logger.debug("release_record_found", job=job, release=release, release_id=job_record.id)
     job_number = job_record.job
     release_number = job_record.release
     card_id = job_record.trello_card_id
@@ -1135,25 +1297,30 @@ def add_procore_link_to_trello_card(job, release):
 
     # Get companies list
     company_id = get_companies_list()
-    print(company_id)
+    logger.debug("company_id_fetched", company_id=company_id)
     if not company_id:
-        logger.error("No Procore company_id returned; aborting add_procore_link_to_trello_card for job=%s release=%s", job, release)
+        logger.error("procore_company_id_missing", job=job, release=release)
         return None
 
     # Get project by company id
     project_id = get_projects_by_company_id(company_id, job_number)
-    print(project_id)
+    logger.debug("project_id_fetched", project_id=project_id, job=job_number)
     if not project_id:
-        logger.error("No Procore project found for job=%s release=%s company_id=%s", job_number, release_number, company_id)
+        logger.error(
+            "procore_project_not_found",
+            job=job_number,
+            release=release_number,
+            company_id=company_id,
+        )
         return None
 
     # Get submittals by project id
     # job-release
     identifier = f"{job_number}-{release_number}"
-    print(identifier)
+    logger.debug("submittal_identifier_built", identifier=identifier)
     submittals = get_submittals_by_project_id(project_id, identifier)
     if not submittals:
-        logger.error("No Procore submittals found for project_id=%s identifier=%s", project_id, identifier)
+        logger.error("procore_submittals_not_found", project_id=project_id, identifier=identifier)
         return None
     final_pdfs = get_final_pdf_viewers(project_id, submittals)
     if not final_pdfs:
@@ -1195,7 +1362,7 @@ def get_drafting_workload():
         if project['id'] == 589044:
             continue
         submittals = procore.get_submittals_for_drafting_workload(project['id'])
-        print(f"Submittals: {len(submittals)} for project {project['id']}")
+        logger.debug("project_submittals_fetched", project_id=project['id'], count=len(submittals))
         
         # Extract submittal_id and project_id for each submittal
         for submittal in submittals:
@@ -1205,7 +1372,7 @@ def get_drafting_workload():
                     'project_id': project['id']
                 })
 
-    print(f"Total submittals: {len(all_submittals)}")
+    logger.debug("drafting_workload_fetched", count=len(all_submittals))
     return all_submittals
 
 
@@ -1222,22 +1389,27 @@ def cross_reference_db_vs_api():
             - db_submittal_ids: Set of submittal IDs from DB (filtered)
             - missing_in_api: Count of submittals in DB but not in API
     """
-    logger.info("=" * 80)
-    logger.info("Starting cross-reference of DB vs API submittals")
-    logger.info("=" * 80)
-    
+    logger.debug("db_api_cross_reference_started")
+
     # Get submittals from API
-    logger.info("Fetching submittals from Procore API...")
     api_submittals = get_drafting_workload()
     api_submittal_ids = {s['submittal_id'] for s in api_submittals}
-    logger.info(f"✓ Found {len(api_submittals)} submittals from API, {len(api_submittal_ids)} unique submittal IDs")
-    
+    logger.debug("api_submittals_fetched", count=len(api_submittals), unique_count=len(api_submittal_ids))
+
     # Debug: Show sample API submittals
     if api_submittals:
-        logger.info(f"DEBUG: Sample API submittals (first 5):")
         for i, sub in enumerate(api_submittals[:5]):
-            logger.info(f"  [{i+1}] submittal_id={sub.get('submittal_id')} (type={type(sub.get('submittal_id'))}), project_id={sub.get('project_id')}")
-        logger.info(f"DEBUG: API submittal_id types: {set(type(sid).__name__ for sid in api_submittal_ids)}")
+            logger.debug(
+                "api_submittal_sample",
+                index=i + 1,
+                submittal_id=sub.get('submittal_id'),
+                submittal_id_type=type(sub.get('submittal_id')).__name__,
+                project_id=sub.get('project_id'),
+            )
+        logger.debug(
+            "api_submittal_id_types",
+            types=sorted({type(sid).__name__ for sid in api_submittal_ids}),
+        )
     
     # Filter DB submittals to match API criteria:
     # - status: "Open" (status_id 203238 in API)
@@ -1252,69 +1424,81 @@ def cross_reference_db_vs_api():
         "Submittal For Gc Approval",
     ]
     
-    logger.info(f"DEBUG: Filtering DB submittals with criteria:")
-    logger.info(f"  - status == 'Open'")
-    logger.info(f"  - type IN {valid_types}")
-    
+    logger.debug("db_submittal_filter_applied", status_filter="Open", type_filter=valid_types)
+
     # First, check total count in DB
     total_db_count = Submittals.query.count()
-    logger.info(f"DEBUG: Total submittals in DB (no filters): {total_db_count}")
-    
+    logger.debug("db_submittal_total", count=total_db_count)
+
     # Check count by status
     status_counts = db.session.query(
         Submittals.status,
         db.func.count(Submittals.id)
     ).group_by(Submittals.status).all()
-    logger.info(f"DEBUG: DB submittals by status: {dict(status_counts)}")
-    
+    logger.debug("db_submittal_status_counts", counts=dict(status_counts))
+
     # Check count by type
     type_counts = db.session.query(
         Submittals.type,
         db.func.count(Submittals.id)
     ).group_by(Submittals.type).all()
-    logger.info(f"DEBUG: DB submittals by type (top 10): {dict(type_counts[:10])}")
-    
+    logger.debug("db_submittal_type_counts", counts=dict(type_counts[:10]))
+
     # Apply filters
     db_submittals = Submittals.query.filter(
         Submittals.status == "Open",
         Submittals.type.in_(valid_types)
     ).all()
-    
-    logger.info(f"✓ Found {len(db_submittals)} submittals in database matching API criteria")
-    
+
+    logger.debug("db_submittals_filtered", count=len(db_submittals))
+
     # Debug: Show sample DB submittals
     if db_submittals:
-        logger.info(f"DEBUG: Sample DB submittals (first 5):")
         for i, sub in enumerate(db_submittals[:5]):
-            logger.info(f"  [{i+1}] submittal_id={sub.submittal_id} (type={type(sub.submittal_id).__name__}), "
-                       f"project_id={sub.procore_project_id}, status={sub.status}, type={sub.type}")
-        logger.info(f"DEBUG: DB submittal_id types: {set(type(s.submittal_id).__name__ for s in db_submittals)}")
-    
+            logger.debug(
+                "db_submittal_sample",
+                index=i + 1,
+                submittal_id=sub.submittal_id,
+                submittal_id_type=type(sub.submittal_id).__name__,
+                project_id=sub.procore_project_id,
+                submittal_status=sub.status,
+                submittal_type=sub.type,
+            )
+        logger.debug(
+            "db_submittal_id_types",
+            types=sorted({type(s.submittal_id).__name__ for s in db_submittals}),
+        )
+
     db_submittal_ids = {s.submittal_id for s in db_submittals}
-    logger.info(f"✓ Extracted {len(db_submittal_ids)} unique submittal IDs from filtered DB records")
-    
+    logger.debug("db_submittal_ids_extracted", count=len(db_submittal_ids))
+
     # Debug: Check for type mismatches
     api_id_types = {type(sid).__name__ for sid in api_submittal_ids}
     db_id_types = {type(sid).__name__ for sid in db_submittal_ids}
-    logger.info(f"DEBUG: API submittal_id types: {api_id_types}")
-    logger.info(f"DEBUG: DB submittal_id types: {db_id_types}")
-    
+    logger.debug("submittal_id_types_compared", api_types=sorted(api_id_types), db_types=sorted(db_id_types))
+
     if api_id_types != db_id_types:
-        logger.warning(f"⚠ Type mismatch detected! API IDs are {api_id_types}, DB IDs are {db_id_types}")
+        logger.warning(
+            "submittal_id_type_mismatch",
+            api_types=sorted(api_id_types),
+            db_types=sorted(db_id_types),
+        )
         # Convert both to strings for comparison
         api_submittal_ids_str = {str(sid) for sid in api_submittal_ids}
         db_submittal_ids_str = {str(sid) for sid in db_submittal_ids}
-        logger.info(f"DEBUG: Converting both to strings for comparison...")
-        logger.info(f"DEBUG: API IDs (as strings): {len(api_submittal_ids_str)}")
-        logger.info(f"DEBUG: DB IDs (as strings): {len(db_submittal_ids_str)}")
-        
+        logger.debug(
+            "submittal_ids_stringified",
+            api_count=len(api_submittal_ids_str),
+            db_count=len(db_submittal_ids_str),
+        )
+
         # Use string comparison
         db_only_ids = db_submittal_ids_str - api_submittal_ids_str
-        logger.info(f"DEBUG: Found {len(db_only_ids)} DB-only IDs (using string comparison)")
+        logger.debug("db_only_ids_found", count=len(db_only_ids), comparison="string")
     else:
         # Direct comparison
         db_only_ids = db_submittal_ids - api_submittal_ids
-        logger.info(f"DEBUG: Found {len(db_only_ids)} DB-only IDs (direct comparison)")
+        logger.debug("db_only_ids_found", count=len(db_only_ids), comparison="direct")
     
     # Find submittals in DB but not in API
     # Convert db_submittal_ids to strings if needed for matching
@@ -1323,15 +1507,21 @@ def cross_reference_db_vs_api():
         db_only_submittals = [s for s in db_submittals if str(s.submittal_id) in db_only_ids]
     else:
         db_only_submittals = [s for s in db_submittals if s.submittal_id in db_only_ids]
-    
-    logger.info(f"✓ Found {len(db_only_submittals)} submittals in DB but not in API response")
-    
+
+    logger.debug("db_only_submittals_found", count=len(db_only_submittals))
+
     # Debug: Show sample orphaned submittals
     if db_only_submittals:
-        logger.info(f"DEBUG: Sample orphaned submittals (first 5):")
         for i, sub in enumerate(db_only_submittals[:5]):
-            logger.info(f"  [{i+1}] submittal_id={sub.submittal_id}, project_id={sub.procore_project_id}, "
-                       f"title={sub.title[:50] if sub.title else 'N/A'}..., status={sub.status}, type={sub.type}")
+            logger.debug(
+                "orphaned_submittal_sample",
+                index=i + 1,
+                submittal_id=sub.submittal_id,
+                project_id=sub.procore_project_id,
+                title=sub.title[:50] if sub.title else None,
+                submittal_status=sub.status,
+                submittal_type=sub.type,
+            )
     
     # Group by project_id for easier analysis
     db_only_by_project = {}
@@ -1340,24 +1530,21 @@ def cross_reference_db_vs_api():
         if project_id not in db_only_by_project:
             db_only_by_project[project_id] = []
         db_only_by_project[project_id].append(submittal)
-    
-    logger.info(f"✓ DB-only submittals are in {len(db_only_by_project)} unique projects")
-    
+
     # Debug: Show projects with orphaned submittals
     if db_only_by_project:
-        logger.info(f"DEBUG: Projects with orphaned submittals:")
         for project_id, submittals in list(db_only_by_project.items())[:10]:
-            logger.info(f"  Project {project_id}: {len(submittals)} orphaned submittals")
-    
+            logger.debug("project_orphan_count", project_id=project_id, count=len(submittals))
+
     # Summary
-    logger.info("=" * 80)
-    logger.info("Cross-reference Summary:")
-    logger.info(f"  API submittals: {len(api_submittal_ids)}")
-    logger.info(f"  DB submittals (filtered): {len(db_submittal_ids)}")
-    logger.info(f"  Orphaned submittals (in DB, not in API): {len(db_only_submittals)}")
-    logger.info(f"  Projects with orphaned submittals: {len(db_only_by_project)}")
-    logger.info("=" * 80)
-    
+    logger.debug(
+        "db_api_cross_reference_complete",
+        api_count=len(api_submittal_ids),
+        db_count=len(db_submittal_ids),
+        orphan_count=len(db_only_submittals),
+        orphan_project_count=len(db_only_by_project),
+    )
+
     return {
         'db_only_submittals': db_only_submittals,
         'db_only_by_project': db_only_by_project,
@@ -1384,7 +1571,7 @@ def check_webhook_health(project_ids=None):
             - webhook_details: Dict mapping project_id to webhook info
             - broken_webhooks: List of projects with webhooks that appear broken
     """
-    logger.info("Starting webhook health check")
+    logger.debug("webhook_health_check_started")
     procore = get_procore_client()
     
     # If no project_ids provided, get all unique project IDs from DB
@@ -1400,11 +1587,11 @@ def check_webhook_health(project_ids=None):
             Submittals.type.in_(valid_types)
         ).distinct().all()
         project_ids = [str(p[0]) for p in db_projects if p[0]]
-        logger.info(f"Checking webhooks for {len(project_ids)} projects from database (filtered by status=Open, valid types)")
+        logger.debug("webhook_check_projects_selected", count=len(project_ids), selection="db_filtered")
     else:
         # Convert to strings for consistency
         project_ids = [str(pid) for pid in project_ids]
-        logger.info(f"Checking webhooks for {len(project_ids)} specified projects")
+        logger.debug("webhook_check_projects_selected", count=len(project_ids), selection="specified")
     
     projects_with_webhooks = []
     projects_without_webhooks = []
@@ -1423,7 +1610,7 @@ def check_webhook_health(project_ids=None):
                     'webhook_count': 0,
                     'webhooks': []
                 }
-                logger.warning(f"Project {project_id} has no webhooks")
+                logger.warning("project_webhooks_missing", project_id=project_id)
             else:
                 projects_with_webhooks.append(project_id)
                 
@@ -1464,7 +1651,14 @@ def check_webhook_health(project_ids=None):
                                 if project_id not in broken_webhooks:
                                     broken_webhooks.append(project_id)
                         except Exception as e:
-                            logger.error(f"Error checking webhook {hook_id} for project {project_id}: {e}")
+                            logger.error(
+                                "webhook_check_failed",
+                                webhook_id=hook_id,
+                                project_id=project_id,
+                                error=str(e),
+                                error_type=type(e).__name__,
+                                exc_info=True,
+                            )
                             webhook_info.append({
                                 'id': hook_id,
                                 'error': str(e)
@@ -1477,15 +1671,25 @@ def check_webhook_health(project_ids=None):
                 }
                 
         except Exception as e:
-            logger.error(f"Error checking webhooks for project {project_id}: {e}")
+            logger.error(
+                "project_webhook_check_failed",
+                project_id=project_id,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             projects_without_webhooks.append(project_id)
             webhook_details[project_id] = {
                 'has_webhook': False,
                 'error': str(e)
             }
     
-    logger.info(f"Webhook health check complete: {len(projects_with_webhooks)} with webhooks, "
-                f"{len(projects_without_webhooks)} without, {len(broken_webhooks)} broken")
+    logger.debug(
+        "webhook_health_check_complete",
+        with_webhooks=len(projects_with_webhooks),
+        without_webhooks=len(projects_without_webhooks),
+        broken=len(broken_webhooks),
+    )
     
     return {
         'projects_with_webhooks': projects_with_webhooks,
@@ -1517,18 +1721,16 @@ def comprehensive_health_scan(skip_user_prompt=False):
             - differences: Detailed list of all mismatches
             - updated_count: Number of records updated (if user confirmed)
     """
-    logger.info("=" * 80)
-    logger.info("Starting Comprehensive Health Scan")
-    logger.info("=" * 80)
-    
+    logger.debug("health_scan_started")
+
     # Step 1: Find orphaned submittals
-    logger.info("Step 1: Finding orphaned submittals (in DB but not in API response)...")
+    logger.debug("orphan_scan_started")
     cross_ref = cross_reference_db_vs_api()
     orphaned_submittals = cross_ref['db_only_submittals']
     orphaned_by_project = cross_ref['db_only_by_project']
-    
+
     if not orphaned_submittals:
-        logger.info("✓ No orphaned submittals found - all DB submittals are in API response")
+        logger.debug("orphan_scan_clean")
         return {
             'orphaned_submittals': [],
             'webhook_status': None,
@@ -1549,16 +1751,23 @@ def comprehensive_health_scan(skip_user_prompt=False):
             'updated_count': 0
         }
     
-    logger.info(f"✓ Found {len(orphaned_submittals)} orphaned submittals in {len(orphaned_by_project)} projects")
-    
+    logger.debug(
+        "orphans_found",
+        count=len(orphaned_submittals),
+        project_count=len(orphaned_by_project),
+    )
+
     # Step 2: Check webhooks for projects with orphaned submittals
-    logger.info("Step 2: Checking webhooks for projects with orphaned submittals...")
+    logger.debug("orphan_webhook_check_started")
     orphaned_project_ids = list(orphaned_by_project.keys())
     webhook_status = check_webhook_health(orphaned_project_ids)
-    logger.info(f"✓ Webhook check complete: {len(webhook_status['projects_without_webhooks'])} projects missing webhooks")
-    
+    logger.debug(
+        "orphan_webhook_check_complete",
+        projects_missing_webhooks=len(webhook_status['projects_without_webhooks']),
+    )
+
     # Step 3 & 4: Fetch API data and compare for each orphaned submittal
-    logger.info("Step 3: Fetching full submittal data from API and comparing with DB...")
+    logger.debug("orphan_comparison_started")
     procore = get_procore_client()
     differences = []
     sync_issues = []
@@ -1584,7 +1793,7 @@ def comprehensive_health_scan(skip_user_prompt=False):
                     'db_ball_in_court': submittal.ball_in_court,
                     'recommendation': 'Consider removing from DB or marking as archived'
                 })
-                logger.warning(f"  Submittal {submittal_id} (project {project_id}) not found in API - likely deleted")
+                logger.warning("submittal_missing_in_api", submittal_id=submittal_id, project_id=project_id)
                 continue
             
             # Parse ball_in_court from API data
@@ -1629,12 +1838,17 @@ def comprehensive_health_scan(skip_user_prompt=False):
                 }
                 differences.append(diff)
                 sync_issues.append(diff)
-                logger.warning(f"  ⚠ Sync issue for submittal {submittal_id}: ball_in_court mismatch={ball_mismatch}, status mismatch={status_mismatch}")
+                logger.warning(
+                    "submittal_sync_mismatch",
+                    submittal_id=submittal_id,
+                    ball_mismatch=ball_mismatch,
+                    status_mismatch=status_mismatch,
+                )
             else:
                 # Values match - submittal exists in API but wasn't in the filtered API response
                 # This could mean status/type changed, or it's filtered out for another reason
-                logger.info(f"  ✓ Submittal {submittal_id} exists in API with matching values (not in filtered response)")
-                
+                logger.debug("submittal_values_match", submittal_id=submittal_id)
+
         except Exception as e:
             # Error fetching from API
             api_fetch_errors.append({
@@ -1645,12 +1859,21 @@ def comprehensive_health_scan(skip_user_prompt=False):
                 'error': str(e),
                 'recommendation': 'Check API access and submittal permissions'
             })
-            logger.error(f"  ✗ Error fetching submittal {submittal_id} from API: {e}")
-    
-    logger.info(f"✓ Comparison complete:")
-    logger.info(f"  - Sync issues (mismatches): {len(sync_issues)}")
-    logger.info(f"  - Deleted submittals (not in API): {len(deleted_submittals)}")
-    logger.info(f"  - API fetch errors: {len(api_fetch_errors)}")
+            logger.error(
+                "submittal_fetch_failed",
+                submittal_id=submittal_id,
+                project_id=project_id,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
+
+    logger.debug(
+        "orphan_comparison_complete",
+        sync_issues=len(sync_issues),
+        deleted_submittals=len(deleted_submittals),
+        api_fetch_errors=len(api_fetch_errors),
+    )
     
     # Compile results
     summary = {
@@ -1664,105 +1887,134 @@ def comprehensive_health_scan(skip_user_prompt=False):
     }
     
     # Log detailed differences
-    logger.info("=" * 80)
-    logger.info("Detailed Differences:")
-    logger.info("=" * 80)
-    
     if sync_issues:
-        logger.info(f"\n🔴 SYNC ISSUES ({len(sync_issues)} submittals with mismatches):")
         for issue in sync_issues:
-            logger.info(f"  Submittal {issue['submittal_id']} (Project {issue['project_id']} - {issue['project_name']})")
-            logger.info(f"    Title: {issue['title']}")
+            logger.debug(
+                "sync_issue_detail",
+                submittal_id=issue['submittal_id'],
+                project_id=issue['project_id'],
+                project_name=issue['project_name'],
+                title=issue['title'],
+            )
             if issue['ball_in_court']['mismatch']:
-                logger.info(f"    ⚠ ball_in_court: DB='{issue['ball_in_court']['db']}' vs API='{issue['ball_in_court']['api']}'")
+                logger.debug(
+                    "sync_issue_ball_in_court",
+                    submittal_id=issue['submittal_id'],
+                    old=issue['ball_in_court']['db'],
+                    new=issue['ball_in_court']['api'],
+                )
             if issue['status']['mismatch']:
-                logger.info(f"    ⚠ status: DB='{issue['status']['db']}' vs API='{issue['status']['api']}'")
-            logger.info(f"    Recommendation: {issue['recommendation']}")
-            logger.info("")
-    
+                logger.debug(
+                    "sync_issue_status",
+                    submittal_id=issue['submittal_id'],
+                    old=issue['status']['db'],
+                    new=issue['status']['api'],
+                )
+
     if deleted_submittals:
-        logger.info(f"\n🟡 DELETED/ARCHIVED SUBMITTALS ({len(deleted_submittals)} submittals not found in API):")
         for deleted in deleted_submittals:
-            logger.info(f"  Submittal {deleted['submittal_id']} (Project {deleted['project_id']} - {deleted['project_name']})")
-            logger.info(f"    Title: {deleted['title']}")
-            logger.info(f"    Last known status: {deleted['db_status']}, ball_in_court: {deleted['db_ball_in_court']}")
-            logger.info(f"    Recommendation: {deleted['recommendation']}")
-            logger.info("")
-    
+            logger.debug(
+                "deleted_submittal_detail",
+                submittal_id=deleted['submittal_id'],
+                project_id=deleted['project_id'],
+                project_name=deleted['project_name'],
+                title=deleted['title'],
+                db_status=deleted['db_status'],
+                db_ball_in_court=deleted['db_ball_in_court'],
+            )
+
     if api_fetch_errors:
-        logger.info(f"\n🔴 API FETCH ERRORS ({len(api_fetch_errors)} submittals):")
         for error in api_fetch_errors:
-            logger.info(f"  Submittal {error['submittal_id']} (Project {error['project_id']} - {error['project_name']})")
-            logger.info(f"    Title: {error['title']}")
-            logger.info(f"    Error: {error['error']}")
-            logger.info(f"    Recommendation: {error['recommendation']}")
-            logger.info("")
-    
+            logger.debug(
+                "api_fetch_error_detail",
+                submittal_id=error['submittal_id'],
+                project_id=error['project_id'],
+                project_name=error['project_name'],
+                title=error['title'],
+                error=error['error'],
+            )
+
     if webhook_status['projects_without_webhooks']:
-        logger.info(f"\n🔴 PROJECTS MISSING WEBHOOKS ({len(webhook_status['projects_without_webhooks'])} projects):")
         for project_id in webhook_status['projects_without_webhooks']:
-            logger.info(f"  Project {project_id}: No webhooks configured")
-        logger.info("")
-    
-    logger.info("=" * 80)
-    logger.info("Health Scan Summary:")
-    logger.info(f"  Total orphaned submittals: {summary['total_orphaned']}")
-    logger.info(f"  Projects with orphans: {summary['projects_with_orphans']}")
-    logger.info(f"  Sync issues (mismatches): {summary['sync_issues']}")
-    logger.info(f"  Deleted/archived submittals: {summary['deleted_submittals']}")
-    logger.info(f"  API fetch errors: {summary['api_fetch_errors']}")
-    logger.info(f"  Projects missing webhooks: {summary['projects_missing_webhooks']}")
-    logger.info("=" * 80)
+            logger.debug("project_webhook_missing_detail", project_id=project_id)
+
+    logger.info(
+        "health_scan_complete",
+        total_orphaned=summary['total_orphaned'],
+        projects_with_orphans=summary['projects_with_orphans'],
+        sync_issues=summary['sync_issues'],
+        deleted_submittals=summary['deleted_submittals'],
+        api_fetch_errors=summary['api_fetch_errors'],
+        projects_missing_webhooks=summary['projects_missing_webhooks'],
+    )
     
     # Ask user if they want to update DB records to match API (only if not skipping prompt)
     updated_count = 0
     if sync_issues and not skip_user_prompt:
-        print("\n" + "=" * 80)
-        print(f"Found {len(sync_issues)} submittals with sync issues (DB values don't match API)")
-        print("=" * 80)
+        logger.info("sync_fix_prompted", count=len(sync_issues))
         user_input = input("\nWould you like to update DB records to match API values? (yes/no): ").strip().lower()
-        
+
         if user_input == 'yes':
-            logger.info("User confirmed: Updating DB records to match API values...")
+            logger.debug("sync_fix_confirmed", count=len(sync_issues))
             for issue in sync_issues:
                 try:
                     # Find the DB record
                     db_record = Submittals.query.filter_by(submittal_id=issue['submittal_id']).first()
                     if not db_record:
-                        logger.warning(f"  Could not find DB record for submittal {issue['submittal_id']}")
+                        logger.warning("submittal_record_missing", submittal_id=issue['submittal_id'])
                         continue
-                    
+
                     # Update ball_in_court if there's a mismatch
                     if issue['ball_in_court']['mismatch']:
                         old_value = db_record.ball_in_court
                         db_record.ball_in_court = issue['ball_in_court']['api']
-                        logger.info(f"  Updated submittal {issue['submittal_id']}: ball_in_court '{old_value}' -> '{issue['ball_in_court']['api']}'")
-                    
+                        logger.info(
+                            "ball_in_court_updated",
+                            submittal_id=issue['submittal_id'],
+                            old=old_value,
+                            new=issue['ball_in_court']['api'],
+                            source="health_scan",
+                        )
+
                     # Update status if there's a mismatch
                     if issue['status']['mismatch']:
                         old_value = db_record.status
                         db_record.status = issue['status']['api']
-                        logger.info(f"  Updated submittal {issue['submittal_id']}: status '{old_value}' -> '{issue['status']['api']}'")
-                    
+                        logger.info(
+                            "submittal_status_updated",
+                            submittal_id=issue['submittal_id'],
+                            old=old_value,
+                            new=issue['status']['api'],
+                            source="health_scan",
+                        )
+
                     # Update last_updated timestamp
                     db_record.last_updated = datetime.utcnow()
                     updated_count += 1
-                    
+
                 except Exception as e:
-                    logger.error(f"  Error updating submittal {issue['submittal_id']}: {e}")
-            
+                    logger.error(
+                        "submittal_update_failed",
+                        submittal_id=issue['submittal_id'],
+                        error=str(e),
+                        error_type=type(e).__name__,
+                        exc_info=True,
+                    )
+
             # Commit all changes
             try:
                 db.session.commit()
-                logger.info(f"✓ Successfully updated {updated_count} submittal records in database")
-                print(f"\n✓ Successfully updated {updated_count} submittal records in database")
+                logger.info("sync_fix_committed", count=updated_count)
             except Exception as e:
                 db.session.rollback()
-                logger.error(f"Error committing updates to database: {e}")
-                print(f"\n✗ Error committing updates to database: {e}")
+                logger.error(
+                    "sync_fix_commit_failed",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
         else:
-            logger.info("User declined to update DB records")
-            print("\nSkipping DB updates.")
+            logger.debug("sync_fix_declined")
     
     return {
         'orphaned_submittals': orphaned_submittals,
@@ -1785,11 +2037,14 @@ if __name__ == "__main__":
 
         # Comprehensive health scan
         result = comprehensive_health_scan()
-        print(f"Total orphaned submittals: {result['summary']['total_orphaned']}")
-        print(f"Projects with orphans: {result['summary']['projects_with_orphans']}")
-        print(f"Sync issues (mismatches): {result['summary']['sync_issues']}")
-        print(f"Deleted/archived submittals: {result['summary']['deleted_submittals']}")
-        print(f"API fetch errors: {result['summary']['api_fetch_errors']}")
-        print(f"Projects missing webhooks: {result['summary']['projects_missing_webhooks']}")
+        logger.info(
+            "health_scan_summary",
+            total_orphaned=result['summary']['total_orphaned'],
+            projects_with_orphans=result['summary']['projects_with_orphans'],
+            sync_issues=result['summary']['sync_issues'],
+            deleted_submittals=result['summary']['deleted_submittals'],
+            api_fetch_errors=result['summary']['api_fetch_errors'],
+            projects_missing_webhooks=result['summary']['projects_missing_webhooks'],
+        )
         if 'updated_count' in result:
-            print(f"Updated records: {result['updated_count']}")
+            logger.info("health_scan_records_updated", count=result['updated_count'])

--- a/app/procore/webhook_utils.py
+++ b/app/procore/webhook_utils.py
@@ -25,6 +25,9 @@ from typing import Dict, List, Optional, Tuple
 from app.models import db, Submittals
 from app.procore.client import get_procore_client
 from app.config import Config as cfg
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_unique_projects(include_name: bool = False) -> List[Tuple]:
@@ -51,8 +54,14 @@ def get_unique_projects(include_name: bool = False) -> List[Tuple]:
                 try:
                     project_id_int = int(project_id)
                     projects.append((project_id_int, project_number, project_name))
-                except (ValueError, TypeError):
-                    print(f"Warning: Invalid project_id {project_id}")
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        "project_id_invalid_skipped",
+                        project_id=project_id,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                        exc_info=True,
+                    )
         return projects
     else:
         results = db.session.query(
@@ -66,8 +75,15 @@ def get_unique_projects(include_name: bool = False) -> List[Tuple]:
                 try:
                     project_id_int = int(project_id)
                     projects.append((project_id_int, project_number))
-                except (ValueError, TypeError):
-                    print(f"Warning: Invalid project_id {project_id} for project_number {project_number}")
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        "project_id_invalid_skipped",
+                        project_id=project_id,
+                        project_number=project_number,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                        exc_info=True,
+                    )
         return projects
 
 
@@ -93,7 +109,13 @@ def log_operation(log_file: str, action: str, project_id: int, project_number: O
     with open(log_path, "a") as f:
         f.write(json.dumps(log_entry) + "\n")
     
-    print(f"[{status.upper()}] {action} - Project {project_id} ({project_number}): {json.dumps(data)[:100]}")
+    logger.debug(
+        "webhook_operation_logged",
+        action=action,
+        project_id=project_id,
+        project_number=project_number,
+        status=status,
+    )
 
 
 
@@ -103,7 +125,14 @@ def get_webhook_triggers(procore_client, project_id: int, hook_id: int) -> List[
         triggers = procore_client.get_webhook_triggers(project_id, hook_id)
         return triggers if triggers else []
     except Exception as e:
-        print(f"Error getting triggers for hook {hook_id} in project {project_id}: {e}")
+        logger.error(
+            "webhook_triggers_fetch_failed",
+            hook_id=hook_id,
+            project_id=project_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return []
 
 
@@ -149,6 +178,13 @@ def get_recent_deliveries(procore_client, project_id: int, hook_id: int,
         return recent_deliveries
         
     except Exception as e:
-        print(f"Error getting deliveries for hook {hook_id}: {e}")
+        logger.error(
+            "webhook_deliveries_fetch_failed",
+            hook_id=hook_id,
+            project_id=project_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return []
 

--- a/app/route_utils.py
+++ b/app/route_utils.py
@@ -47,7 +47,7 @@ def handle_errors(operation_name, raw_error=False):
                         "error_type": type(exc).__name__
                     }), 500
                 else:
-                    logger.error(f"Error in {operation_name}", error=str(exc))
+                    logger.error(f"Error in {operation_name}", error=str(exc), exc_info=True)
                     db.session.rollback()
                     return jsonify({
                         "error": f"Failed to {operation_name}",

--- a/app/route_utils.py
+++ b/app/route_utils.py
@@ -40,14 +40,16 @@ def handle_errors(operation_name, raw_error=False):
                 return f(*args, **kwargs)
             except Exception as exc:
                 if raw_error:
-                    logger.error(f"{operation_name} failed", exc_info=True)
+                    logger.error("route_operation_failed", operation=operation_name,
+                                 error=str(exc), error_type=type(exc).__name__, exc_info=True)
                     db.session.rollback()
                     return jsonify({
                         "error": str(exc),
                         "error_type": type(exc).__name__
                     }), 500
                 else:
-                    logger.error(f"Error in {operation_name}", error=str(exc), exc_info=True)
+                    logger.error("route_operation_failed", operation=operation_name,
+                                 error=str(exc), error_type=type(exc).__name__, exc_info=True)
                     db.session.rollback()
                     return jsonify({
                         "error": f"Failed to {operation_name}",

--- a/app/services/database_mapping.py
+++ b/app/services/database_mapping.py
@@ -8,7 +8,7 @@ exports:
   JobMappingResult: Dataclass capturing the match result and field diffs for one job.
   MappingStatistics: Dataclass aggregating counts and per-field update tallies for a mapping run.
   map_production_fab_order_to_sandbox: Convenience function that maps fab_order from production to sandbox in one call.
-imports_from: [sqlalchemy, pandas]
+imports_from: [sqlalchemy, pandas, app/logging_config]
 imported_by: []
 invariants:
   - Jobs are matched by (job, release) composite key — duplicates in the lookup silently overwrite earlier rows.
@@ -28,6 +28,10 @@ from datetime import datetime
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 import pandas as pd
+
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -392,7 +396,15 @@ class DatabaseMappingService:
             
             return True
         except Exception as e:
-            print(f"Error updating job {job_id}-{release}: {e}")
+            logger.error(
+                "job_fields_update_failed",
+                job=job_id,
+                release=release,
+                count=len(fields),
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             return False
 
 

--- a/app/services/job_event_service.py
+++ b/app/services/job_event_service.py
@@ -63,14 +63,15 @@ class JobEventService:
         payload_hash = hashlib.sha256(hash_string.encode('utf-8')).hexdigest()
 
         # Create event
-        logger.info(f"Creating job event", extra={
-            'job': job,
-            'release': release,
-            'action': action,
-            'source': source,
-            'external_user_id': external_user_id,
-            'internal_user_id': internal_user_id,
-        })
+        logger.debug(
+            "release_event_creating",
+            job=job,
+            release=release,
+            action=action,
+            source=source,
+            external_user_id=external_user_id,
+            user_id=internal_user_id,
+        )
 
         event = ReleaseEvents(
             job=job,
@@ -89,15 +90,25 @@ class JobEventService:
                 db.session.add(event)
                 db.session.flush()
         except IntegrityError:
-            logger.info("Duplicate event detected (DB constraint)", extra={
-                'job': job,
-                'release': release,
-                'action': action,
-                'payload_hash': payload_hash,
-            })
+            logger.debug(
+                "release_event_deduplicated",
+                job=job,
+                release=release,
+                action=action,
+                payload_hash=payload_hash,
+                status="skipped",
+            )
             return None
 
-        logger.info(f"Job event created: {event.id}")
+        logger.info(
+            "release_event_created",
+            event_id=event.id,
+            job=job,
+            release=release,
+            action=action,
+            source=source,
+            user_id=internal_user_id,
+        )
         return event
 
     @staticmethod
@@ -108,9 +119,9 @@ class JobEventService:
         event = db.session.get(ReleaseEvents, event_id)
         if event:
             event.applied_at = datetime.utcnow()
-            logger.debug(f"Event {event_id} marked as applied")
+            logger.debug("release_event_closed", event_id=event_id)
         else:
-            logger.warning(f"Attempted to close non-existent event {event_id}")
+            logger.warning("release_event_close_missing", event_id=event_id)
 
     @staticmethod
     def create_and_close(job, release, action, source, payload, external_user_id=None):

--- a/app/services/outbox_service.py
+++ b/app/services/outbox_service.py
@@ -46,7 +46,13 @@ class OutboxService:
         db.session.add(outbox_item)
         db.session.flush()
         
-        logger.debug(f"Outbox item created: {outbox_item.id} for event {event_id}")
+        logger.debug(
+            "outbox_item_created",
+            outbox_id=outbox_item.id,
+            event_id=event_id,
+            destination=destination,
+            action=action,
+        )
         return outbox_item
     
     @staticmethod
@@ -79,7 +85,14 @@ class OutboxService:
             # Get the associated event
             event = outbox_item.event
             if not event:
-                logger.error(f"Outbox {outbox_item.id}: no associated event")
+                logger.error(
+                    "outbox_event_missing",
+                    outbox_id=outbox_item.id,
+                    event_id=outbox_item.event_id,
+                    destination=outbox_item.destination,
+                    action=outbox_item.action,
+                    status="error",
+                )
                 outbox_item.status = 'failed'
                 outbox_item.error_message = "No associated event found"
                 db.session.commit()
@@ -88,7 +101,16 @@ class OutboxService:
             # Get the job record to derive card_id and other data
             job_record = Releases.query.filter_by(job=event.job, release=event.release).first()
             if not job_record:
-                logger.error(f"Outbox {outbox_item.id}: Job {event.job}-{event.release} not found")
+                logger.error(
+                    "outbox_release_not_found",
+                    outbox_id=outbox_item.id,
+                    event_id=event.id,
+                    job=event.job,
+                    release=event.release,
+                    destination=outbox_item.destination,
+                    action=outbox_item.action,
+                    status="error",
+                )
                 outbox_item.status = 'failed'
                 outbox_item.error_message = f"Job {event.job}-{event.release} not found"
                 db.session.commit()
@@ -102,7 +124,17 @@ class OutboxService:
                 # Derive stage from event payload
                 stage = event.payload.get('to')
                 if not stage:
-                    logger.error(f"Outbox {outbox_item.id}: Event payload missing 'to' field")
+                    logger.error(
+                        "outbox_payload_invalid",
+                        outbox_id=outbox_item.id,
+                        event_id=event.id,
+                        job=event.job,
+                        release=event.release,
+                        destination=outbox_item.destination,
+                        action=outbox_item.action,
+                        error="Event payload missing 'to' field",
+                        status="error",
+                    )
                     outbox_item.status = 'failed'
                     outbox_item.error_message = "Event payload missing 'to' field"
                     db.session.commit()
@@ -111,7 +143,16 @@ class OutboxService:
                 # Get card_id from job record
                 card_id = job_record.trello_card_id
                 if not card_id:
-                    logger.warning(f"Outbox {outbox_item.id}: Job {event.job}-{event.release} has no trello_card_id")
+                    logger.warning(
+                    "outbox_card_id_missing",
+                    outbox_id=outbox_item.id,
+                    event_id=event.id,
+                    job=event.job,
+                    release=event.release,
+                    destination=outbox_item.destination,
+                    action=outbox_item.action,
+                    status="error",
+                )
                     outbox_item.status = 'failed'
                     outbox_item.error_message = "Job has no trello_card_id"
                     db.session.commit()
@@ -121,7 +162,17 @@ class OutboxService:
                 from app.brain.job_log.routes import get_list_id_by_stage
                 list_id = get_list_id_by_stage(stage)
                 if not list_id:
-                    logger.error(f"Outbox {outbox_item.id}: Could not get list ID for stage '{stage}'")
+                    logger.error(
+                        "outbox_stage_unmapped",
+                        outbox_id=outbox_item.id,
+                        event_id=event.id,
+                        job=event.job,
+                        release=event.release,
+                        stage=stage,
+                        destination=outbox_item.destination,
+                        action=outbox_item.action,
+                        status="error",
+                    )
                     outbox_item.status = 'failed'
                     outbox_item.error_message = f"Could not get list ID for stage: {stage}"
                     db.session.commit()
@@ -143,8 +194,17 @@ class OutboxService:
                     JobEventService.close(event.id)
                     db.session.commit()
                     logger.info(
-                        f"[TRELLO_MOCK] move_card: job {event.job}-{event.release} "
-                        f"→ list '{target_list_name}' (id={list_id}) — skipped API call"
+                        "outbox_move_card_mocked",
+                        outbox_id=outbox_item.id,
+                        event_id=event.id,
+                        job=event.job,
+                        release=event.release,
+                        card_id=card_id,
+                        list_id=list_id,
+                        list_name=target_list_name,
+                        destination=outbox_item.destination,
+                        action=outbox_item.action,
+                        status="ok",
                     )
                     return True
 
@@ -162,7 +222,18 @@ class OutboxService:
                     JobEventService.close(event.id)
                     db.session.commit()
                     
-                    logger.info(f"Outbox {outbox_item.id} completed successfully")
+                    logger.info(
+                        "outbox_item_completed",
+                        outbox_id=outbox_item.id,
+                        event_id=event.id,
+                        job=event.job,
+                        release=event.release,
+                        card_id=card_id,
+                        destination=outbox_item.destination,
+                        action=outbox_item.action,
+                        retry_count=outbox_item.retry_count,
+                        status="ok",
+                    )
                     return True
                     
                 except Exception as api_error:
@@ -176,15 +247,33 @@ class OutboxService:
                         outbox_item.next_retry_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
                         outbox_item.status = 'pending'  # Reset to pending for retry
                         
-                        logger.warning(
-                            f"Outbox {outbox_item.id} failed, will retry ({outbox_item.retry_count}/{outbox_item.max_retries}): {str(api_error)[:100]}"
+                        logger.debug(
+                            "outbox_retry_scheduled",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     else:
                         # Max retries exceeded - mark as failed
                         outbox_item.status = 'failed'
                         logger.error(
-                            f"Outbox {outbox_item.id} failed after {outbox_item.max_retries} retries: {str(api_error)[:100]}",
-                            exc_info=True
+                            "outbox_delivery_failed",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            status="error",
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     
                     db.session.commit()
@@ -194,7 +283,16 @@ class OutboxService:
                 # Get card_id from job record
                 card_id = job_record.trello_card_id
                 if not card_id:
-                    logger.warning(f"Outbox {outbox_item.id}: Job {event.job}-{event.release} has no trello_card_id")
+                    logger.warning(
+                    "outbox_card_id_missing",
+                    outbox_id=outbox_item.id,
+                    event_id=event.id,
+                    job=event.job,
+                    release=event.release,
+                    destination=outbox_item.destination,
+                    action=outbox_item.action,
+                    status="error",
+                )
                     outbox_item.status = 'failed'
                     outbox_item.error_message = "Job has no trello_card_id"
                     db.session.commit()
@@ -239,7 +337,18 @@ class OutboxService:
                                 JobEventService.close(event.id)
                                 db.session.commit()
                                 
-                                logger.info(f"Outbox {outbox_item.id} completed successfully (fab_order update)")
+                                logger.info(
+                                    "outbox_item_completed",
+                                    outbox_id=outbox_item.id,
+                                    event_id=event.id,
+                                    job=event.job,
+                                    release=event.release,
+                                    card_id=card_id,
+                                    destination=outbox_item.destination,
+                                    action=outbox_item.action,
+                                    retry_count=outbox_item.retry_count,
+                                    status="ok",
+                                )
                                 return True
                             else:
                                 raise Exception("Failed to update Trello custom field")
@@ -254,7 +363,18 @@ class OutboxService:
                             JobEventService.close(event.id)
                             db.session.commit()
                             
-                            logger.info(f"Outbox {outbox_item.id} completed (fab_order cleared)")
+                            logger.info(
+                                "outbox_item_completed",
+                                outbox_id=outbox_item.id,
+                                event_id=event.id,
+                                job=event.job,
+                                release=event.release,
+                                card_id=card_id,
+                                destination=outbox_item.destination,
+                                action=outbox_item.action,
+                                retry_count=outbox_item.retry_count,
+                                status="skipped",
+                            )
                             return True
                     else:
                         raise Exception("FAB_ORDER_FIELD_ID not configured")
@@ -269,14 +389,32 @@ class OutboxService:
                         outbox_item.next_retry_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
                         outbox_item.status = 'pending'
                         
-                        logger.warning(
-                            f"Outbox {outbox_item.id} failed, will retry ({outbox_item.retry_count}/{outbox_item.max_retries}): {str(api_error)[:100]}"
+                        logger.debug(
+                            "outbox_retry_scheduled",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     else:
                         outbox_item.status = 'failed'
                         logger.error(
-                            f"Outbox {outbox_item.id} failed after {outbox_item.max_retries} retries: {str(api_error)[:100]}",
-                            exc_info=True
+                            "outbox_delivery_failed",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            status="error",
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     
                     db.session.commit()
@@ -286,7 +424,16 @@ class OutboxService:
                 # Get card_id from job record
                 card_id = job_record.trello_card_id
                 if not card_id:
-                    logger.warning(f"Outbox {outbox_item.id}: Job {event.job}-{event.release} has no trello_card_id")
+                    logger.warning(
+                    "outbox_card_id_missing",
+                    outbox_id=outbox_item.id,
+                    event_id=event.id,
+                    job=event.job,
+                    release=event.release,
+                    destination=outbox_item.destination,
+                    action=outbox_item.action,
+                    status="error",
+                )
                     outbox_item.status = 'failed'
                     outbox_item.error_message = "Job has no trello_card_id"
                     db.session.commit()
@@ -304,7 +451,18 @@ class OutboxService:
                     JobEventService.close(event.id)
                     db.session.commit()
                     
-                    logger.info(f"Outbox {outbox_item.id} completed (notes empty, skipping Trello)")
+                    logger.info(
+                        "outbox_item_completed",
+                        outbox_id=outbox_item.id,
+                        event_id=event.id,
+                        job=event.job,
+                        release=event.release,
+                        card_id=card_id,
+                        destination=outbox_item.destination,
+                        action=outbox_item.action,
+                        retry_count=outbox_item.retry_count,
+                        status="skipped",
+                    )
                     return True
                 
                 # Derive sender initials from the event's user
@@ -333,7 +491,18 @@ class OutboxService:
                         JobEventService.close(event.id)
                         db.session.commit()
                         
-                        logger.info(f"Outbox {outbox_item.id} completed successfully (notes update)")
+                        logger.info(
+                            "outbox_item_completed",
+                            outbox_id=outbox_item.id,
+                            event_id=event.id,
+                            job=event.job,
+                            release=event.release,
+                            card_id=card_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            status="ok",
+                        )
                         return True
                     else:
                         raise Exception("Failed to add comment to Trello card")
@@ -348,14 +517,32 @@ class OutboxService:
                         outbox_item.next_retry_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
                         outbox_item.status = 'pending'
                         
-                        logger.warning(
-                            f"Outbox {outbox_item.id} failed, will retry ({outbox_item.retry_count}/{outbox_item.max_retries}): {str(api_error)[:100]}"
+                        logger.debug(
+                            "outbox_retry_scheduled",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     else:
                         outbox_item.status = 'failed'
                         logger.error(
-                            f"Outbox {outbox_item.id} failed after {outbox_item.max_retries} retries: {str(api_error)[:100]}",
-                            exc_info=True
+                            "outbox_delivery_failed",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            status="error",
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     
                     db.session.commit()
@@ -389,10 +576,18 @@ class OutboxService:
                         JobEventService.close(event.id)
                         db.session.commit()
 
-                        adopted_note = " (adopted existing card)" if trello_result.get('adopted') else ""
                         logger.info(
-                            f"Outbox {outbox_item.id} completed successfully "
-                            f"(create_card for {event.job}-{event.release}){adopted_note}"
+                            "outbox_item_completed",
+                            outbox_id=outbox_item.id,
+                            event_id=event.id,
+                            job=event.job,
+                            release=event.release,
+                            card_id=job_record.trello_card_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            adopted=bool(trello_result.get('adopted')),
+                            status="ok",
                         )
                         return True
                     else:
@@ -408,14 +603,32 @@ class OutboxService:
                         outbox_item.next_retry_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
                         outbox_item.status = 'pending'
 
-                        logger.warning(
-                            f"Outbox {outbox_item.id} failed, will retry ({outbox_item.retry_count}/{outbox_item.max_retries}): {str(api_error)[:100]}"
+                        logger.debug(
+                            "outbox_retry_scheduled",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     else:
                         outbox_item.status = 'failed'
                         logger.error(
-                            f"Outbox {outbox_item.id} failed after {outbox_item.max_retries} retries: {str(api_error)[:100]}",
-                            exc_info=True
+                            "outbox_delivery_failed",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            status="error",
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
 
                     db.session.commit()
@@ -425,7 +638,16 @@ class OutboxService:
                 # Get card_id from job record
                 card_id = job_record.trello_card_id
                 if not card_id:
-                    logger.warning(f"Outbox {outbox_item.id}: Job {event.job}-{event.release} has no trello_card_id")
+                    logger.warning(
+                    "outbox_card_id_missing",
+                    outbox_id=outbox_item.id,
+                    event_id=event.id,
+                    job=event.job,
+                    release=event.release,
+                    destination=outbox_item.destination,
+                    action=outbox_item.action,
+                    status="error",
+                )
                     outbox_item.status = 'failed'
                     outbox_item.error_message = "Job has no trello_card_id"
                     db.session.commit()
@@ -449,7 +671,18 @@ class OutboxService:
                     JobEventService.close(event.id)
                     db.session.commit()
 
-                    logger.info(f"Outbox {outbox_item.id} completed (no Trello-relevant fields changed)")
+                    logger.info(
+                        "outbox_item_completed",
+                        outbox_id=outbox_item.id,
+                        event_id=event.id,
+                        job=event.job,
+                        release=event.release,
+                        card_id=card_id,
+                        destination=outbox_item.destination,
+                        action=outbox_item.action,
+                        retry_count=outbox_item.retry_count,
+                        status="skipped",
+                    )
                     return True
 
                 # Execute the Trello API call(s)
@@ -495,7 +728,13 @@ class OutboxService:
                         )
                     except Exception as mirror_error:
                         logger.warning(
-                            f"Outbox {outbox_item.id}: failed to sync mirror card content: {mirror_error}"
+                            "mirror_card_sync_failed",
+                            outbox_id=outbox_item.id,
+                            event_id=event.id,
+                            card_id=card_id,
+                            error=str(mirror_error),
+                            error_type=type(mirror_error).__name__,
+                            exc_info=True,
                         )
 
                     # Success! Mark outbox item as completed
@@ -508,7 +747,18 @@ class OutboxService:
                     JobEventService.close(event.id)
                     db.session.commit()
 
-                    logger.info(f"Outbox {outbox_item.id} completed successfully (update_release_fields)")
+                    logger.info(
+                        "outbox_item_completed",
+                        outbox_id=outbox_item.id,
+                        event_id=event.id,
+                        job=event.job,
+                        release=event.release,
+                        card_id=card_id,
+                        destination=outbox_item.destination,
+                        action=outbox_item.action,
+                        retry_count=outbox_item.retry_count,
+                        status="ok",
+                    )
                     return True
 
                 except Exception as api_error:
@@ -521,14 +771,32 @@ class OutboxService:
                         outbox_item.next_retry_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
                         outbox_item.status = 'pending'
 
-                        logger.warning(
-                            f"Outbox {outbox_item.id} failed, will retry ({outbox_item.retry_count}/{outbox_item.max_retries}): {str(api_error)[:100]}"
+                        logger.debug(
+                            "outbox_retry_scheduled",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
                     else:
                         outbox_item.status = 'failed'
                         logger.error(
-                            f"Outbox {outbox_item.id} failed after {outbox_item.max_retries} retries: {str(api_error)[:100]}",
-                            exc_info=True
+                            "outbox_delivery_failed",
+                            outbox_id=outbox_item.id,
+                            event_id=outbox_item.event_id,
+                            destination=outbox_item.destination,
+                            action=outbox_item.action,
+                            retry_count=outbox_item.retry_count,
+                            max_retries=outbox_item.max_retries,
+                            status="error",
+                            error=str(api_error),
+                            error_type=type(api_error).__name__,
+                            exc_info=True,
                         )
 
                     db.session.commit()
@@ -536,7 +804,14 @@ class OutboxService:
 
             else:
                 # Unsupported destination/action combination
-                logger.error(f"Outbox {outbox_item.id}: Unsupported {outbox_item.destination}/{outbox_item.action}")
+                logger.error(
+                    "outbox_action_unsupported",
+                    outbox_id=outbox_item.id,
+                    event_id=event.id,
+                    destination=outbox_item.destination,
+                    action=outbox_item.action,
+                    status="error",
+                )
                 outbox_item.status = 'failed'
                 outbox_item.error_message = f"Unsupported: {outbox_item.destination}/{outbox_item.action}"
                 db.session.commit()
@@ -544,7 +819,18 @@ class OutboxService:
                 
         except Exception as e:
             # Unexpected error during processing
-            logger.error(f"Outbox {outbox_item.id}: Unexpected error: {e}", exc_info=True)
+            logger.error(
+                "outbox_process_failed",
+                outbox_id=outbox_item.id,
+                event_id=outbox_item.event_id,
+                destination=outbox_item.destination,
+                action=outbox_item.action,
+                retry_count=outbox_item.retry_count,
+                status="error",
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
             outbox_item.status = 'pending'  # Reset to pending so it can be retried
             outbox_item.error_message = f"Unexpected error: {str(e)}"
             outbox_item.retry_count += 1
@@ -597,7 +883,17 @@ class OutboxService:
                         if list_id:
                             lists_to_sort.add(list_id)
             except Exception as e:
-                logger.error(f"Error processing outbox {item.id}: {e}", exc_info=True)
+                logger.error(
+                    "outbox_batch_item_failed",
+                    outbox_id=item.id,
+                    event_id=item.event_id,
+                    destination=item.destination,
+                    action=item.action,
+                    retry_count=item.retry_count,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
 
         # Batch sort: sort each affected list once after all fab_order updates
         if lists_to_sort:
@@ -608,8 +904,18 @@ class OutboxService:
                     try:
                         sort_list_if_needed(list_id, cfg.FAB_ORDER_FIELD_ID, None, "batch")
                     except Exception as e:
-                        logger.error(f"Batch sort failed for list {list_id}: {e}", exc_info=True)
+                        logger.error(
+                            "trello_list_sort_failed",
+                            list_id=list_id,
+                            error=str(e),
+                            error_type=type(e).__name__,
+                            exc_info=True,
+                        )
 
         if processed_count > 0:
-            logger.debug(f"Processed {processed_count}/{len(pending_items)} outbox items")
+            logger.debug(
+                "outbox_batch_processed",
+                count=processed_count,
+                batch_size=len(pending_items),
+            )
         return processed_count

--- a/app/services/system_log_service.py
+++ b/app/services/system_log_service.py
@@ -23,7 +23,14 @@ class SystemLogService:
         from app.models import SystemLogs, db
         import traceback
         
-        logger.error(f"System error: {category} in {operation}", exc_info=True)
+        logger.error(
+            "system_error_logged",
+            category=category,
+            operation=operation,
+            error=str(error),
+            error_type=type(error).__name__,
+            exc_info=True,
+        )
         
         system_log = SystemLogs(
             timestamp=datetime.utcnow(),

--- a/app/sync_lock.py
+++ b/app/sync_lock.py
@@ -15,12 +15,13 @@ invariants:
 updated_by_agent: 2026-04-14T00:00:00Z (commit e133a47)
 """
 import threading
-import logging
 from contextlib import contextmanager
 from typing import Optional
 from datetime import datetime
 
-logger = logging.getLogger(__name__)
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class SyncLockManager:
@@ -71,12 +72,13 @@ class SyncLockManager:
                     current_op = self._current_operation
                     # If the same thread holds it, allow reentrancy without error
                     if self._holder_thread_id == current_thread_id:
-                        logger.info(f"Re-entrant sync lock for operation: {operation_name}")
+                        logger.debug("sync_lock_reentered", operation=operation_name,
+                                     thread_id=current_thread_id)
                     else:
-                        logger.warning(
-                            f"Sync lock already held by '{current_op}' (thread {self._holder_thread_id}). "
-                            f"Cannot acquire for '{operation_name}' (thread {current_thread_id})"
-                        )
+                        logger.warning("sync_lock_contended", operation=operation_name,
+                                       held_by=current_op,
+                                       holder_thread_id=self._holder_thread_id,
+                                       thread_id=current_thread_id)
                         raise RuntimeError(f"Sync already in progress: {current_op}")
 
                 self._is_syncing = True
@@ -84,7 +86,8 @@ class SyncLockManager:
                 self._holder_thread_id = current_thread_id
                 self._acquired_at = datetime.now()
                 acquired = True
-                logger.info(f"Sync lock acquired for operation: {operation_name} (thread {current_thread_id})")
+                logger.debug("sync_lock_acquired", operation=operation_name,
+                             thread_id=current_thread_id)
             finally:
                 # Release the manager mutex so work can happen while state is busy
                 self._lock.release()
@@ -98,7 +101,7 @@ class SyncLockManager:
                     self._current_operation = None
                     self._holder_thread_id = None
                     self._acquired_at = None
-                    logger.info(f"Sync lock released for operation: {operation_name}")
+                    logger.debug("sync_lock_released", operation=operation_name)
 
     def get_status(self) -> dict:
         """Get current status of the lock manager"""
@@ -131,7 +134,7 @@ def synchronized_sync(operation_name: str):
                 with sync_lock_manager.acquire_sync_lock(operation_name):
                     return func(*args, **kwargs)
             except RuntimeError as e:
-                logger.warning(f"Cannot execute {operation_name}: {e}")
+                logger.warning("sync_lock_unavailable", operation=operation_name, error=str(e))
                 raise
 
         return wrapper

--- a/app/sync_lock.py
+++ b/app/sync_lock.py
@@ -20,8 +20,6 @@ from contextlib import contextmanager
 from typing import Optional
 from datetime import datetime
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/app/trello/__init__.py
+++ b/app/trello/__init__.py
@@ -21,11 +21,14 @@ from flask import Blueprint, request, current_app, jsonify
 from app.trello.utils import parse_webhook_data
 from app.trello.sync import sync_from_trello
 from app.sync_lock import sync_lock_manager
+from app.logging_config import get_logger
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from collections import defaultdict
 from queue import Queue, Full, Empty
 import time
+
+logger = get_logger(__name__)
 
 
 class ThreadTracker:
@@ -87,7 +90,7 @@ def trello_webhook():
 
     if request.method == "POST":
         if current_app.config.get("TRELLO_MOCK"):
-            current_app.logger.info("[TRELLO_MOCK] inbound webhook dropped")
+            logger.info("trello_mock_webhook_dropped", source="trello")
             return "", 200
 
         data = request.json
@@ -97,7 +100,7 @@ def trello_webhook():
         # Skip unhandled webhooks
         if not event_info.get("handled"):
             action_type = event_info.get("action_type", "unknown")
-            app.logger.debug(f"Skipping unhandled webhook: {action_type}")
+            logger.debug("trello_webhook_skipped", action_type=action_type, source="trello")
             return "", 200
 
         # If locked, enqueue the event for later processing and return 202
@@ -106,11 +109,22 @@ def trello_webhook():
             try:
                 trello_event_queue.put_nowait(event_info)
                 thread_tracker.thread_rejected()
-                app.logger.info(f"Trello webhook queued due to active lock: {current_op}")
+                logger.info(
+                    "trello_webhook_queued",
+                    lock_holder=current_op,
+                    card_id=event_info.get("card_id"),
+                    source="trello",
+                    status="queued",
+                )
                 return jsonify({"status": "queued", "reason": f"lock_held_by_{current_op}"}), 202
             except Full:
                 thread_tracker.thread_rejected()
-                app.logger.warning("Trello event queue is full; dropping event")
+                logger.warning(
+                    "trello_queue_full",
+                    card_id=event_info.get("card_id"),
+                    source="trello",
+                    status="skipped",
+                )
                 return jsonify({"status": "overloaded"}), 429
 
         def run_sync():
@@ -124,11 +138,22 @@ def trello_webhook():
                     # between the initial check and thread execution
                     if sync_lock_manager.is_locked():
                         current_op = sync_lock_manager.get_current_operation()
-                        app.logger.info(f"Lock acquired by {current_op} before thread execution - queuing event")
+                        logger.info(
+                            "trello_webhook_requeued",
+                            lock_holder=current_op,
+                            card_id=event_info.get("card_id"),
+                            source="trello",
+                            status="queued",
+                        )
                         try:
                             trello_event_queue.put_nowait(event_info)
                         except Full:
-                            app.logger.warning("Queue full while requeuing - dropping event")
+                            logger.warning(
+                                "trello_event_requeue_failed",
+                                reason="queue_full",
+                                card_id=event_info.get("card_id"),
+                                source="trello",
+                            )
                         duration = thread_tracker.thread_completed(thread_id, success=False)
                         thread_tracker.thread_rejected()
                         return
@@ -136,20 +161,30 @@ def trello_webhook():
                     # Try to acquire the sync lock in the thread
                     try:
                         with sync_lock_manager.acquire_sync_lock("Trello-Hook"):
-                            app.logger.debug("Trello sync started with lock acquired")
+                            logger.debug("trello_sync_started", card_id=event_info.get("card_id"), source="trello")
                             sync_from_trello(event_info)
-                            app.logger.debug("Trello sync completed successfully")
+                            logger.debug("trello_sync_finished", card_id=event_info.get("card_id"), source="trello")
 
                         duration = thread_tracker.thread_completed(
                             thread_id, success=True
                         )
-                        app.logger.info(f"Sync completed in {duration:.2f}s")
+                        logger.info(
+                            "trello_sync_completed",
+                            duration_ms=int(duration * 1000),
+                            card_id=event_info.get("card_id"),
+                            source="trello",
+                            status="ok",
+                        )
 
                     except RuntimeError as lock_error:
                         # Lock acquisition failed - this shouldn't happen since we checked above
                         # but it's possible another sync started between the check and thread execution
-                        app.logger.warning(
-                            f"Trello sync lock acquisition failed in thread: {lock_error}"
+                        logger.warning(
+                            "trello_sync_lock_failed",
+                            error=str(lock_error),
+                            error_type=type(lock_error).__name__,
+                            card_id=event_info.get("card_id"),
+                            source="trello",
                         )
                         duration = thread_tracker.thread_completed(
                             thread_id, success=False
@@ -158,7 +193,16 @@ def trello_webhook():
 
             except Exception as e:
                 duration = thread_tracker.thread_completed(thread_id, success=False)
-                app.logger.error(f"Sync failed after {duration:.2f}s: {e}")
+                logger.error(
+                    "trello_sync_failed",
+                    duration_ms=int(duration * 1000) if duration is not None else None,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    card_id=event_info.get("card_id"),
+                    source="trello",
+                    status="error",
+                    exc_info=True,
+                )
 
         # Submit to thread pool and attach error callback
         future = executor.submit(run_sync)
@@ -166,9 +210,16 @@ def trello_webhook():
             try:
                 _ = f.result()
             except Exception as e:
-                app.logger.error(f"Trello sync task failed: {e}")
+                logger.error(
+                    "trello_sync_task_failed",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    source="trello",
+                    status="error",
+                    exc_info=True,
+                )
         future.add_done_callback(_log_future)
-        app.logger.debug("Trello webhook submitted to thread pool")
+        logger.debug("trello_webhook_submitted", card_id=event_info.get("card_id"), source="trello")
 
     return "", 200
 
@@ -204,23 +255,50 @@ def drain_trello_queue(max_items: int = 5):
                 with app.app_context():
                     try:
                         with sync_lock_manager.acquire_sync_lock("Trello-Queue"):
-                            app.logger.info("Drained Trello event started with lock acquired")
+                            logger.info("trello_drain_sync_started", card_id=evt.get("card_id"), source="trello")
                             sync_from_trello(evt)
-                            app.logger.info("Drained Trello event completed successfully")
+                            logger.info("trello_drain_sync_finished", card_id=evt.get("card_id"), source="trello")
                         duration = thread_tracker.thread_completed(thread_id, success=True)
-                        app.logger.info(f"Drained sync completed in {duration:.2f}s")
+                        logger.info(
+                            "trello_drain_sync_completed",
+                            duration_ms=int(duration * 1000),
+                            card_id=evt.get("card_id"),
+                            source="trello",
+                            status="ok",
+                        )
                     except RuntimeError as lock_error:
                         # Could not acquire (race); requeue and stop draining
-                        app.logger.info(f"Queue drain lock contention: {lock_error}")
+                        logger.info(
+                            "trello_drain_lock_contention",
+                            error=str(lock_error),
+                            error_type=type(lock_error).__name__,
+                            card_id=evt.get("card_id"),
+                            source="trello",
+                            status="queued",
+                        )
                         try:
                             trello_event_queue.put_nowait(evt)
                         except Full:
-                            app.logger.warning("Queue full while requeuing drained event; dropping")
+                            logger.warning(
+                                "trello_drain_requeue_failed",
+                                reason="queue_full",
+                                card_id=evt.get("card_id"),
+                                source="trello",
+                            )
                         thread_tracker.thread_completed(thread_id, success=False)
                         return False
             except Exception as e:
                 duration = thread_tracker.thread_completed(thread_id, success=False)
-                app.logger.error(f"Drained sync failed after {duration:.2f}s: {e}")
+                logger.error(
+                    "trello_drain_sync_failed",
+                    duration_ms=int(duration * 1000) if duration is not None else None,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    card_id=evt.get("card_id"),
+                    source="trello",
+                    status="error",
+                    exc_info=True,
+                )
                 return True
             return True
 

--- a/app/trello/__init__.py
+++ b/app/trello/__init__.py
@@ -97,7 +97,7 @@ def trello_webhook():
         # Skip unhandled webhooks
         if not event_info.get("handled"):
             action_type = event_info.get("action_type", "unknown")
-            app.logger.info(f"Skipping unhandled webhook: {action_type}")
+            app.logger.debug(f"Skipping unhandled webhook: {action_type}")
             return "", 200
 
         # If locked, enqueue the event for later processing and return 202
@@ -136,9 +136,9 @@ def trello_webhook():
                     # Try to acquire the sync lock in the thread
                     try:
                         with sync_lock_manager.acquire_sync_lock("Trello-Hook"):
-                            app.logger.info("Trello sync started with lock acquired")
+                            app.logger.debug("Trello sync started with lock acquired")
                             sync_from_trello(event_info)
-                            app.logger.info("Trello sync completed successfully")
+                            app.logger.debug("Trello sync completed successfully")
 
                         duration = thread_tracker.thread_completed(
                             thread_id, success=True
@@ -168,7 +168,7 @@ def trello_webhook():
             except Exception as e:
                 app.logger.error(f"Trello sync task failed: {e}")
         future.add_done_callback(_log_future)
-        app.logger.info("Trello webhook submitted to thread pool")
+        app.logger.debug("Trello webhook submitted to thread pool")
 
     return "", 200
 

--- a/app/trello/api.py
+++ b/app/trello/api.py
@@ -36,6 +36,10 @@ from datetime import datetime
 import pandas as pd
 import math
 
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
 
 # Main function for updating trello card information
 def update_trello_card(
@@ -70,8 +74,14 @@ def update_trello_card(
     # If neither new_due_date nor clear_due_date, don't include 'due' parameter at all
 
     try:
-        # Log the payload for debugging
-        print(f"[TRELLO API] Updating card {card_id} with payload: {payload}")
+        # Log the update parameters for debugging (never the payload itself — it carries credentials)
+        logger.debug(
+            "card_update_requested",
+            card_id=card_id,
+            new_list_id=new_list_id,
+            due=payload.get("due"),
+            clear_due_date=clear_due_date,
+        )
 
         # Use JSON when clearing due dates (null values), otherwise use URL params
         if clear_due_date and payload.get("due") is None:
@@ -87,15 +97,27 @@ def update_trello_card(
 
         response.raise_for_status()  # Raise an exception for HTTP errors (4xx or 5xx)
 
-        print(f"[TRELLO API] Card {card_id} updated successfully")
+        logger.debug("card_updated", card_id=card_id)
         return response.json()
 
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error updating card {card_id}: {http_err}")
-        print("[TRELLO API] Response content:", response.text)
+        logger.error(
+            "card_update_failed",
+            card_id=card_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
+        logger.debug("card_update_error_response", card_id=card_id, body=response.text)
         raise
     except Exception as err:
-        print(f"[TRELLO API] Other error updating card {card_id}: {err}")
+        logger.error(
+            "card_update_failed",
+            card_id=card_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         raise
 
 
@@ -129,7 +151,12 @@ def _refresh_board_lists_cache():
         response.raise_for_status()
         lists = response.json()
     except Exception as e:
-        print(f"[TRELLO API] Error refreshing board lists cache: {e}")
+        logger.error(
+            "board_lists_cache_refresh_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return
 
     by_name = {}
@@ -178,7 +205,8 @@ def get_list_name_by_id(list_id):
             _board_lists_by_name[name] = new_entry
         return name
     else:
-        print(f"Trello API error: {response.status_code} {response.text}")
+        logger.warning("list_fetch_failed", list_id=list_id, status=response.status_code)
+        logger.debug("list_fetch_error_response", list_id=list_id, body=response.text)
         return None
 
 
@@ -207,7 +235,12 @@ def get_board_info(board_id=None):
         data = response.json()
         return {"id": data.get("id"), "name": data.get("name"), "url": data.get("url")}
     except Exception as e:
-        print(f"Trello API error fetching board: {e}")
+        logger.error(
+            "board_fetch_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return None
 
 
@@ -229,7 +262,8 @@ def get_trello_card_by_id(card_id):
     if response.status_code == 200:
         return response.json()
     else:
-        print(f"Trello API error: {response.status_code} {response.text}")
+        logger.warning("card_fetch_failed", card_id=card_id, status=response.status_code)
+        logger.debug("card_fetch_error_response", card_id=card_id, body=response.text)
         return None
 
 
@@ -380,45 +414,56 @@ def check_job_exists_in_db(job_number, release_number):
         Exception: For debugging purposes - will be caught and logged by caller
     """
     try:
-        print(f"[DEBUG] Checking for job: {job_number}-{release_number}")
+        logger.debug("job_lookup_started", job=str(job_number), release=str(release_number))
 
         # Convert job_number to int, keep release_number as string to preserve format like "v862"
         try:
             job_int = int(job_number)
         except (ValueError, TypeError):
             error_msg = f"Invalid job number: {job_number} - cannot convert to integer"
-            print(f"[ERROR] {error_msg}")
+            logger.error("job_number_invalid", job=str(job_number), error=error_msg, exc_info=True)
             raise Exception(error_msg)
 
         release_str = str(release_number)
 
-        print(
-            f"[DEBUG] Converted identifiers - job_int: {job_int}, release_str: {release_str}"
-        )
+        logger.debug("job_identifiers_converted", job=str(job_int), release=release_str)
 
         # Use Flask application context for database access
         existing_job = Releases.query.filter_by(
             job=job_int, release=release_str
         ).one_or_none()
-        print(
-            f"[DEBUG] Database query completed, found job: {existing_job is not None}"
+        logger.debug(
+            "job_lookup_completed",
+            job=str(job_int),
+            release=release_str,
+            found=existing_job is not None,
         )
 
         return existing_job
 
     except (ValueError, TypeError) as e:
         error_msg = f"Invalid job or release identifiers: job={job_number}, release={release_number}, error={str(e)}"
-        print(f"[ERROR] {error_msg}")
+        logger.error(
+            "job_lookup_invalid_identifiers",
+            job=str(job_number),
+            release=str(release_number),
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         raise Exception(error_msg)
     except Exception as e:
         error_msg = (
             f"Database error checking for job {job_number}-{release_number}: {str(e)}"
         )
-        print(f"[ERROR] {error_msg}")
-        print(f"[ERROR] Exception type: {type(e).__name__}")
-        import traceback
-
-        print(f"[ERROR] Traceback: {traceback.format_exc()}")
+        logger.error(
+            "job_lookup_failed",
+            job=str(job_number),
+            release=str(release_number),
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         raise Exception(error_msg)
 
 
@@ -468,7 +513,12 @@ def create_job_record_from_excel_data(excel_data):
         try:
             job_number = int(job_val) if job_val is not None else 0
         except (ValueError, TypeError):
-            print(f"[ERROR] Invalid Job # value: {job_val} - cannot convert to integer")
+            logger.error(
+                "job_number_invalid",
+                job=str(job_val),
+                error="Invalid Job # value - cannot convert to integer",
+                exc_info=True,
+            )
             return None
 
         release_number = str(excel_data.get("Release #", ""))
@@ -515,16 +565,21 @@ def create_job_record_from_excel_data(excel_data):
         db.session.add(new_job)
         db.session.commit()
 
-        print(
-            f"[DEBUG] Created Job record: {job_number}-{release_number} (ID: {new_job.id})"
+        logger.info(
+            "release_record_created",
+            job=str(job_number),
+            release=release_number,
+            release_id=new_job.id,
         )
         return new_job
 
     except Exception as e:
-        print(f"[ERROR] Failed to create Job record: {str(e)}")
-        import traceback
-
-        print(f"[ERROR] Traceback: {traceback.format_exc()}")
+        logger.error(
+            "release_record_create_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         db.session.rollback()
         return None
 
@@ -572,14 +627,16 @@ def update_job_record_with_trello_data(job_record, card_data):
         db.session.commit()
 
         # Use the stored ID instead of accessing the expired object
-        print(f"[DEBUG] Updated Job record {job_id} with Trello data")
+        logger.debug("release_record_trello_data_updated", release_id=job_id)
         return True
 
     except Exception as e:
-        print(f"[ERROR] Failed to update Job record with Trello data: {str(e)}")
-        import traceback
-
-        print(f"[ERROR] Traceback: {traceback.format_exc()}")
+        logger.error(
+            "release_record_trello_update_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         db.session.rollback()
         return False
 
@@ -597,27 +654,39 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
         Dictionary with card creation result
     """
     try:
-        print(f"[DEBUG] Starting card creation with data: {excel_data}")
+        logger.debug("card_creation_started", payload=excel_data)
 
         # Check for duplicate job in database first
         job_number = excel_data.get("Job #")
         release_number = excel_data.get("Release #")
 
-        print(
-            f"[DEBUG] Extracted identifiers - Job #: {job_number}, Release #: {release_number}"
+        logger.debug(
+            "card_creation_identifiers_extracted",
+            job=str(job_number),
+            release=str(release_number),
         )
 
         if not job_number or not release_number:
             error_msg = "Missing Job # or Release # in Excel data"
-            print(f"[ERROR] {error_msg}")
+            logger.warning(
+                "card_creation_missing_identifiers",
+                job=str(job_number),
+                release=str(release_number),
+            )
             return {"success": False, "error": error_msg}
 
-        print(f"[DEBUG] Checking for duplicate job in database...")
+        logger.debug("duplicate_job_check_started", job=str(job_number), release=str(release_number))
         existing_job = check_job_exists_in_db(job_number, release_number)
 
         if existing_job:
             error_msg = f"Job {job_number}-{release_number} already exists in database"
-            print(f"[DEBUG] {error_msg}")
+            logger.debug(
+                "card_creation_skipped_duplicate",
+                job=str(job_number),
+                release=str(release_number),
+                release_id=existing_job.id,
+                card_id=existing_job.trello_card_id,
+            )
             return {
                 "success": False,
                 "error": error_msg,
@@ -625,16 +694,16 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
                 "existing_trello_card_id": existing_job.trello_card_id,
             }
 
-        print(f"[DEBUG] No duplicate found, proceeding with card creation...")
+        logger.debug("duplicate_job_check_passed", job=str(job_number), release=str(release_number))
 
         # Create database record with Excel data first
-        print(f"[DEBUG] Creating database record with Excel data...")
+        logger.debug("release_record_create_started", job=str(job_number), release=str(release_number))
         new_job = create_job_record_from_excel_data(excel_data)
 
         if not new_job:
             return {"success": False, "error": "Failed to create database record"}
 
-        print(f"[DEBUG] Database record created: Job {new_job.id}")
+        logger.debug("release_record_ready", release_id=new_job.id)
 
         # Determine Trello list to create the card in
         if list_name:
@@ -708,22 +777,37 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
             "pos": "top",  # Add to top of list
         }
 
-        print(f"[TRELLO API] Creating card with payload: {payload}")
+        logger.debug(
+            "trello_card_create_requested",
+            job=str(job_number),
+            release=str(release_number),
+            list_id=list_id,
+        )
 
         response = requests.post(url, params=payload)
         response.raise_for_status()
 
         card_data = response.json()
-        print(f"[TRELLO API] Card created successfully: {card_data['id']}")
+        logger.info(
+            "trello_card_created",
+            card_id=card_data["id"],
+            job=str(job_number),
+            release=str(release_number),
+            list_id=list_id,
+        )
 
         # Update the existing database record with Trello card data
-        print(f"[DEBUG] Updating database record with Trello card data...")
+        logger.debug("release_record_trello_update_started", release_id=new_job.id)
         success = update_job_record_with_trello_data(new_job, card_data)
 
         if success:
-            print(f"[DEBUG] Successfully updated database record with Trello data")
+            logger.debug("release_record_trello_data_saved", release_id=new_job.id)
         else:
-            print(f"[ERROR] Failed to update database record with Trello data")
+            logger.warning(
+                "release_record_trello_update_incomplete",
+                release_id=new_job.id,
+                card_id=card_data["id"],
+            )
 
         # Handle Fab Order custom field - set if value exists in Excel
         fab_order_value = excel_data.get("Fab Order")
@@ -741,8 +825,10 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
                         card_data["id"], cfg.FAB_ORDER_FIELD_ID, fab_order_int
                     )
                     if fab_order_success:
-                        print(
-                            f"[DEBUG] Successfully set Fab Order custom field to {fab_order_int}"
+                        logger.debug(
+                            "fab_order_field_set",
+                            card_id=card_data["id"],
+                            fab_order=fab_order_int,
                         )
 
                         # Sort the list if it's one of the target lists
@@ -755,14 +841,25 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
                             "list",
                         )
                     else:
-                        print(f"[ERROR] Failed to set Fab Order custom field")
+                        logger.warning(
+                            "fab_order_field_set_failed",
+                            card_id=card_data["id"],
+                            fab_order=fab_order_int,
+                        )
                 else:
-                    print(
-                        f"[WARNING] FAB_ORDER_FIELD_ID not configured, skipping Fab Order custom field"
+                    logger.warning(
+                        "fab_order_field_skipped",
+                        card_id=card_data["id"],
+                        reason="FAB_ORDER_FIELD_ID not configured",
                     )
             except (ValueError, TypeError) as e:
-                print(
-                    f"[ERROR] Could not convert Fab Order '{fab_order_value}' to int: {e}"
+                logger.error(
+                    "fab_order_conversion_failed",
+                    card_id=card_data["id"],
+                    fab_order_value=str(fab_order_value),
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    exc_info=True,
                 )
 
         # Handle notes field - append as comment if not empty
@@ -774,19 +871,19 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
             and str(notes_value).strip()
             and str(notes_value).strip().lower() not in ["nan", "none"]
         ):
-            print(
-                f"[DEBUG] Notes field found, appending as comment to Trello card: {notes_value}"
-            )
+            logger.debug("notes_comment_add_started", card_id=card_data["id"])
             comment_success = add_comment_to_trello_card(
                 card_data["id"], str(notes_value).strip()
             )
             if comment_success:
-                print(f"[DEBUG] Successfully added notes as comment to Trello card")
+                logger.debug("notes_comment_added", card_id=card_data["id"])
             else:
-                print(f"[ERROR] Failed to add notes as comment to Trello card")
+                logger.warning("notes_comment_add_failed", card_id=card_data["id"])
         else:
-            print(
-                f"[DEBUG] No notes field, empty notes, NaN value, or 'nan'/'none' string, skipping comment addition"
+            logger.debug(
+                "notes_comment_skipped",
+                card_id=card_data["id"],
+                reason="empty or missing notes",
             )
 
         # Add FC Drawing link if viewer_url exists on the job
@@ -796,13 +893,20 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
                     card_data["id"], new_job.viewer_url, link_name="FC Drawing"
                 )
                 if link_result.get("success"):
-                    print(f"[DEBUG] Added FC Drawing link to card {card_data['id']}")
+                    logger.debug("fc_drawing_link_added", card_id=card_data["id"])
                 else:
-                    print(
-                        f"[WARNING] Failed to add FC Drawing link: {link_result.get('error')}"
+                    logger.warning(
+                        "fc_drawing_link_add_failed",
+                        card_id=card_data["id"],
+                        error=link_result.get("error"),
                     )
             except Exception as link_err:
-                print(f"[WARNING] Error adding FC Drawing link: {link_err}")
+                logger.warning(
+                    "fc_drawing_link_add_failed",
+                    card_id=card_data["id"],
+                    error=str(link_err),
+                    error_type=type(link_err).__name__,
+                )
 
         return {
             "success": True,
@@ -813,23 +917,37 @@ def create_trello_card_from_excel_data(excel_data, list_name=None):
         }
 
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error creating card: {http_err}")
-        print("[TRELLO API] Response content:", response.text)
+        logger.error(
+            "trello_card_create_failed",
+            job=str(job_number),
+            release=str(release_number),
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
+        logger.debug("trello_card_create_error_response", body=response.text)
         return {
             "success": False,
             "error": f"HTTP error: {http_err}",
             "response": response.text,
         }
     except Exception as err:
-        print(f"[TRELLO API] Other error creating card: {err}")
+        logger.error(
+            "trello_card_create_failed",
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": str(err)}
 
     except Exception as e:
         error_msg = f"Unexpected error in create_trello_card_from_excel_data: {str(e)}"
-        print(f"[ERROR] {error_msg}")
-        import traceback
-
-        print(f"[ERROR] Full traceback: {traceback.format_exc()}")
+        logger.error(
+            "card_creation_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {
             "success": False,
             "error": error_msg,
@@ -855,13 +973,21 @@ def get_card_custom_field_items(card_id):
         response.raise_for_status()
         return response.json()
     except requests.exceptions.HTTPError as http_err:
-        print(
-            f"[TRELLO API] HTTP error getting custom field items for card {card_id}: {http_err}"
+        logger.error(
+            "custom_field_items_fetch_failed",
+            card_id=card_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
         )
         return None
     except Exception as err:
-        print(
-            f"[TRELLO API] Error getting custom field items for card {card_id}: {err}"
+        logger.error(
+            "custom_field_items_fetch_failed",
+            card_id=card_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
         )
         return None
 
@@ -883,19 +1009,39 @@ def update_card_custom_field(card_id, custom_field_id, text_value):
     data = {"value": {"text": text_value}}
 
     try:
-        print(
-            f"[TRELLO API] Updating custom field {custom_field_id} on card {card_id} with value: {text_value[:100]}..."
+        logger.debug(
+            "custom_field_update_requested",
+            card_id=card_id,
+            custom_field_id=custom_field_id,
         )
         response = requests.put(url, params=params, json=data)
         response.raise_for_status()
-        print(f"[TRELLO API] Custom field updated successfully")
+        logger.debug("custom_field_updated", card_id=card_id, custom_field_id=custom_field_id)
         return True
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error updating custom field: {http_err}")
-        print("[TRELLO API] Response content:", response.text)
+        logger.error(
+            "custom_field_update_failed",
+            card_id=card_id,
+            custom_field_id=custom_field_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
+        logger.debug(
+            "custom_field_update_error_response",
+            card_id=card_id,
+            body=response.text,
+        )
         return False
     except Exception as err:
-        print(f"[TRELLO API] Error updating custom field: {err}")
+        logger.error(
+            "custom_field_update_failed",
+            card_id=card_id,
+            custom_field_id=custom_field_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return False
 
 
@@ -917,11 +1063,21 @@ def get_board_custom_fields(board_id):
         response.raise_for_status()
         return response.json()
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error getting custom fields: {http_err}")
-        print("[TRELLO API] Response content:", response.text)
+        logger.error(
+            "board_custom_fields_fetch_failed",
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
+        logger.debug("board_custom_fields_error_response", body=response.text)
         return None
     except Exception as err:
-        print(f"[TRELLO API] Error getting custom fields: {err}")
+        logger.error(
+            "board_custom_fields_fetch_failed",
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return None
 
 
@@ -964,19 +1120,40 @@ def update_card_custom_field_number(card_id, custom_field_id, number_value):
     }
 
     try:
-        print(
-            f"[TRELLO API] Updating custom field {custom_field_id} on card {card_id} with value: {number_value}"
+        logger.debug(
+            "custom_field_update_requested",
+            card_id=card_id,
+            custom_field_id=custom_field_id,
+            value=number_value,
         )
         response = requests.put(url, params=params, json=data)
         response.raise_for_status()
-        print(f"[TRELLO API] Custom field updated successfully")
+        logger.debug("custom_field_updated", card_id=card_id, custom_field_id=custom_field_id)
         return True
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error updating custom field: {http_err}")
-        print("[TRELLO API] Response content:", response.text)
+        logger.error(
+            "custom_field_update_failed",
+            card_id=card_id,
+            custom_field_id=custom_field_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
+        logger.debug(
+            "custom_field_update_error_response",
+            card_id=card_id,
+            body=response.text,
+        )
         return False
     except Exception as err:
-        print(f"[TRELLO API] Error updating custom field: {err}")
+        logger.error(
+            "custom_field_update_failed",
+            card_id=card_id,
+            custom_field_id=custom_field_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return False
 
 
@@ -1012,7 +1189,7 @@ def sort_list_by_fab_order(list_id, fab_order_field_id):
         cards = response.json()
 
         if not cards:
-            print(f"[TRELLO API] List {list_id} is empty, nothing to sort")
+            logger.debug("list_sort_skipped", list_id=list_id, reason="empty list")
             return {
                 "success": True,
                 "cards_sorted": 0,
@@ -1096,24 +1273,33 @@ def sort_list_by_fab_order(list_id, fab_order_field_id):
                 update_response.raise_for_status()
                 updated_count += 1
             except requests.exceptions.HTTPError as http_err:
-                print(
-                    f"[TRELLO API] HTTP error updating card {update['card_id']} position: {http_err}"
+                logger.error(
+                    "card_position_update_failed",
+                    card_id=update["card_id"],
+                    error=str(http_err),
+                    error_type=type(http_err).__name__,
+                    exc_info=True,
                 )
                 failed_count += 1
             except Exception as err:
-                print(
-                    f"[TRELLO API] Error updating card {update['card_id']} position: {err}"
+                logger.error(
+                    "card_position_update_failed",
+                    card_id=update["card_id"],
+                    error=str(err),
+                    error_type=type(err).__name__,
+                    exc_info=True,
                 )
                 failed_count += 1
 
         if failed_count > 0:
-            print(
-                f"[TRELLO API] Sort completed with {failed_count} failures out of {len(position_updates)} cards"
+            logger.warning(
+                "list_sort_completed_with_failures",
+                list_id=list_id,
+                cards_failed=failed_count,
+                count=len(position_updates),
             )
         else:
-            print(
-                f"[TRELLO API] Successfully sorted list {list_id} ({updated_count} cards)"
-            )
+            logger.debug("list_sorted", list_id=list_id, count=updated_count)
 
         return {
             "success": True,
@@ -1124,9 +1310,19 @@ def sort_list_by_fab_order(list_id, fab_order_field_id):
 
     except requests.exceptions.HTTPError as http_err:
         error_msg = f"HTTP error sorting list {list_id}: {http_err}"
-        print(f"[TRELLO API] {error_msg}")
+        logger.error(
+            "list_sort_failed",
+            list_id=list_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
         if hasattr(http_err.response, "text"):
-            print(f"[TRELLO API] Response: {http_err.response.text}")
+            logger.debug(
+                "list_sort_error_response",
+                list_id=list_id,
+                body=http_err.response.text,
+            )
         return {
             "success": False,
             "error": error_msg,
@@ -1136,7 +1332,13 @@ def sort_list_by_fab_order(list_id, fab_order_field_id):
         }
     except Exception as err:
         error_msg = f"Error sorting list {list_id}: {err}"
-        print(f"[TRELLO API] {error_msg}")
+        logger.error(
+            "list_sort_failed",
+            list_id=list_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return {
             "success": False,
             "error": error_msg,
@@ -1160,7 +1362,7 @@ def add_comment_to_trello_card(card_id, comment_text, operation_id=None, sender_
         True if successful, False otherwise
     """
     if not comment_text or not comment_text.strip():
-        print(f"[TRELLO API] Skipping empty comment for card {card_id}")
+        logger.debug("comment_skipped", card_id=card_id, reason="empty comment")
         return True
 
     # Format comment with timestamp and sender initials
@@ -1176,21 +1378,34 @@ def add_comment_to_trello_card(card_id, comment_text, operation_id=None, sender_
     }
 
     try:
-        print(
-            f"[TRELLO API] Adding comment to card {card_id}: {formatted_comment[:100]}..."
+        logger.debug(
+            "comment_add_requested",
+            card_id=card_id,
+            operation_id=operation_id,
+            comment_length=len(formatted_comment),
         )
         response = requests.post(url, params=params)
         response.raise_for_status()
-        print(f"[TRELLO API] Comment added successfully")
-        if operation_id:
-            print(f"[TRELLO API] Operation ID: {operation_id}")
+        logger.debug("comment_added", card_id=card_id, operation_id=operation_id)
         return True
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error adding comment: {http_err}")
-        print("[TRELLO API] Response content:", response.text)
+        logger.error(
+            "comment_add_failed",
+            card_id=card_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
+        logger.debug("comment_add_error_response", card_id=card_id, body=response.text)
         return False
     except Exception as err:
-        print(f"[TRELLO API] Error adding comment: {err}")
+        logger.error(
+            "comment_add_failed",
+            card_id=card_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return False
 
 
@@ -1211,12 +1426,12 @@ def get_card_attachments_by_job_release(job_number, release_number):
             job_int = int(job_number)
         except (ValueError, TypeError):
             error_msg = f"Invalid job number: {job_number} - cannot convert to integer"
-            print(f"[TRELLO API] {error_msg}")
+            logger.warning("attachments_lookup_invalid_job", job=str(job_number), error=error_msg)
             return {"success": False, "error": error_msg, "attachments": []}
 
         release_str = str(release_number)
 
-        print(f"[TRELLO API] Looking up attachments for job: {job_int}-{release_str}")
+        logger.debug("attachments_lookup_started", job=str(job_int), release=release_str)
 
         # Find the job record in the database
         job_record = Releases.query.filter_by(
@@ -1248,8 +1463,11 @@ def get_card_attachments_by_job_release(job_number, release_number):
 
         if response.status_code == 200:
             attachments = response.json()
-            print(
-                f"[TRELLO API] Found {len(attachments)} attachments for job {job_int}-{release_str}"
+            logger.debug(
+                "attachments_fetched",
+                job=str(job_int),
+                release=release_str,
+                count=len(attachments),
             )
             return {
                 "success": True,
@@ -1260,8 +1478,15 @@ def get_card_attachments_by_job_release(job_number, release_number):
                 "attachments": attachments,
             }
         else:
-            print(
-                f"[TRELLO API] Error getting attachments: {response.status_code} {response.text}"
+            logger.warning(
+                "attachments_fetch_failed",
+                card_id=job_record.trello_card_id,
+                status=response.status_code,
+            )
+            logger.debug(
+                "attachments_fetch_error_response",
+                card_id=job_record.trello_card_id,
+                body=response.text,
             )
             return {
                 "success": False,
@@ -1271,13 +1496,27 @@ def get_card_attachments_by_job_release(job_number, release_number):
 
     except (ValueError, TypeError) as e:
         error_msg = f"Invalid job or release identifiers: job={job_number}, release={release_number}, error={str(e)}"
-        print(f"[TRELLO API] {error_msg}")
+        logger.error(
+            "attachments_lookup_failed",
+            job=str(job_number),
+            release=str(release_number),
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": error_msg, "attachments": []}
     except Exception as e:
         error_msg = (
             f"Error getting attachments for job {job_number}-{release_number}: {str(e)}"
         )
-        print(f"[TRELLO API] {error_msg}")
+        logger.error(
+            "attachments_fetch_failed",
+            job=str(job_number),
+            release=str(release_number),
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": error_msg, "attachments": []}
 
 
@@ -1309,8 +1548,10 @@ def update_mirror_card_date_range(trello_card_id, start_date, install_hrs):
         if len(attachments) == 0:
             return {"success": False, "error": "No attachments found for this card"}
         elif len(attachments) > 1:
-            print(
-                f"[TRELLO API] Warning: Found {len(attachments)} attachments, expected 1 mirror card"
+            logger.warning(
+                "mirror_card_multiple_attachments",
+                card_id=trello_card_id,
+                count=len(attachments),
             )
             # Continue anyway, but log the warning
 
@@ -1338,7 +1579,13 @@ def update_mirror_card_date_range(trello_card_id, start_date, install_hrs):
 
     except Exception as e:
         error_msg = f"Error updating mirror card date range: {str(e)}"
-        print(f"[TRELLO API] {error_msg}")
+        logger.error(
+            "mirror_card_date_range_update_failed",
+            card_id=trello_card_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": error_msg}
 
 
@@ -1353,7 +1600,7 @@ def get_card_attachments_by_card_id(trello_card_id):
         dict: Dictionary containing success status and attachments data
     """
     try:
-        print(f"[TRELLO API] Looking up attachments for card: {trello_card_id}")
+        logger.debug("attachments_lookup_started", card_id=trello_card_id)
 
         # Get attachments from Trello API
         url = f"https://api.trello.com/1/cards/{trello_card_id}/attachments"
@@ -1366,8 +1613,10 @@ def get_card_attachments_by_card_id(trello_card_id):
 
         if response.status_code == 200:
             attachments = response.json()
-            print(
-                f"[TRELLO API] Found {len(attachments)} attachments for card {trello_card_id}"
+            logger.debug(
+                "attachments_fetched",
+                card_id=trello_card_id,
+                count=len(attachments),
             )
             return {
                 "success": True,
@@ -1375,8 +1624,15 @@ def get_card_attachments_by_card_id(trello_card_id):
                 "attachments": attachments,
             }
         else:
-            print(
-                f"[TRELLO API] Error getting attachments: {response.status_code} {response.text}"
+            logger.warning(
+                "attachments_fetch_failed",
+                card_id=trello_card_id,
+                status=response.status_code,
+            )
+            logger.debug(
+                "attachments_fetch_error_response",
+                card_id=trello_card_id,
+                body=response.text,
             )
             return {
                 "success": False,
@@ -1386,7 +1642,13 @@ def get_card_attachments_by_card_id(trello_card_id):
 
     except Exception as e:
         error_msg = f"Error getting attachments for card {trello_card_id}: {str(e)}"
-        print(f"[TRELLO API] {error_msg}")
+        logger.error(
+            "attachments_fetch_failed",
+            card_id=trello_card_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": error_msg, "attachments": []}
 
 
@@ -1406,7 +1668,7 @@ def calculate_installation_duration(install_hrs, num_guys=2):
     """
     try:
         if install_hrs is None or str(install_hrs).lower() in ["nan", "none", ""]:
-            print(f"[DEBUG] Install HRS is empty/None: {install_hrs}")
+            logger.debug("install_hrs_empty", install_hrs=str(install_hrs))
             return None
 
         install_hrs_float = float(install_hrs)
@@ -1415,24 +1677,39 @@ def calculate_installation_duration(install_hrs, num_guys=2):
             installation_duration = math.ceil(
                 (install_hrs_float / float(num_guys)) / 8.0
             )
-            print(
-                f"[DEBUG] Install HRS: {install_hrs} / Num Guys: {num_guys} / 8hrs/day -> Duration: {installation_duration} days"
+            logger.debug(
+                "installation_duration_calculated",
+                install_hrs=install_hrs_float,
+                num_guys=num_guys,
+                duration_days=installation_duration,
             )
             return installation_duration
         else:
-            print(
-                f"[DEBUG] Install HRS is zero or negative: {install_hrs_float}, or num_guys is zero: {num_guys}"
+            logger.debug(
+                "installation_duration_skipped",
+                install_hrs=install_hrs_float,
+                num_guys=num_guys,
+                reason="non-positive install_hrs or num_guys",
             )
             return None
 
     except (ValueError, TypeError) as e:
-        print(
-            f"[DEBUG] Error calculating installation duration: {e}, Install HRS: {install_hrs} (type: {type(install_hrs)}), Num Guys: {num_guys}"
+        logger.debug(
+            "installation_duration_calc_failed",
+            install_hrs=str(install_hrs),
+            num_guys=num_guys,
+            error=str(e),
+            error_type=type(e).__name__,
         )
         return None
     except Exception as e:
-        print(
-            f"[DEBUG] Unexpected error calculating installation duration: {e}, Install HRS: {install_hrs}"
+        logger.warning(
+            "installation_duration_calc_failed",
+            install_hrs=str(install_hrs),
+            num_guys=num_guys,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
         )
         return None
 
@@ -1498,7 +1775,12 @@ def sync_num_guys_on_card(card_id, install_hrs, num_guys):
     try:
         card = get_trello_card_by_id(card_id)
     except Exception as e:
-        print(f"[TRELLO API] sync_num_guys_on_card: fetch failed for {card_id}: {e}")
+        logger.warning(
+            "num_guys_sync_card_fetch_failed",
+            card_id=card_id,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
         return False
     if not card:
         return False
@@ -1527,22 +1809,25 @@ def update_installation_duration_in_description(description, install_hrs, num_gu
         str: Updated description with new installation duration, or original if update fails
     """
     if not description or not install_hrs or not num_guys:
-        print(
-            f"[DEBUG] update_installation_duration_in_description: Missing required input - desc={bool(description)}, install_hrs={install_hrs}, num_guys={num_guys}"
+        logger.debug(
+            "installation_duration_update_skipped",
+            reason="missing required input",
+            has_description=bool(description),
+            install_hrs=install_hrs,
+            num_guys=num_guys,
         )
         return description
 
     # Calculate new installation duration
     installation_duration = calculate_installation_duration(install_hrs, num_guys)
     if installation_duration is None:
-        print(
-            f"[DEBUG] update_installation_duration_in_description: Could not calculate duration"
+        logger.debug(
+            "installation_duration_update_skipped",
+            reason="could not calculate duration",
         )
         return description
 
-    print(
-        f"[DEBUG] update_installation_duration_in_description: Target duration = {installation_duration} days"
-    )
+    logger.debug("installation_duration_target", duration_days=installation_duration)
 
     # Pattern to match "**Installation Duration:** X days"
     pattern = r"(\*\*Installation\s+Duration:\*\*\s*)(\d+)\s*days"
@@ -1550,9 +1835,7 @@ def update_installation_duration_in_description(description, install_hrs, num_gu
     match = re.search(pattern, description, re.IGNORECASE)
     if match:
         current_duration = int(match.group(2))
-        print(
-            f"[DEBUG] update_installation_duration_in_description: Found existing duration = {current_duration} days"
-        )
+        logger.debug("installation_duration_existing_found", duration_days=current_duration)
 
         # Only update if duration has actually changed
         if current_duration != installation_duration:
@@ -1563,18 +1846,21 @@ def update_installation_duration_in_description(description, install_hrs, num_gu
             updated_description = re.sub(
                 pattern, replace_duration, description, flags=re.IGNORECASE
             )
-            print(
-                f"[DEBUG] update_installation_duration_in_description: Updated {current_duration} -> {installation_duration} days"
+            logger.debug(
+                "installation_duration_updated",
+                from_days=current_duration,
+                to_days=installation_duration,
             )
             return updated_description
         else:
-            print(
-                f"[DEBUG] update_installation_duration_in_description: Duration unchanged ({current_duration} days)"
+            logger.debug(
+                "installation_duration_unchanged", duration_days=current_duration
             )
             return description
     else:
-        print(
-            f"[DEBUG] update_installation_duration_in_description: No existing Installation Duration found, attempting to add"
+        logger.debug(
+            "installation_duration_add_attempted",
+            reason="no existing Installation Duration line",
         )
         # If no installation duration line exists, add it after Number of Guys
         num_guys_pattern = r"(\*\*Number\s+of\s+Guys:\*\*\s*\d+(?:\.\d+)?)"
@@ -1587,13 +1873,14 @@ def update_installation_duration_in_description(description, install_hrs, num_gu
             updated_description = re.sub(
                 num_guys_pattern, add_duration, description, flags=re.IGNORECASE
             )
-            print(
-                f"[DEBUG] update_installation_duration_in_description: Added new Installation Duration line"
+            logger.debug(
+                "installation_duration_line_added", duration_days=installation_duration
             )
             return updated_description
         else:
-            print(
-                f"[DEBUG] update_installation_duration_in_description: Could not find Number of Guys line to add duration after"
+            logger.debug(
+                "installation_duration_add_skipped",
+                reason="Number of Guys line not found",
             )
 
     return description
@@ -1640,9 +1927,7 @@ def update_num_guys_in_description(description, install_hrs, default_num_guys=2)
             updated_description = re.sub(
                 num_guys_pattern, replace_num_guys, description, flags=re.IGNORECASE
             )
-            print(
-                f"[DEBUG] update_num_guys_in_description: Fixed invalid Number of Guys format"
-            )
+            logger.debug("num_guys_format_fixed", num_guys=default_num_guys)
             return updated_description
     else:
         # Number of Guys doesn't exist - add it after Install HRS
@@ -1657,15 +1942,11 @@ def update_num_guys_in_description(description, install_hrs, default_num_guys=2)
             updated_description = re.sub(
                 install_hrs_pattern, add_num_guys, description, flags=re.IGNORECASE
             )
-            print(
-                f"[DEBUG] update_num_guys_in_description: Added Number of Guys field with value {default_num_guys}"
-            )
+            logger.debug("num_guys_line_added", num_guys=default_num_guys)
             return updated_description
         else:
             # Install HRS not found, can't determine where to add Number of Guys
-            print(
-                f"[DEBUG] update_num_guys_in_description: Install HRS not found, cannot add Number of Guys"
-            )
+            logger.debug("num_guys_add_skipped", reason="Install HRS line not found")
             return description
 
 
@@ -1706,22 +1987,36 @@ def update_trello_card_description(card_id, new_description):
     }
 
     try:
-        print(f"[TRELLO API] Updating description for card {card_id}")
+        logger.debug("card_description_update_requested", card_id=card_id)
         response = requests.put(url, params=params)
         response.raise_for_status()
 
-        print(f"[TRELLO API] Card {card_id} description updated successfully")
+        logger.debug("card_description_updated", card_id=card_id)
         return response.json()
 
     except requests.exceptions.HTTPError as http_err:
-        print(
-            f"[TRELLO API] HTTP error updating card {card_id} description: {http_err}"
+        logger.error(
+            "card_description_update_failed",
+            card_id=card_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
         )
         if hasattr(http_err.response, "text"):
-            print("[TRELLO API] Response content:", http_err.response.text)
+            logger.debug(
+                "card_description_update_error_response",
+                card_id=card_id,
+                body=http_err.response.text,
+            )
         raise
     except Exception as err:
-        print(f"[TRELLO API] Other error updating card {card_id} description: {err}")
+        logger.error(
+            "card_description_update_failed",
+            card_id=card_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         raise
 
 
@@ -1741,20 +2036,36 @@ def update_trello_card_name(card_id, new_name):
     params = {"key": cfg.TRELLO_API_KEY, "token": cfg.TRELLO_TOKEN, "name": new_name}
 
     try:
-        print(f"[TRELLO API] Updating name for card {card_id}")
+        logger.debug("card_name_update_requested", card_id=card_id)
         response = requests.put(url, params=params)
         response.raise_for_status()
 
-        print(f"[TRELLO API] Card {card_id} name updated successfully")
+        logger.debug("card_name_updated", card_id=card_id)
         return response.json()
 
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error updating card {card_id} name: {http_err}")
+        logger.error(
+            "card_name_update_failed",
+            card_id=card_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
         if hasattr(http_err.response, "text"):
-            print("[TRELLO API] Response content:", http_err.response.text)
+            logger.debug(
+                "card_name_update_error_response",
+                card_id=card_id,
+                body=http_err.response.text,
+            )
         raise
     except Exception as err:
-        print(f"[TRELLO API] Other error updating card {card_id} name: {err}")
+        logger.error(
+            "card_name_update_failed",
+            card_id=card_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         raise
 
 
@@ -1830,14 +2141,17 @@ def update_card_date_range(card_short_link, start_date, due_date):
             "due": due_date_str,
         }
 
-        print(
-            f"[TRELLO API] Updating mirror card {card_short_link} with start: {start_date_str}, due: {due_date_str}"
+        logger.debug(
+            "mirror_card_date_range_update_requested",
+            card_id=card_short_link,
+            start_date=start_date_str,
+            due_date=due_date_str,
         )
 
         response = requests.put(url, params=payload)
 
         if response.status_code == 200:
-            print(f"[TRELLO API] Successfully updated mirror card {card_short_link}")
+            logger.debug("mirror_card_date_range_updated", card_id=card_short_link)
             return {
                 "success": True,
                 "card_short_link": card_short_link,
@@ -1845,8 +2159,15 @@ def update_card_date_range(card_short_link, start_date, due_date):
                 "due_date": due_date_str,
             }
         else:
-            print(
-                f"[TRELLO API] Error updating mirror card: {response.status_code} {response.text}"
+            logger.warning(
+                "mirror_card_date_range_update_failed",
+                card_id=card_short_link,
+                status=response.status_code,
+            )
+            logger.debug(
+                "mirror_card_date_range_error_response",
+                card_id=card_short_link,
+                body=response.text,
             )
             return {
                 "success": False,
@@ -1855,7 +2176,13 @@ def update_card_date_range(card_short_link, start_date, due_date):
 
     except Exception as e:
         error_msg = f"Error updating card date range: {str(e)}"
-        print(f"[TRELLO API] {error_msg}")
+        logger.error(
+            "card_date_range_update_failed",
+            card_id=card_short_link,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": error_msg}
 
 
@@ -1872,7 +2199,7 @@ def add_procore_link(card_id, procore_url, link_name=None):
         dict: Dictionary containing success status and attachment data, or error message
     """
     if not procore_url or not procore_url.strip():
-        print(f"[TRELLO API] Skipping empty Procore URL for card {card_id}")
+        logger.debug("procore_link_skipped", card_id=card_id, reason="empty url")
         return {"success": False, "error": "Procore URL is required"}
 
     url = f"https://api.trello.com/1/cards/{card_id}/attachments"
@@ -1889,15 +2216,15 @@ def add_procore_link(card_id, procore_url, link_name=None):
         params["name"] = link_name
 
     try:
-        print(
-            f"[TRELLO API] Adding Procore link to card {card_id}: {procore_url[:100]}..."
-        )
+        logger.debug("procore_link_add_requested", card_id=card_id)
         response = requests.post(url, params=params)
         response.raise_for_status()
 
         attachment_data = response.json()
-        print(
-            f"[TRELLO API] Procore link added successfully (attachment ID: {attachment_data.get('id')})"
+        logger.debug(
+            "procore_link_added",
+            card_id=card_id,
+            attachment_id=attachment_data.get("id"),
         )
 
         return {
@@ -1909,9 +2236,19 @@ def add_procore_link(card_id, procore_url, link_name=None):
         }
 
     except requests.exceptions.HTTPError as http_err:
-        print(f"[TRELLO API] HTTP error adding Procore link: {http_err}")
+        logger.error(
+            "procore_link_add_failed",
+            card_id=card_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
         if hasattr(http_err.response, "text"):
-            print("[TRELLO API] Response content:", http_err.response.text)
+            logger.debug(
+                "procore_link_add_error_response",
+                card_id=card_id,
+                body=http_err.response.text,
+            )
         return {
             "success": False,
             "error": f"HTTP error: {http_err}",
@@ -1920,7 +2257,13 @@ def add_procore_link(card_id, procore_url, link_name=None):
             ),
         }
     except Exception as err:
-        print(f"[TRELLO API] Error adding Procore link: {err}")
+        logger.error(
+            "procore_link_add_failed",
+            card_id=card_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": str(err)}
 
 
@@ -1977,17 +2320,30 @@ def move_mirror_card(primary_card_id, target_list_id):
     linked mirror or no target list is available.
     """
     if not primary_card_id or not target_list_id:
-        print(f"[TRELLO API] move_mirror_card skipped: card={primary_card_id} list={target_list_id}")
+        logger.warning(
+            "mirror_card_move_skipped",
+            card_id=primary_card_id,
+            list_id=target_list_id,
+            reason="missing card or list id",
+        )
         return None
 
     result = get_card_attachments_by_card_id(primary_card_id)
     if not result.get("success"):
-        print(f"[TRELLO API] move_mirror_card: failed to read attachments for {primary_card_id}")
+        logger.warning(
+            "mirror_card_move_failed",
+            card_id=primary_card_id,
+            reason="failed to read attachments",
+        )
         return None
 
     mirror_short_link = _mirror_short_link_from_attachments(result.get("attachments"))
     if not mirror_short_link:
-        print(f"[TRELLO API] move_mirror_card: no linked mirror card for {primary_card_id}")
+        logger.warning(
+            "mirror_card_move_skipped",
+            card_id=primary_card_id,
+            reason="no linked mirror card",
+        )
         return None
 
     return update_trello_card(card_id=mirror_short_link, new_list_id=target_list_id)
@@ -2021,14 +2377,22 @@ def set_mirror_date_range(primary_card_id, start_date, due_date):
     try:
         mirror_card = get_trello_card_by_id(mirror_short_link)
     except Exception as e:
-        print(f"[TRELLO API] set_mirror_date_range: could not resolve mirror card: {e}")
+        logger.error(
+            "mirror_card_resolve_failed",
+            card_id=primary_card_id,
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {"success": False, "error": f"could not resolve mirror card: {e}"}
     if not mirror_card:
         return {"success": False, "error": "mirror card not found"}
     if mirror_card.get("idBoard") != cfg.TRELLO_BOARD_ID:
-        print(
-            f"[TRELLO API] set_mirror_date_range: linked card {mirror_card.get('id')} is on board "
-            f"{mirror_card.get('idBoard')}, not {cfg.TRELLO_BOARD_ID}; refusing cross-board push"
+        logger.warning(
+            "mirror_card_cross_board_refused",
+            card_id=mirror_card.get("id"),
+            mirror_board_id=mirror_card.get("idBoard"),
+            expected_board_id=cfg.TRELLO_BOARD_ID,
         )
         return {
             "success": False,

--- a/app/trello/card_creation.py
+++ b/app/trello/card_creation.py
@@ -141,8 +141,10 @@ def create_trello_card_core(
                 existing = find_card_in_list_by_name(list_id, card_title)
                 if existing:
                     logger.warning(
-                        f"Idempotency: adopting existing Trello card {existing['id']} "
-                        f"with matching title in list {list_id} (skipping POST)"
+                        "trello_card_adopted",
+                        card_id=existing["id"],
+                        list_id=list_id,
+                        status="skipped",
                     )
                     return {
                         "success": True,
@@ -153,7 +155,12 @@ def create_trello_card_core(
             except Exception as scan_err:
                 # If the lookup fails we fall through to the create path; better
                 # to risk a duplicate than to block the retry entirely.
-                logger.warning(f"Idempotency scan failed, proceeding with create: {scan_err}")
+                logger.warning(
+                    "trello_idempotency_scan_failed",
+                    list_id=list_id,
+                    error=str(scan_err),
+                    error_type=type(scan_err).__name__,
+                )
 
         url = "https://api.trello.com/1/cards"
         payload = {
@@ -165,12 +172,12 @@ def create_trello_card_core(
             "pos": position
         }
 
-        logger.info(f"Creating Trello card in list {list_id}")
+        logger.debug("trello_card_create_started", list_id=list_id)
         response = requests.post(url, params=payload)
         response.raise_for_status()
 
         card_data = response.json()
-        logger.info(f"Trello card created successfully: {card_data['id']}")
+        logger.info("trello_card_created", card_id=card_data["id"], list_id=list_id)
 
         return {
             "success": True,
@@ -181,7 +188,13 @@ def create_trello_card_core(
 
     except Exception as err:
         error_msg = f"Error creating Trello card: {str(err)}"
-        logger.error(error_msg, exc_info=True)
+        logger.error(
+            "trello_card_create_failed",
+            list_id=list_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return {
             "success": False,
             "error": error_msg
@@ -261,12 +274,30 @@ def apply_card_post_creation_features(
                     # Commit the viewer_url update
                     try:
                         db.session.commit()
-                        logger.info(f"Fetched and saved viewer_url from Procore for {job_record.job}-{job_record.release}")
+                        logger.info(
+                            "viewer_url_saved",
+                            job=job_record.job,
+                            release=job_record.release,
+                            card_id=card_id,
+                        )
                     except Exception as commit_err:
-                        logger.warning(f"Failed to commit viewer_url: {commit_err}")
+                        logger.warning(
+                            "viewer_url_commit_failed",
+                            job=job_record.job,
+                            release=job_record.release,
+                            error=str(commit_err),
+                            error_type=type(commit_err).__name__,
+                        )
                         db.session.rollback()
         except Exception as procore_err:
-            logger.warning(f"Failed to fetch viewer_url from Procore: {procore_err}")
+            logger.warning(
+                "viewer_url_fetch_failed",
+                job=job_record.job,
+                release=job_record.release,
+                card_id=card_id,
+                error=str(procore_err),
+                error_type=type(procore_err).__name__,
+            )
     
     # Get fab_order from job_record if not provided
     if fab_order is None and job_record and hasattr(job_record, 'fab_order'):
@@ -289,7 +320,7 @@ def apply_card_post_creation_features(
                 )
                 if fab_order_success:
                     results["fab_order_set"] = True
-                    logger.info(f"Successfully set Fab Order custom field to {fab_order_int}")
+                    logger.info("fab_order_field_set", card_id=card_id, fab_order=fab_order_int)
                     
                     # Sort the list if it's one of the target lists
                     sort_success = sort_list_if_needed(
@@ -301,11 +332,18 @@ def apply_card_post_creation_features(
                     if sort_success:
                         results["fab_order_sorted"] = True
                 else:
-                    logger.error(f"Failed to set Fab Order custom field")
+                    logger.warning("fab_order_field_set_failed", card_id=card_id, fab_order=fab_order_int)
             else:
-                logger.debug("FAB_ORDER_FIELD_ID not configured, skipping Fab Order custom field")
+                logger.debug("fab_order_field_skipped", card_id=card_id)
         except (ValueError, TypeError) as e:
-            logger.error(f"Could not convert Fab Order '{fab_order}' to int: {e}")
+            logger.error(
+                "fab_order_conversion_failed",
+                card_id=card_id,
+                fab_order=fab_order,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
     
     # Add FC Drawing link if viewer_url exists
     if viewer_url:
@@ -313,11 +351,20 @@ def apply_card_post_creation_features(
             link_result = add_procore_link(card_id, viewer_url, link_name="FC Drawing")
             if link_result.get("success"):
                 results["fc_drawing_added"] = True
-                logger.info(f"Added FC Drawing link to card {card_id}")
+                logger.info("fc_drawing_link_added", card_id=card_id)
             else:
-                logger.warning(f"Failed to add FC Drawing link: {link_result.get('error')}")
+                logger.warning(
+                    "fc_drawing_link_add_failed",
+                    card_id=card_id,
+                    error=link_result.get("error"),
+                )
         except Exception as link_err:
-            logger.warning(f"Error adding FC Drawing link: {link_err}")
+            logger.warning(
+                "fc_drawing_link_add_failed",
+                card_id=card_id,
+                error=str(link_err),
+                error_type=type(link_err).__name__,
+            )
     
     # Handle notes field - append as comment if not empty
     if notes is not None:
@@ -329,16 +376,21 @@ def apply_card_post_creation_features(
                 comment_success = add_comment_to_trello_card(card_id, str(notes).strip())
                 if comment_success:
                     results["notes_added"] = True
-                    logger.info(f"Successfully added notes as comment to Trello card")
+                    logger.info("notes_comment_added", card_id=card_id)
             except Exception as comment_err:
-                logger.warning(f"Error adding notes comment: {comment_err}")
+                logger.warning(
+                    "notes_comment_add_failed",
+                    card_id=card_id,
+                    error=str(comment_err),
+                    error_type=type(comment_err).__name__,
+                )
     
     # Create mirror card in unassigned list if configured
     if create_mirror and cfg.UNASSIGNED_CARDS_LIST_ID:
         try:
             # Check if card already has a link (to avoid duplicates)
             if not card_has_link_to(card_id):
-                logger.info(f"Creating mirror card in unassigned list for card {card_id}")
+                logger.debug("mirror_card_create_started", card_id=card_id)
                 cloned = copy_trello_card(card_id, cfg.UNASSIGNED_CARDS_LIST_ID, pos="bottom")
                 mirror_card_id = cloned["id"]
                 link_cards(card_id, mirror_card_id)
@@ -346,7 +398,7 @@ def apply_card_post_creation_features(
                 update_trello_card(card_id, clear_due_date=True)
                 update_trello_card(mirror_card_id, clear_due_date=True)
                 results["mirror_card_id"] = mirror_card_id
-                logger.info(f"Mirror card created and linked: {mirror_card_id}")
+                logger.info("mirror_card_created", card_id=card_id, mirror_card_id=mirror_card_id)
 
                 # Persist the mirror id on the release so inbound mirror webhooks resolve
                 # directly (no attachment walk). The clone is same-board by construction
@@ -357,12 +409,23 @@ def apply_card_post_creation_features(
                         job_record.mirror_trello_card_id = mirror_card_id
                         db.session.commit()
                     except Exception as persist_err:
-                        logger.warning(f"Failed to persist mirror_trello_card_id: {persist_err}")
+                        logger.warning(
+                            "mirror_card_id_persist_failed",
+                            card_id=card_id,
+                            mirror_card_id=mirror_card_id,
+                            error=str(persist_err),
+                            error_type=type(persist_err).__name__,
+                        )
                         db.session.rollback()
             else:
-                logger.info(f"Card {card_id} already has a link, skipping mirror card creation")
+                logger.debug("mirror_card_create_skipped", card_id=card_id)
         except Exception as mirror_err:
-            logger.warning(f"Failed to create mirror card: {mirror_err}")
+            logger.warning(
+                "mirror_card_create_failed",
+                card_id=card_id,
+                error=str(mirror_err),
+                error_type=type(mirror_err).__name__,
+            )
     
     return results
 

--- a/app/trello/scanner.py
+++ b/app/trello/scanner.py
@@ -134,10 +134,10 @@ def scan_trello_db_comparison() -> Dict:
             ]
         }
     """
-    logger.info("Starting Trello-DB scanner comparison")
-    
+    logger.debug("trello_db_scan_started")
+
     # Step 1: Get all DB jobs
-    logger.info("Fetching all jobs from database...")
+    logger.debug("db_releases_fetch_started")
     db_jobs = Releases.query.all()
     db_jobs_by_identifier = {}
     db_identifiers = set()
@@ -147,14 +147,19 @@ def scan_trello_db_comparison() -> Dict:
         db_identifiers.add(identifier)
         db_jobs_by_identifier[identifier] = job
     
-    logger.info(f"Found {len(db_jobs)} jobs in database")
+    logger.debug("db_releases_fetched", count=len(db_jobs))
     
     # Step 2: Get all Trello cards
-    logger.info("Fetching all Trello cards from board...")
+    logger.debug("trello_cards_fetch_started")
     try:
         trello_cards = get_all_trello_cards()
     except Exception as e:
-        logger.error(f"Error fetching Trello cards: {e}")
+        logger.error(
+            "trello_cards_fetch_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {
             "error": f"Failed to fetch Trello cards: {str(e)}",
             "summary": {
@@ -196,7 +201,7 @@ def scan_trello_db_comparison() -> Dict:
             if identifier not in trello_cards_by_identifier:
                 trello_cards_by_identifier[identifier] = card
     
-    logger.info(f"Found {len(trello_cards)} Trello cards, {len(trello_identifiers)} with valid identifiers")
+    logger.debug("trello_cards_fetched", count=len(trello_cards), with_identifiers=len(trello_identifiers))
     
     # Step 4: Build comparison results
     in_both = []
@@ -278,7 +283,7 @@ def scan_trello_db_comparison() -> Dict:
         "list_mismatches": len(list_mismatches)
     }
     
-    logger.info(f"Scan complete: {summary}")
+    logger.info("trello_db_scan_complete", **summary)
     
     return {
         "summary": summary,
@@ -309,18 +314,28 @@ def delete_trello_card(card_id: str) -> Dict:
     }
     
     try:
-        logger.info(f"Deleting Trello card: {card_id}")
+        logger.debug("trello_card_delete_started", card_id=card_id)
         response = requests.delete(url, params=params)
         response.raise_for_status()
-        logger.info(f"Successfully deleted Trello card: {card_id}")
+        logger.info("trello_card_deleted", card_id=card_id)
         return {"success": True, "card_id": card_id}
     except requests.exceptions.HTTPError as http_err:
-        error_msg = f"HTTP error deleting card {card_id}: {http_err}"
-        logger.error(error_msg)
+        logger.error(
+            "trello_card_delete_failed",
+            card_id=card_id,
+            error=str(http_err),
+            error_type=type(http_err).__name__,
+            exc_info=True,
+        )
         return {"success": False, "card_id": card_id, "error": str(http_err)}
     except Exception as err:
-        error_msg = f"Error deleting card {card_id}: {err}"
-        logger.error(error_msg)
+        logger.error(
+            "trello_card_delete_failed",
+            card_id=card_id,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return {"success": False, "card_id": card_id, "error": str(err)}
 
 
@@ -347,7 +362,13 @@ def create_trello_card_for_db_job(job: Releases, list_name: Optional[str] = None
     try:
         # Skip if job already has a Trello card
         if job.trello_card_id:
-            logger.info(f"Job {job.job}-{job.release} already has Trello card {job.trello_card_id}, skipping creation")
+            logger.debug(
+                "trello_card_create_skipped",
+                job=str(job.job),
+                release=job.release,
+                card_id=job.trello_card_id,
+                status="skipped",
+            )
             return {"success": False, "error": "Card already exists", "card_id": job.trello_card_id}
         
         # Determine list name from stage if not provided
@@ -361,7 +382,7 @@ def create_trello_card_for_db_job(job: Releases, list_name: Optional[str] = None
         if not target_list:
             # Fall back to configured new-card list
             list_id = cfg.NEW_TRELLO_CARD_LIST_ID
-            logger.warning(f"List '{list_name}' not found, using default list")
+            logger.warning("trello_list_not_found", list_name=list_name, job=str(job.job), release=job.release)
         else:
             list_id = target_list["id"]
         
@@ -404,9 +425,20 @@ def create_trello_card_for_db_job(job: Releases, list_name: Optional[str] = None
         # Update the job record with Trello card data
         success = update_job_record_with_trello_data(job, card_data)
         if success:
-            logger.info(f"Successfully updated database record with Trello data")
+            logger.info(
+                "release_updated_from_trello",
+                job=str(job.job),
+                release=job.release,
+                card_id=card_id,
+                source="trello",
+            )
         else:
-            logger.error(f"Failed to update database record with Trello data")
+            logger.error(
+                "release_update_from_trello_failed",
+                job=str(job.job),
+                release=job.release,
+                card_id=card_id,
+            )
         
         # Apply post-creation features (Fab Order, FC Drawing, notes, mirror card)
         post_creation_results = apply_card_post_creation_features(
@@ -429,8 +461,14 @@ def create_trello_card_for_db_job(job: Releases, list_name: Optional[str] = None
         }
         
     except Exception as err:
-        error_msg = f"Error creating Trello card for job {job.job}-{job.release}: {err}"
-        logger.error(error_msg, exc_info=True)
+        logger.error(
+            "trello_card_create_failed",
+            job=str(job.job),
+            release=job.release,
+            error=str(err),
+            error_type=type(err).__name__,
+            exc_info=True,
+        )
         return {
             "success": False,
             "job": job.job,
@@ -454,7 +492,7 @@ def sync_trello_with_db(dry_run: bool = False) -> Dict:
     """
     from app.trello.api import get_list_by_name, update_trello_card
     
-    logger.info(f"Starting Trello-DB sync (dry_run={dry_run})")
+    logger.debug("trello_db_sync_started", dry_run=dry_run)
     
     # Get comparison scan
     scan_results = scan_trello_db_comparison()
@@ -475,7 +513,7 @@ def sync_trello_with_db(dry_run: bool = False) -> Dict:
     }
     
     # 1. Delete Trello-only cards
-    logger.info(f"Deleting {len(scan_results['trello_only'])} Trello-only cards...")
+    logger.debug("trello_only_card_deletion_started", count=len(scan_results['trello_only']))
     for card_info in scan_results['trello_only']:
         card_id = card_info['trello_card_id']
         if dry_run:
@@ -492,20 +530,26 @@ def sync_trello_with_db(dry_run: bool = False) -> Dict:
                 results["deleted"]["failed"].append(delete_result)
     
     # 2. Move cards to correct lists based on DB stage
-    logger.info(f"Moving {len(scan_results['list_mismatches'])} cards to correct lists...")
+    logger.debug("card_moves_started", count=len(scan_results['list_mismatches']))
     for mismatch in scan_results['list_mismatches']:
         card_id = mismatch['trello_card_id']
         expected_list = mismatch['expected_list']
         
         if not expected_list:
-            logger.warning(f"Skipping card {card_id} - no expected list for stage '{mismatch['db_stage']}'")
+            logger.warning("card_move_skipped", card_id=card_id, db_stage=mismatch['db_stage'], status="skipped")
             continue
         
         # Get list ID
         list_info = get_list_by_name(expected_list)
         if not list_info:
             error_msg = f"List '{expected_list}' not found"
-            logger.error(error_msg)
+            logger.error(
+                "trello_list_lookup_failed",
+                card_id=card_id,
+                list_name=expected_list,
+                job_release=mismatch['identifier'],
+                error=error_msg,
+            )
             results["moved"]["failed"].append({
                 "card_id": card_id,
                 "identifier": mismatch['identifier'],
@@ -531,7 +575,12 @@ def sync_trello_with_db(dry_run: bool = False) -> Dict:
                     job.trello_list_id = list_info['id']
                     job.trello_list_name = expected_list
                     db.session.commit()
-                    logger.info(f"Updated DB record for {mismatch['identifier']} with new list info")
+                    logger.info(
+                        "release_list_updated",
+                        job_release=mismatch['identifier'],
+                        card_id=card_id,
+                        to_list=expected_list,
+                    )
                 
                 results["moved"]["success"].append({
                     "card_id": card_id,
@@ -539,10 +588,23 @@ def sync_trello_with_db(dry_run: bool = False) -> Dict:
                     "from_list": mismatch['trello_list'],
                     "to_list": expected_list
                 })
-                logger.info(f"Moved card {card_id} from '{mismatch['trello_list']}' to '{expected_list}'")
+                logger.info(
+                    "trello_card_moved",
+                    card_id=card_id,
+                    job_release=mismatch['identifier'],
+                    from_list=mismatch['trello_list'],
+                    to_list=expected_list,
+                )
             except Exception as err:
                 error_msg = str(err)
-                logger.error(f"Error moving card {card_id}: {error_msg}")
+                logger.error(
+                    "trello_card_move_failed",
+                    card_id=card_id,
+                    job_release=mismatch['identifier'],
+                    error=error_msg,
+                    error_type=type(err).__name__,
+                    exc_info=True,
+                )
                 results["moved"]["failed"].append({
                     "card_id": card_id,
                     "identifier": mismatch['identifier'],
@@ -550,12 +612,12 @@ def sync_trello_with_db(dry_run: bool = False) -> Dict:
                 })
     
     # 3. Create cards for DB-only jobs
-    logger.info(f"Creating {len(scan_results['db_only'])} cards for DB-only jobs...")
+    logger.debug("db_only_card_creation_started", count=len(scan_results['db_only']))
     for job_info in scan_results['db_only']:
         # Get the job from database
         job = Releases.query.filter_by(job=job_info['job'], release=job_info['release']).first()
         if not job:
-            logger.warning(f"Job {job_info['identifier']} not found in database, skipping")
+            logger.warning("release_not_found", job_release=job_info['identifier'], status="skipped")
             continue
         
         if dry_run:
@@ -581,9 +643,16 @@ def sync_trello_with_db(dry_run: bool = False) -> Dict:
     results["summary"]["moved_failed"] = len(results["moved"]["failed"])
     results["summary"]["created_failed"] = len(results["created"]["failed"])
     
-    logger.info(f"Sync complete: deleted={results['summary']['deleted_count']}, "
-                f"moved={results['summary']['moved_count']}, "
-                f"created={results['summary']['created_count']}")
+    logger.info(
+        "trello_db_sync_complete",
+        deleted=results['summary']['deleted_count'],
+        moved=results['summary']['moved_count'],
+        created=results['summary']['created_count'],
+        deleted_failed=results['summary']['deleted_failed'],
+        moved_failed=results['summary']['moved_failed'],
+        created_failed=results['summary']['created_failed'],
+        dry_run=dry_run,
+    )
     
     return results
 
@@ -606,7 +675,7 @@ def scan_and_create_cards_for_all_jobs(dry_run: bool = False, limit: Optional[in
     Returns:
         Dictionary with scan and creation results
     """
-    logger.info(f"Starting scan and create cards for all jobs (dry_run={dry_run})")
+    logger.debug("scan_and_create_started", dry_run=dry_run)
     
     try:
         # Query all jobs that don't have Trello cards
@@ -617,7 +686,7 @@ def scan_and_create_cards_for_all_jobs(dry_run: bool = False, limit: Optional[in
         
         jobs_without_cards = query.all()
         
-        logger.info(f"Found {len(jobs_without_cards)} jobs without Trello cards")
+        logger.debug("jobs_without_cards_found", count=len(jobs_without_cards))
         
         if len(jobs_without_cards) == 0:
             return {
@@ -653,7 +722,7 @@ def scan_and_create_cards_for_all_jobs(dry_run: bool = False, limit: Optional[in
                     expected_list = "Released"  # Default fallback
                 
                 if dry_run:
-                    logger.info(f"[DRY RUN] Would create card for {job_id} in list '{expected_list}'")
+                    logger.debug("card_create_dry_run", job_release=job_id, list_name=expected_list)
                     results["created"] += 1
                     results["created_details"].append({
                         "job": job.job,
@@ -663,7 +732,13 @@ def scan_and_create_cards_for_all_jobs(dry_run: bool = False, limit: Optional[in
                         "stage": job.stage
                     })
                 else:
-                    logger.info(f"[{idx}/{len(jobs_without_cards)}] Creating card for {job_id} in list '{expected_list}'")
+                    logger.debug(
+                        "card_create_started",
+                        job_release=job_id,
+                        list_name=expected_list,
+                        index=idx,
+                        total=len(jobs_without_cards),
+                    )
                     
                     # Create card using the standard function (handles all features)
                     create_result = create_trello_card_for_db_job(job, list_name=expected_list)
@@ -679,12 +754,12 @@ def scan_and_create_cards_for_all_jobs(dry_run: bool = False, limit: Optional[in
                             "list_name": create_result.get("list_name"),
                             "stage": job.stage
                         })
-                        logger.info(f"Successfully created card for {job_id}")
+                        logger.debug("trello_card_created", job_release=job_id, card_id=create_result.get("card_id"))
                     else:
                         error = create_result.get("error", "Unknown error")
                         if "already exists" in error.lower():
                             results["skipped"] += 1
-                            logger.info(f"Skipped {job_id}: {error}")
+                            logger.debug("card_create_skipped", job_release=job_id, status="skipped", reason=error)
                         else:
                             results["failed"] += 1
                             results["failed_details"].append({
@@ -694,11 +769,17 @@ def scan_and_create_cards_for_all_jobs(dry_run: bool = False, limit: Optional[in
                                 "error": error,
                                 "stage": job.stage
                             })
-                            logger.error(f"Failed to create card for {job_id}: {error}")
+                            logger.error("card_create_failed", job_release=job_id, error=error)
             
             except Exception as err:
                 error_msg = str(err)
-                logger.error(f"Error processing {job_id}: {error_msg}", exc_info=True)
+                logger.error(
+                    "card_processing_failed",
+                    job_release=job_id,
+                    error=error_msg,
+                    error_type=type(err).__name__,
+                    exc_info=True,
+                )
                 results["failed"] += 1
                 results["failed_details"].append({
                     "job": job.job,
@@ -708,14 +789,25 @@ def scan_and_create_cards_for_all_jobs(dry_run: bool = False, limit: Optional[in
                     "stage": job.stage if hasattr(job, 'stage') else None
                 })
         
-        logger.info(f"Scan and create complete: created={results['created']}, "
-                   f"failed={results['failed']}, skipped={results['skipped']}")
+        logger.info(
+            "scan_and_create_complete",
+            created=results['created'],
+            failed=results['failed'],
+            skipped=results['skipped'],
+            total=results['total_jobs'],
+            dry_run=dry_run,
+        )
         
         return results
         
     except Exception as e:
         error_msg = f"Scan and create failed: {str(e)}"
-        logger.error(error_msg, exc_info=True)
+        logger.error(
+            "scan_and_create_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {
             "success": False,
             "error": error_msg,
@@ -739,7 +831,7 @@ def clear_trello_board(dry_run: bool = False) -> Dict:
     """
     from app.trello.api import get_all_trello_cards, get_board_info
 
-    logger.info(f"Starting clear_trello_board (dry_run={dry_run})")
+    logger.debug("clear_trello_board_started", dry_run=dry_run)
 
     try:
         board = get_board_info()
@@ -750,10 +842,10 @@ def clear_trello_board(dry_run: bool = False) -> Dict:
                 "dry_run": dry_run,
             }
         board_name = board["name"]
-        logger.info(f"Board to clear: {board_name!r} (ID: {board.get('id')})")
+        logger.debug("board_info_fetched", board_name=board_name, board_id=board.get('id'))
 
         cards = get_all_trello_cards()
-        logger.info(f"Found {len(cards)} cards on board")
+        logger.debug("board_cards_fetched", count=len(cards))
 
         deleted = 0
         failed = []
@@ -783,7 +875,7 @@ def clear_trello_board(dry_run: bool = False) -> Dict:
                 synchronize_session=False,
             )
             db.session.commit()
-            logger.info(f"Cleared Trello data from {jobs_with_cards} DB records")
+            logger.info("releases_trello_data_cleared", count=jobs_with_cards)
 
         return {
             "success": len(failed) == 0,
@@ -796,7 +888,12 @@ def clear_trello_board(dry_run: bool = False) -> Dict:
             "dry_run": dry_run,
         }
     except Exception as e:
-        logger.error(f"clear_trello_board failed: {e}", exc_info=True)
+        logger.error(
+            "clear_trello_board_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {
             "success": False,
             "error": str(e),
@@ -836,9 +933,12 @@ def sync_releases_to_trello(
     """
     from app.trello.api import get_trello_card_by_id, update_job_record_with_trello_data
 
-    logger.info(
-        f"Starting sync_releases_to_trello (dry_run={dry_run}, create_only={create_only}, "
-        f"update_only={update_only}, clear_board_first={clear_board_first})"
+    logger.debug(
+        "sync_releases_to_trello_started",
+        dry_run=dry_run,
+        create_only=create_only,
+        update_only=update_only,
+        clear_board_first=clear_board_first,
     )
 
     try:
@@ -852,14 +952,16 @@ def sync_releases_to_trello(
                     "clear_result": clear_result,
                 }
             if dry_run:
-                logger.info(
-                    f"Would clear board: {clear_result.get('cards_deleted', 0)} cards, "
-                    f"{clear_result.get('db_would_clear', 0)} DB records"
+                logger.debug(
+                    "board_clear_dry_run",
+                    cards_deleted=clear_result.get('cards_deleted', 0),
+                    db_would_clear=clear_result.get('db_would_clear', 0),
                 )
             else:
                 logger.info(
-                    f"Board cleared: deleted={clear_result.get('cards_deleted', 0)} cards, "
-                    f"db_cleared={clear_result.get('db_cleared', 0)} records"
+                    "board_cleared",
+                    cards_deleted=clear_result.get('cards_deleted', 0),
+                    db_cleared=clear_result.get('db_cleared', 0),
                 )
 
         query = Releases.query.order_by(Releases.job, Releases.release)
@@ -871,7 +973,7 @@ def sync_releases_to_trello(
             query = query.limit(limit)
 
         releases = query.all()
-        logger.info(f"Found {len(releases)} releases to process")
+        logger.debug("releases_fetched", count=len(releases))
 
         results = {
             "success": True,
@@ -915,7 +1017,13 @@ def sync_releases_to_trello(
                             "card_id": create_result.get("card_id"),
                             "list_name": create_result.get("list_name"),
                         })
-                        logger.info(f"[{idx}/{len(releases)}] Created card for {identifier}")
+                        logger.debug(
+                            "trello_card_created",
+                            job_release=identifier,
+                            card_id=create_result.get("card_id"),
+                            index=idx,
+                            total=len(releases),
+                        )
                     else:
                         error = create_result.get("error", "Unknown error")
                         results["failed"] += 1
@@ -925,7 +1033,7 @@ def sync_releases_to_trello(
                             "identifier": identifier,
                             "error": error,
                         })
-                        logger.error(f"Failed to create card for {identifier}: {error}")
+                        logger.error("card_create_failed", job_release=identifier, error=error)
                 else:
                     # UPDATE: refresh DB from Trello
                     if create_only:
@@ -951,7 +1059,7 @@ def sync_releases_to_trello(
                             "card_id": rec.trello_card_id,
                             "error": "Card not found in Trello",
                         })
-                        logger.warning(f"Card {rec.trello_card_id} not found for {identifier}")
+                        logger.warning("trello_card_not_found", card_id=rec.trello_card_id, job_release=identifier)
                         continue
                     # Normalize: Trello API returns idList; ensure we pass it
                     if "idList" not in card_data and "list_id" in card_data:
@@ -966,7 +1074,12 @@ def sync_releases_to_trello(
                             "card_id": rec.trello_card_id,
                         })
                         if idx % 25 == 0:
-                            logger.info(f"[{idx}/{len(releases)}] Refreshed Trello data for {identifier}")
+                            logger.debug(
+                                "trello_refresh_progress",
+                                job_release=identifier,
+                                index=idx,
+                                total=len(releases),
+                            )
                     else:
                         results["failed"] += 1
                         results["failed_details"].append({
@@ -977,7 +1090,13 @@ def sync_releases_to_trello(
                         })
             except Exception as err:
                 error_msg = str(err)
-                logger.error(f"Error processing {identifier}: {error_msg}", exc_info=True)
+                logger.error(
+                    "release_sync_failed",
+                    job_release=identifier,
+                    error=error_msg,
+                    error_type=type(err).__name__,
+                    exc_info=True,
+                )
                 results["failed"] += 1
                 results["failed_details"].append({
                     "job": rec.job,
@@ -987,14 +1106,24 @@ def sync_releases_to_trello(
                 })
 
         logger.info(
-            f"sync_releases_to_trello complete: created={results['created']}, "
-            f"updated={results['updated']}, failed={results['failed']}, skipped={results['skipped']}"
+            "sync_releases_to_trello_complete",
+            created=results['created'],
+            updated=results['updated'],
+            failed=results['failed'],
+            skipped=results['skipped'],
+            total=results['total'],
+            dry_run=dry_run,
         )
         return results
 
     except Exception as e:
         error_msg = f"sync_releases_to_trello failed: {str(e)}"
-        logger.error(error_msg, exc_info=True)
+        logger.error(
+            "sync_releases_to_trello_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {
             "success": False,
             "error": error_msg,

--- a/app/trello/utils.py
+++ b/app/trello/utils.py
@@ -10,7 +10,7 @@ exports:
   calculate_business_days_before: Count backward N business days from a date.
   should_sort_list_by_fab_order: Decide whether a list needs Fab-Order re-sorting.
   sort_list_if_needed: Sort a list by Fab Order if it is a target list, with logging.
-imports_from: [app.config, app.trello.api, app.trello.logging, zoneinfo, re]
+imports_from: [app.config, app.trello.api, app.trello.logging, app.logging_config, zoneinfo, re]
 imported_by: [app/trello/sync.py, app/trello/scanner.py, app/trello/card_creation.py, app/trello/api.py, app/brain/job_log/routes.py, app/services/outbox_service.py]
 invariants:
   - parse_webhook_data never raises; errors return {"event": "error", "handled": False}.
@@ -21,6 +21,10 @@ updated_by_agent: 2026-04-14T00:00:00Z (commit e133a47)
 import re
 from datetime import datetime, date, timezone, time, timedelta
 from zoneinfo import ZoneInfo
+
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def parse_webhook_data(data):
@@ -129,7 +133,13 @@ def parse_webhook_data(data):
         # If nothing above matched, it's unhandled
         return {"event": "unhandled", "handled": False, "details": data, "action_type": action_type}
     except Exception as e:
-        print(f"Error parsing webhook data: {e}")
+        logger.error(
+            "webhook_parse_failed",
+            source="trello",
+            error=str(e),
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         return {"event": "error", "handled": False, "error": str(e)}
 
 
@@ -338,7 +348,12 @@ def sort_list_if_needed(list_id, fab_order_field_id, operation_id, list_type="li
                 cards_sorted=sort_result.get("cards_sorted", 0)
             )
         else:
-            print(f"[TRELLO API] {list_type.capitalize()} list sorted by Fab Order: {list_id} ({sort_result.get('cards_sorted', 0)} cards)")
+            logger.info(
+                "list_sorted_by_fab_order",
+                list_id=list_id,
+                list_type=list_type,
+                count=sort_result.get("cards_sorted", 0),
+            )
         return True
     else:
         if operation_id:
@@ -350,6 +365,11 @@ def sort_list_if_needed(list_id, fab_order_field_id, operation_id, list_type="li
                 error=sort_result.get("error", "Unknown error")
             )
         else:
-            print(f"[TRELLO API] {list_type.capitalize()} list sort failed: {list_id} - {sort_result.get('error', 'Unknown error')}")
+            logger.warning(
+                "list_sort_failed",
+                list_id=list_id,
+                list_type=list_type,
+                error=sort_result.get("error", "Unknown error"),
+            )
         return False
 

--- a/docs/logging-cleanup-plan.md
+++ b/docs/logging-cleanup-plan.md
@@ -1,0 +1,119 @@
+# Logging Cleanup Plan
+
+Production (Render, ~30 concurrent users) is drowning in steady-state log noise.
+Guiding principle for every task below: **log volume must scale with business
+activity (writes, changes, failures) — never with reader count.** Any log line
+on a GET/polling success path fails this test. Non-200s, real state changes,
+and failures must keep logging exactly as before.
+
+Work in phase order. Each phase is one commit. Run `pytest` after each phase —
+all tests must pass before moving on. Do not refactor beyond what a task asks.
+
+---
+
+## Phase 1 — Urgent (security + the dead filter)
+
+### 1.1 Stop logging DB credentials
+`app/__init__.py` (~line 303) logs the first 50 chars of
+`SQLALCHEMY_DATABASE_URI` at startup. Postgres URLs are
+`postgresql://user:password@host/db`, so this leaks the password into Render
+logs and `logs/app.log`. Replace it with a log of the environment name and the
+DB **host only** (parse with `urllib.parse.urlsplit`; never log username,
+password, or the raw string, truncated or not).
+
+### 1.2 Activate the gunicorn access-log filter
+`gunicorn.conf.py` defines `_QuietPathFilter` and a custom `Logger` class, but
+gunicorn only honors module-level variables that match setting names — the file
+never assigns `logger_class = Logger`, so the filter has never run. Add that
+assignment. Then extend `_QUIET_PATHS` so it also suppresses successful (200)
+access lines for the job-log delta poll: match `/brain/jobs?since=` (the query
+string is present in the access line; matching on `?since=` keeps initial
+full loads visible). **Do not** suppress non-200 responses — the existing
+filter already only drops lines containing `" 200 `; preserve that behavior.
+
+---
+
+## Phase 2 — Volume: silence the steady state
+
+### 2.1 Runtime log level from env
+`app/__init__.py` (~line 44) hardcodes `configure_logging(log_level="INFO", ...)`.
+Read the level from a `LOG_LEVEL` env var, defaulting to `INFO`. This makes
+every `debug` demotion below recoverable in prod without a deploy.
+
+### 2.2 Job-log cursor poll (`app/brain/job_log/routes.py`, `get_jobs`)
+Search for `[CURSOR]` in this file (~lines 480–640). Rules:
+- Delta polls (`since` param present) that return **zero** rows must emit no
+  INFO lines at all. Demote the per-poll narration to `debug`.
+- When a delta poll returns rows, emit **one** INFO line carrying the row
+  count and latest timestamp.
+- Initial full loads (no `since`) may keep one INFO line.
+- Leave the invalid-`since` warning at `warning`.
+
+### 2.3 Trello webhook path (`app/trello/__init__.py`, ~lines 95–175)
+- "Skipping unhandled webhook" fires for the majority of all Trello traffic
+  (every comment, label, checklist tick on the board) → demote to `debug`.
+- The per-handled-webhook quartet ("submitted to thread pool", "sync started",
+  "sync completed successfully", "Sync completed in Ns") → collapse to a single
+  INFO completion line that includes the duration; demote the rest to `debug`.
+- Leave every `warning`/`error` (queue full, lock failures, sync failed) alone.
+
+### 2.4 Procore webhook path (`app/procore/__init__.py`)
+Procore sends 2–5 duplicate deliveries per change, and our own outbound writes
+bounce back as webhooks — so per-delivery INFO lines are multiplied noise.
+Demote to `debug`: the "Received Procore webhook" receipt line, the
+"Duplicate webhook delivery rejected (burst dedup)" line, the "webhook user"
+id-resolution line, the connector bounce-back ("processing for side-effect
+diffs") line, and the "no changes applied (DB already in sync)" line.
+Keep at INFO: lines reporting an actual DB change (submittal created/updated).
+Keep all warnings/errors unchanged.
+
+### 2.5 Remove the rogue basicConfig
+`app/sync_lock.py` calls `logging.basicConfig(level=logging.INFO)` at import
+time, which can attach a duplicate root handler and fight the central
+dictConfig in `app/logging_config.py`. Delete the `basicConfig` call only —
+keep the module's `getLogger` line and all its log statements.
+
+### 2.6 Restore stack traces in the shared route wrapper
+`app/route_utils.py` (~line 50): the non-`raw_error` branch logs
+`error=str(exc)` without a traceback, and it wraps many routes. Add
+`exc_info=True` to that `logger.error` call. Change nothing else about the
+wrapper (response shape, rollback, status codes).
+
+---
+
+## Phase 3 — Deferred (separate effort; do NOT do as part of this plan)
+
+Listed so nobody "helpfully" starts them here: converting the ~700 runtime
+`print()` calls in `app/trello/` and `app/procore/` to loggers; fixing the
+stdout formatter mismatch in `app/logging_config.py` (console handler uses the
+plain formatter around structlog's pre-rendered JSON); migrating the five
+`logging.getLogger` modules to structlog; converting f-string logs to
+structured key-values; request-id binding via `structlog.contextvars`.
+
+---
+
+## Guardrails
+
+- **Never** touch `print()` calls anywhere in this plan — including
+  `app/*/scripts/` (CLI output, intentional) and `app/seed.py`.
+- **Never** change what warnings/errors log, or any response body/status code.
+- The heartbeat (`Scheduler heartbeat: alive`, `app/__init__.py`) is
+  intentional — leave it.
+- Loggers here are a mix of structlog (`get_logger`) and Flask's `app.logger`;
+  demotions are just `info` → `debug` on the same logger object. Don't swap
+  logger types or rewrite messages beyond what a task specifies.
+- Frontend (`console.log` noise in `frontend/src/`) is out of scope.
+
+## Verification
+
+1. `pytest` green after each phase.
+2. `grep -rn "SQLALCHEMY_DATABASE_URI" app/__init__.py` — no log statement
+   includes the raw value.
+3. `grep -n "logger_class" gunicorn.conf.py` — assignment exists.
+4. Manual: start the app, hit `GET /brain/jobs?since=<recent ISO timestamp>`
+   twice with no data changes → zero INFO lines emitted. Hit it without
+   `since` → at most one INFO line.
+5. `grep -n "basicConfig" app/ -r` — only matches outside runtime code, if any.
+6. Confirm the Render start command runs gunicorn from the repo root (so
+   `./gunicorn.conf.py` auto-loads) and does not pass `--logger-class`.
+   (Human step — flag it in the PR description.)

--- a/docs/logging-standard.md
+++ b/docs/logging-standard.md
@@ -1,0 +1,183 @@
+# MHMW Logging & Emission Standard
+
+How every part of this system — current and future — emits telemetry. The goal is
+uniformity: one idiom, one shape, one vocabulary, so everything is queryable together
+and log volume scales with business activity, never with reader count.
+
+Status: adopted 2026-07-05. Decisions marked ⚖ were made with explicit trade-offs and
+can be revisited; everything else is settled.
+
+Related docs: `docs/observability-guide.md` (the why / the wider landscape),
+`docs/logging-cleanup-plan.md` (the volume/hygiene cleanup that preceded this).
+
+---
+
+## 1. One idiom
+
+All runtime code gets its logger exactly one way:
+
+```python
+from app.logging_config import get_logger
+logger = get_logger(__name__)
+```
+
+- **Never** `logging.getLogger(...)` (stdlib) in `app/` runtime code.
+- **Never** `app.logger` / `current_app.logger` — Flask's logger bypasses structlog
+  and renders a different shape. Use the module-level `get_logger(__name__)` even
+  inside routes and webhook handlers.
+- **Never** `print()` on a runtime path (anything reachable from a request, webhook,
+  scheduler job, or worker thread). `print()` ignores log levels and never reaches the
+  file/pipeline. Exception: CLI scripts under `scripts/` and `app/*/scripts/` may
+  print — that's their user interface.
+- **Never** `logging.basicConfig()` anywhere. Configuration lives solely in
+  `app/logging_config.py`.
+
+## 2. Events, not sentences
+
+Log calls take a **stable snake_case event name** plus keyword fields. Data goes in
+fields, never interpolated into the message.
+
+```python
+# YES
+logger.info("submittal_created", submittal_id=sid, project_id=pid, source="webhook")
+
+# NO — unqueryable, and the event name changes every time the wording does
+logger.info(f"Successfully created submittal {sid} for project {pid}")
+```
+
+- **F-strings (and %-format / .format) are banned in logger calls.** If you need a
+  value, it's a field.
+- Event names are permanent identifiers (they end up in queries and dashboards).
+  Naming: `<noun>_<past_tense_verb>` for state changes (`release_archived`,
+  `stage_updated`), `<noun>_<verb>_failed` for failures (`procore_push_failed`),
+  `<noun>_<verb>_skipped` for deliberate no-ops. Don't rename an established event
+  without checking what queries/dashboards reference it.
+- The `meetings/` and `lake/` modules are the house reference for this style.
+
+## 3. Canonical field registry
+
+Reuse these names exactly; never invent a synonym (`uid`, `jobNum`, `sub_id`…).
+Add new names here first when a genuinely new concept appears.
+
+| Field | Meaning |
+|---|---|
+| `request_id` | Correlation id for the request/webhook/job (bound, not hand-passed) |
+| `user_id` | Numeric `User.id` of the acting user |
+| `job` | Job number string (e.g. `"580"`) |
+| `release` | Release number string |
+| `job_release` | Combined `job-release` string (e.g. `"580-659"`) |
+| `release_id` | Numeric `Releases.id` |
+| `submittal_id` | Procore submittal id |
+| `project_id` | Procore project id |
+| `card_id` | Trello card id |
+| `event_id` | `ReleaseEvents` / `SubmittalEvents` row id |
+| `operation_id` | Sync-operation id (webhook/queue processing bundle) |
+| `feature` | Feature slug (`"meeting_extraction"`, `"pdf_review"`, `"job_log"`) |
+| `source` | Origin system: `"trello"`, `"procore"`, `"onedrive"`, `"user"`, `"scheduler"` |
+| `status` | Outcome: `"ok"`, `"error"`, `"skipped"`, `"queued"`, HTTP status where apt |
+| `duration_ms` | Elapsed time in milliseconds (int) |
+| `count` | Number of items processed/returned |
+| `error` | `str(exc)` — always paired with `exc_info=True` at ERROR |
+| `error_type` | Exception class name |
+| `model`, `input_tokens`, `output_tokens`, `cost_usd`, `latency_ms` | AI-call ledger fields |
+
+⚖ We use our own domain-shaped registry rather than OpenTelemetry semantic-convention
+names. If we adopt an OTel pipeline later, a rename map at the collector translates.
+
+## 4. The levels contract
+
+| Level | Meaning | Rules |
+|---|---|---|
+| `DEBUG` | Narrative — *how* something happened | Off in prod by default (`LOG_LEVEL` env var). Unlimited chattiness allowed. |
+| `INFO` | A state actually **changed** | One line per change, emitted by the layer that **owns** the change (command/service — not echoed by route + command + service). Reads, polls, and no-ops NEVER log at INFO. |
+| `WARNING` | Unexpected but handled | Not for normal control flow ("not found" on a user-driven lookup is DEBUG or a 404, not a warning). |
+| `ERROR` | An operation failed | **Always** `exc_info=True` (or `logger.exception`). Never sampled, never suppressed, never `str(e)` alone. |
+
+The test for INFO: *would I want one line per occurrence of this in production, forever?*
+If the occurrence is a read, the answer is no.
+
+**Failure capture at boundaries:** every call to an external system (Trello, Procore,
+Graph, Anthropic) and every background-job/worker/scheduler entry point must catch and
+emit an ERROR event with `error`, `error_type`, `exc_info=True`, and correlation fields.
+Bare `except: pass` and swallowed exceptions are defects.
+
+## 5. Canonical wide line (the target shape)
+
+⚖ **Target:** every unit of work — HTTP request, webhook delivery, scheduled job run,
+outbox batch — emits **exactly one wide completion event** carrying its full context:
+
+```python
+logger.info("request_complete", method=..., path=..., status=200, duration_ms=42,
+            user_id=17, count=0, request_id=...)
+logger.info("webhook_complete", source="procore", event_type="update",
+            submittal_id=..., status="ok", duration_ms=310, changes=2)
+```
+
+- The wide line is INFO; the play-by-play that used to be many INFO lines becomes
+  DEBUG or fields on the wide line.
+- Implementation is a request/job-scoped accumulator (Flask `g` /
+  `structlog.contextvars`): middleware creates it, business logic adds fields, a
+  `finally`/`teardown` emits it — **even when an exception unwinds the stack** (then
+  with `status="error"`).
+- Until the accumulator middleware exists, new code should still *think* in this shape:
+  prefer one rich completion event over several thin progress events.
+
+## 6. Log line vs. event table (the durability rule)
+
+Two streams, one rule:
+
+> **If losing the record would matter next week, it's a database event row.
+> If it only matters while debugging, it's a log line.**
+
+- DB event rows (`ReleaseEvents`, `SubmittalEvents`, ledgers): business state changes,
+  external sync outcomes, integration failures, auth/admin actions, AI calls. These are
+  what the Brain and audit queries read. Durable, schema'd, never in stdout only.
+- Log lines: everything else. Assume they evaporate (Render stdout rotates away).
+- Never put a business fact only in a log line; never put debug chatter in Postgres.
+
+## 7. Correlation
+
+Correlation fields (`request_id`, `operation_id`, `user_id`) are **bound once** per
+unit of work via `structlog.contextvars` (at `before_request` / job entry / thread
+handoff) and ride on every line automatically. Hand-threading ids through function
+signatures just to log them is a smell; binding is the mechanism. New background
+paths must propagate the binding across the async boundary.
+
+## 8. Output format
+
+- stdout: **single-rendered JSON**, one object per line, ISO-8601 UTC timestamps,
+  `event` as the message key. (No plaintext wrapper around a JSON payload — the
+  double-render in `logging_config.py` is a known defect being fixed.)
+- Secrets and credentials never appear in any log field at any level: no tokens, no
+  API keys, no passwords, no connection strings (log the host, never the URI). When
+  logging payloads, log ids and counts, not bodies.
+
+## 9. Migration policy (the ratchet)
+
+⚖ Existing violations (~700 runtime `print()`s, f-string logs, stdlib loggers) are
+migrated by **ratchet**, not big-bang:
+
+1. **All new code** follows this standard fully — no exceptions.
+2. **Any file you touch** for other reasons: migrate the logging in the code you're
+   already changing (same PR, no scope creep beyond it).
+3. **Hot paths** (`app/trello/api.py`, `app/procore/webhook_utils.py`, webhook
+   handlers) get dedicated conversion tasks — see `docs/logging-cleanup-plan.md`
+   Phase 3.
+4. Never mass-rewrite untouched cold paths just for style.
+
+## Quick reference (pin this)
+
+```python
+from app.logging_config import get_logger
+logger = get_logger(__name__)
+
+logger.debug("cursor_filter_applied", since=since_ts)                  # narrative
+logger.info("stage_updated", release_id=rid, from_stage=a, to_stage=b) # state change
+logger.warning("trello_queue_full", queued=n)                          # anomaly, handled
+logger.error("procore_push_failed", submittal_id=sid, error=str(e),
+             error_type=type(e).__name__, exc_info=True)               # failure + trace
+```
+
+- one idiom (`get_logger`) · events not sentences · registry field names ·
+  INFO = state changed · errors always carry tracebacks · one wide line per unit of
+  work · durable facts go to Postgres, not stdout · bind correlation, don't thread it.

--- a/docs/observability-guide.md
+++ b/docs/observability-guide.md
@@ -1,0 +1,296 @@
+# Observability & Logging: A Field Guide for milehigh
+
+A deep-dive on how to think about logs/telemetry as the system grows, how to feed
+signal into the Brain, and where our current setup sits. Written to be re-read.
+
+Companion docs: `docs/logging-standard.md` (the enforceable emission rules),
+`docs/logging-cleanup-plan.md` (the volume/hygiene cleanup that preceded the standard).
+
+---
+
+## 0. The one reframe to start with
+
+Stop thinking "logging." Start thinking **telemetry**: structured records about what
+the system did, emitted so a *machine* can query them later, not so a *human* can read
+them scroll by. The moment you internalize that, most decisions fall out of it:
+messages become events with fields, "levels" matter less, and "is this line readable
+in the terminal" stops being the design goal.
+
+The industry has been on a 15-year march from **logs → structured logs → wide events**.
+We are currently at "structured logs, unevenly applied." The target is wide events. The
+rest of this doc is about why, and how to get there without boiling the ocean.
+
+---
+
+## 1. The three kinds of telemetry (and the debate about them)
+
+Classic model — the **"three pillars":**
+
+- **Logs** — discrete timestamped records of "something happened." Cheap to emit,
+  expensive to store and query at volume. Good for *narrative* ("what happened in this
+  one request").
+- **Metrics** — pre-aggregated numbers over time (counters, gauges, histograms). Tiny
+  and cheap because they're aggregated at write time. Good for *trends and alerts*
+  ("error rate over the last hour"). **Cannot** carry high-cardinality data like a
+  user_id (that would explode the number of time series).
+- **Traces** — a request's path across services/functions, as a tree of timed spans.
+  Good for *"where did the time go / where did it break"* across async boundaries.
+
+The critique (Charity Majors / Honeycomb, "Observability 2.0"): three pillars means
+**three copies of the same truth in three tools**, and the relationships between them
+get "ripped apart." You pay to store the same event as a log, a metric, and a trace,
+and you still can't ask a question you didn't predefine. Their answer: **one source of
+truth — arbitrarily-wide structured events per request** — from which logs, metrics,
+and traces can all be *derived*. You keep the raw high-cardinality event; you compute
+aggregates at read time instead of throwing away detail at write time.
+
+You don't have to pick a camp today. The practical takeaway that's true in *both*
+camps: **emit rich structured events; put as much context on each as you can; don't
+pre-shred your data into un-joinable pieces.**
+
+---
+
+## 2. The distinction we are currently blurring — and it's the important one
+
+There are **two completely different streams** that both happen to be called "logs,"
+and conflating them is the root of most confusion (including "should we stream logs to
+the Brain?"):
+
+### A. Operational telemetry
+For *operators / debugging*. "This webhook took 800ms," "the outbox retried 3×,"
+"this request 500'd with this stack trace." High volume, mostly disposable, sampled
+when hot, tunable by level/env. Audience: us, at 2am, when something's broken.
+
+### B. Domain / business events
+For *the product and the Brain*. "Submittal 1234 moved to Closed," "release entered
+Complete zone," "PM assigned." Low(er) volume, **durable, must-not-lose**, schema'd,
+often the source of truth for a feature. Audience: the application, the audit trail,
+and eventually an agent reasoning over the business.
+
+**We already do (B) correctly and don't fully realize it.** `ReleaseEvents` /
+`SubmittalEvents` with payload-hash dedup, the outbox tables, `JobChangeLog` — that's a
+domain-event store. It's event sourcing in spirit. That is the thing the Brain should
+consume.
+
+**The mistake to avoid: piping operational logs (stream A) into the Brain.** Raw app
+logs are noisy, semantically shallow ("HTTP 200 on /brain/jobs"), full of retries and
+debug chatter. An agent reasoning over that will drown. What the Brain wants is stream
+B — curated, meaningful, entity-anchored domain events ("release X shipped," "submittal
+Y is 4 days overdue"). We already have the table shape for it.
+
+So the honest answer to *"how do we stream logs to the brain"* is: **you mostly don't
+stream logs — you stream events.** Build/lean on the domain-event layer (B), give it
+stable schemas and entity anchors (job/release/submittal/GC — the Hive Mind spine),
+and let the Brain subscribe to *that*. Operational logs (A) go to an observability
+backend for humans, on a separate pipe. More on both pipes in §6.
+
+---
+
+## 3. The formatting answer: canonical log lines / wide events
+
+This is the single most valuable pattern to adopt for stream A, and it directly answers
+"how do I format outputs as the system grows."
+
+**Canonical log line** (Stripe's term; "wide event" is the modern name): instead of
+scattering 8 log lines across a request, you emit **exactly one fat structured event
+per unit of work** (per HTTP request, per webhook, per scheduled job), containing
+everything you'd want to know about it:
+
+```
+event=request_complete method=GET path=/brain/jobs status=200 duration_ms=42
+  user_id=17 rows_returned=0 since_present=true trello_locked=false
+  db_ms=31 request_id=a1b2c3 release_count=0
+```
+
+Why this wins as you scale:
+
+- **Correlation, not just visibility.** Everything about the request is on one row, so
+  you query `path=/brain/jobs status>=500 duration_ms>1000` in one shot — no stitching
+  lines together at 2am. Stripe/Brandur are explicit that the real power is correlation.
+- **Cheap for the machine.** One wide row aggregates and retrieves far faster than
+  N narrow lines the backend has to join.
+- **One line per request = predictable volume.** Volume scales with *requests*, not
+  with how chatty a given code path is. (Contrast our old webhook paths that emitted
+  4–12 lines each.)
+
+**How you implement it:** a request-scoped accumulator (Flask `g` or a
+`structlog.contextvars` bound dict) created in `before_request`; middleware and business
+logic *add fields* to it as work happens (`ctx["db_ms"] = ...`, `ctx["rows"] = ...`);
+`after_request`/`teardown` emits the single event. Wrap the emit so it fires even on
+exception (Stripe logs it in an `ensure`/`finally` block so a thrown error still
+produces the line).
+
+**logfmt vs JSON:** logfmt (`key=value`) is human-skimmable; JSON is universal and
+nests. For us, **JSON to stdout in prod** (machines/Render/agents consume it) is the
+right default; logfmt is a nicety for local dev. As of the logging rebuild we render
+single-rendered JSON on stdout — the remaining gap is that it's one-line-per-event, not
+one-wide-line-per-request (that's §5 / the correlation follow-up).
+
+**Stable field names are a contract.** `user_id` is always `user_id`, never also
+`uid`/`user`/`userId`. Our registry lives in `docs/logging-standard.md §3`. OpenTelemetry
+**semantic conventions** (§5) are the industry version of the same idea.
+
+---
+
+## 4. What matters, what doesn't, what we're missing
+
+### Matters a lot
+- **Structure** (fields, not f-strings). `logger.info("submittal_created",
+  submittal_id=…, project=…)` — queryable. (Now enforced by the standard.)
+- **One event per unit of work** (canonical line, §3).
+- **High cardinality on events** — put the ids on (user, release, submittal, request).
+  Cardinality is *the* thing that makes debugging possible ("which user, which release").
+- **Correlation / request id** on every line, propagated across async hops.
+- **Errors are sacred** — never suppress/sample a non-2xx or an exception.
+- **Runtime-tunable level** (env), so you can turn up detail in prod without a deploy.
+  (Done: `LOG_LEVEL`.)
+- **Cost awareness** — log volume is a bill and a signal-to-noise ratio. Volume must
+  scale with *activity*, never with *reader/user count* (our poll-endpoint problem).
+
+### Doesn't matter much
+- **Pretty console formatting in prod.** Nobody reads raw stdout at scale; a machine does.
+- **Log *levels* as your primary tool.** Useful as a coarse dial, but Majors' point
+  stands: reaching for "should this be info or debug" a hundred times is a smell. A wide
+  event with a `status`/`error` field you can filter on beats level discipline.
+- **Perfect prose in messages.** The event *name* + fields carry meaning.
+- **Chasing every debug line to zero.** Debug is fine when it's off by default.
+
+### What we're missing (the "don't know what you don't know" list)
+- **Correlation IDs are effectively absent.** `SyncContext`/`log_sync_operation` exist
+  but are *never called*; no `before_request` binds a request id. So today you cannot
+  reconstruct one request's or one webhook's full story. Highest-leverage gap.
+- **No metrics at all.** Zero RED/Golden-Signal instrumentation (§5). Can't answer
+  "what's the webhook error rate" or "outbox queue depth over time" without grepping.
+- **No tracing across async boundaries.** Our hardest-to-debug paths are the async ones:
+  webhook → threadpool → sync → outbox → Procore. A trace id through those would turn
+  "grep and guess" into one waterfall view.
+- **No sampling strategy.** Currently all-or-nothing per level.
+- **No retention/tier thinking.** Audit/business events (durable, cheap, keep for years)
+  vs debug logs (voluminous, keep for days) should live in different tiers.
+
+---
+
+## 5. The monitoring-signals canon (what to actually measure)
+
+Three named recipes, all about **metrics** — the pillar we're missing entirely.
+
+- **Google's Four Golden Signals** (SRE book): **Latency, Traffic, Errors, Saturation.**
+  If you instrument only four things on a user-facing service, these. Latency must split
+  success vs failure (a fast 500 lies to you).
+- **RED** (Tom Wilkie) — for request-driven services: **Rate, Errors, Duration.** The
+  per-endpoint version of the golden signals. Apply to our HTTP routes and webhook
+  handlers first.
+- **USE** (Brendan Gregg) — for resources: **Utilization, Saturation, Errors.** Our
+  outbox queue depth, threadpool saturation, and DB pool are textbook USE targets.
+
+Mapped to us: RED on `/brain/*` routes and the Trello/Procore webhook handlers; USE on
+the outbox queue (depth = saturation), the `ThreadPoolExecutor(max_workers=10)`, and the
+APScheduler pool. Emit these as real metrics (Prometheus client or StatsD) — then the
+poll-endpoint noise *becomes a metric* (a request counter) and disappears from logs.
+
+---
+
+## 6. Streaming telemetry — the architecture (two pipes)
+
+### Pipe A — operational telemetry → an observability backend (for humans)
+```
+app (structured JSON to stdout)
+  → collector/agent (OTel Collector | Vector | Fluent Bit)
+      → backend (Grafana Loki | ClickHouse | Honeycomb | our Postgres)
+```
+On **Render**: the app writes structured JSON to stdout; use a **log drain** (or a
+collector sidecar) to ship it somewhere queryable. Don't try to query logs in the Render
+dashboard forever — it doesn't scale and has no real query language.
+
+Collector choices (all mature; pick by need):
+- **OpenTelemetry Collector** — universal, vendor-neutral, multi-signal (logs + metrics
+  + traces). Heavier, but the strategic bet (§8). Standardize here if we add metrics/traces.
+- **Vector** (Datadog, Rust) — fast, efficient, great transformation/routing; logs+metrics.
+  Good if we want a lightweight router into our own Postgres/ClickHouse.
+- **Fluent Bit** (C, tiny) — the featherweight forwarder; ubiquitous at the node/edge layer.
+
+### Pipe B — domain events → the Brain (for the product/agent)
+Not the same pipe; don't reuse the observability backend.
+```
+domain event written (ReleaseEvents / SubmittalEvents / a new EventOutbox)
+  → durable store / event log (we already have the tables)
+      → Brain / Banana Boy subscribes, reasons, anchors to entities
+```
+The Brain reads **stream B**, not stream A. If you want the Brain aware of operational
+health, compute it from **metrics/SLOs** (pipe A) and emit a *domain event*
+("integration_degraded") into pipe B — promote a meaningful operational condition into a
+first-class event the agent can reason about. Don't hand the agent the raw log firehose.
+
+**Rule of thumb:** logs and metrics are for humans and dashboards; *events* are for the
+product and the agent. Convert, don't cross the streams.
+
+---
+
+## 7. Our current state, honestly
+
+- **Good bones:** structlog everywhere (as of the rebuild); `meetings`/`lake`/
+  `material_orders` emit clean structured events; we have a real domain-event store
+  (`*Events` tables, dedup hashing, outbox); `LOG_LEVEL` is env-tunable; single-rendered
+  JSON on stdout; the gunicorn access-log noise filter is live.
+- **Done in the rebuild:** uniform idiom, structured events across ~600 call sites,
+  killed the double-render, restored swallowed tracebacks, trimmed credential/payload
+  leaks, cut steady-state poll volume.
+- **Strategic gaps (not yet touched):** no correlation IDs (dead `SyncContext`), no
+  metrics, no tracing, no sampling, no log→backend pipeline, no AI-call ledger.
+
+---
+
+## 8. A maturity ladder for us (in order)
+
+1. **Uniformity** — one JSON format, structured events everywhere. *(done)*
+2. **Correlation** — `before_request` binds a `request_id` (and user id) via
+   `structlog.contextvars`; propagate into the Trello/Procore worker threads and the
+   outbox. Suddenly every line is joinable. *(highest leverage, small effort — next)*
+3. **Canonical log lines** — one wide event per request/webhook/job (§3).
+4. **Metrics** — RED on routes+webhooks, USE on the queues/pools (§5). Move the poll
+   endpoints from logs to counters. Now you can alert.
+5. **A pipeline** — pick a collector + backend (Grafana Cloud free tier is the cheap,
+   hosted, vendor-neutral default); set up a Render log drain. Stop living in the dashboard.
+6. **Tracing** — OpenTelemetry spans across the async boundaries.
+7. **Event → Brain** — formalize the domain-event stream (schema, entity anchors) as the
+   thing the Brain subscribes to; promote operational conditions into events. *(ties into
+   Hive Mind / Banana Boy)*
+8. **AI-call ledger** — one row per LLM call (user, feature, model, tokens, cost_usd,
+   latency, status, entity) for AI-infra visibility; SQL answers who-uses-what and cost.
+
+**OpenTelemetry is the strategic bet** underneath 4–6. Instrument once with the OTel SDK
++ semantic conventions and you can route logs, metrics, and traces to *any* backend
+without re-instrumenting, plus automatic trace↔log correlation.
+
+---
+
+## 9. Reading list (annotated thought leadership)
+
+**Wide-events / canonical-log-lines core (most directly useful to us):**
+- Brandur Leach, *Using Canonical Log Lines for Online Visibility* — https://brandur.org/canonical-log-lines
+- Brandur Leach, *Canonical Log Lines 2.0* — https://brandur.org/nanoglyphs/025-logs
+- Stripe Engineering, *Fast and flexible observability with canonical log lines* — https://stripe.com/blog/canonical-log-lines
+
+**The observability-2.0 / wide-events argument (the "why"):**
+- Honeycomb, *There Is Only One Key Difference Between Observability 1.0 and 2.0* — https://www.honeycomb.io/blog/one-key-difference-observability1dot0-2dot0
+- Honeycomb, *The Cost Crisis in Observability Tooling* — https://www.honeycomb.io/blog/cost-crisis-observability-tooling
+- Charity Majors, *charity.wtf* (observability 2.0 tag) — https://charity.wtf/tag/observability-2-0/
+- *Observability: the present and future* (Pragmatic Engineer, interview w/ Majors) — https://newsletter.pragmaticengineer.com/p/observability-the-present-and-future
+- Book: **Majors, Fong-Jones & Miranda, *Observability Engineering* (O'Reilly)** — the canonical text.
+
+**Foundational monitoring (the metrics canon):**
+- Google SRE Book, *Monitoring Distributed Systems* — https://sre.google/sre-book/monitoring-distributed-systems/
+- RED (Tom Wilkie) & USE (Brendan Gregg) — overview: https://betterstack.com/community/guides/monitoring/sre-golden-signals/
+- Cindy Sridharan, *Distributed Systems Observability* (free O'Reilly report) + her blog (copyconstruct).
+
+**Standards & tooling (the "how to ship it"):**
+- OpenTelemetry — Logs concepts: https://opentelemetry.io/docs/concepts/signals/logs/
+- OpenTelemetry — Semantic Conventions: https://opentelemetry.io/docs/concepts/semantic-conventions/
+- Collector comparisons: OTel Collector vs Fluent Bit (SigNoz) https://signoz.io/comparisons/opentelemetry-collector-vs-fluentbit/ ; 2026 log-collector benchmark incl. Vector https://victoriametrics.com/blog/log-collectors-benchmark-2026/
+
+---
+
+*The through-line: emit structured events, one wide one per unit of work, with ids and a
+correlation key on every one; send operational telemetry to a real backend for humans and
+curated domain events to the Brain for the product; add metrics for trends and traces for
+async debugging; and treat OpenTelemetry as the standard you instrument against once.*

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -3,7 +3,7 @@ from gunicorn import glogging
 
 # Paths to suppress from access logs when the response is 200.
 # Non-200 responses (errors, auth failures) are still logged.
-_QUIET_PATHS = {'/brain/notifications/unread-count'}
+_QUIET_PATHS = {'/brain/notifications/unread-count', '/brain/jobs?since='}
 
 
 class _QuietPathFilter(logging.Filter):
@@ -16,3 +16,6 @@ class Logger(glogging.Logger):
     def setup(self, cfg):
         super().setup(cfg)
         self.access_log.addFilter(_QuietPathFilter())
+
+
+logger_class = Logger


### PR DESCRIPTION
## What this is

A ground-up logging cleanup + a written emission standard the codebase now follows. Started from one complaint (the `/brain/notifications/unread-count` spam in Render logs) and turned into fixing the whole foundation: a security leak, steady-state noise, inconsistent emission, and lost stack traces.

**38 files, ~570 log call sites migrated. No behavior changes beyond logging.** Full test suite holds at its pre-existing baseline (807 passing; the same 8 environmental failures fail on `main` before this branch — unrelated to logging, none assert on log output).

## The urgent fixes (ship these regardless)

- **Credential leak closed** — startup no longer logs the first 50 chars of the DB URI (which included `user:password`). Now logs host/db name only, via `urlsplit`.
- **Trello API key/token leak closed** — `trello/api.py` card-update payload dumps were printing `TRELLO_API_KEY`/`TRELLO_TOKEN` to stdout. Never logged now, at any level.
- **Poll-endpoint noise cut** — the gunicorn access-log filter (which was dead — `logger_class` was never assigned) is now active and also quiets the job-log delta poll; the `/brain/jobs` cursor endpoint no longer logs on empty polls. At 30 concurrent users this was the bulk of daily log volume.
- **Lost stack traces restored** — the shared route error wrapper and several `except` blocks (incl. two silently-swallowed Procore fetch failures and scheduling-preview errors) now emit `exc_info=True`.

## The standard + the migration

- **New docs:** `docs/logging-standard.md` (the enforceable spec), `docs/observability-guide.md` (the wider landscape + maturity ladder), `docs/logging-cleanup-plan.md`. `CLAUDE.md`'s logging section now carries the hard rules so future work complies by default.
- **Uniform emission:** one idiom (`get_logger`), structured events instead of f-strings/`print()`, snake_case event names + a canonical field registry. Converted across procore, trello, job_log, DWL, auth, services, scheduling, and the feature-command layer.
- **Single-rendered JSON** on both stdout and file — fixed the double-render (plaintext wrapper around a JSON blob) so every line, including third-party (apscheduler/werkzeug) records, is one parseable JSON object.
- **Level discipline:** INFO = a state changed; reads/polls/no-ops are DEBUG; permanent failures (e.g. exhausted outbox delivery = a lost outbound update) stay ERROR.
- **`LOG_LEVEL` env var** (default INFO) makes the debug tier tunable in prod without a deploy.

## Incidental bugs found & fixed
- A shadowed loop variable in DWL bump logging that could report a *neighbor* submittal's id.
- `SyncContext` documented as active in CLAUDE.md is in fact dead code — now flagged as such.

## Not in scope (deferred, by design)
- Correlation IDs (`request_id`) + one-wide-line-per-request — the standard's §5/§7 targets. Outlined and ready as the next branch; it's net-new plumbing, not cleanup.
- Metrics/RED, a log→backend pipeline, an AI-call ledger, tracing — later rungs of the maturity ladder in `observability-guide.md`.
- `seed.py` (162 prints) and `ingest_jobsites.py` — left as-is; both are dead code (zero importers). Delete-or-keep is a separate call.

## Verification
- Full pytest suite at baseline after every wave (807 passing, 8 pre-existing failures unchanged).
- Boot smoke test: 22/22 startup stdout lines are valid JSON.
- Full-repo grep sweep: 0 remaining `print()`/f-string-logger/`app.logger`/stdlib-logger violations in runtime code (excl. CLI `scripts/` and the two dead files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
