### PR TITLE
Mirror Ship Date cell color to Start install

### DIFF
--- a/frontend/src/components/JobsTableRow.jsx
+++ b/frontend/src/components/JobsTableRow.jsx
@@ -1254,19 +1254,28 @@ export function JobsTableRow({ row, columns, formatCellValue, formatDate, rowInd
                         );
                     }
 
-                    // Handle Ship Date column: clickable cell that opens the same modal. A plain
-                    // hard date (past = yellow, future = green), neutralized when the release
-                    // completes. Its color follows start_install_no_color — no separate flag.
-                    // No ASAP/formula concepts apply.
+                    // Handle Ship Date column: clickable cell that opens the same modal.
+                    // The ship date is a derived milestone (~1 biz day before Start install),
+                    // so its cell MIRRORS the paired Start install cell's color exactly — the
+                    // two columns must always read the same. Key every branch on the INSTALL
+                    // date/flags, not the ship date's own past/future: ship crosses "today" a
+                    // day earlier than install, so keying on shipDay would show yellow while
+                    // install is still green. ASAP propagates red; formula/no-color/no-date
+                    // fall through to neutral, matching Start install above.
                     if (column === 'Ship Date') {
                         const displayValue = formatDate(localShipDate);
+                        const isAsap = row['start_install_asap'] === true;
                         const isNoColor = row['start_install_no_color'] === true;
                         const hasDate = !!localShipDate;
-                        const shipDay = toYmd(localShipDate);
+                        // Same hard-date test the Start install cell uses.
+                        const isHardDate = !isAsap && !isNoColor && row['start_install_formulaTF'] === false && localStartInstall;
+                        const isHardDatePast = isHardDate && toYmd(localStartInstall) < localTodayStr();
                         let shipBgClass;
-                        if (!hasDate || isNoColor) {
+                        if (isAsap) {
+                            shipBgClass = 'bg-red-500 text-white hover:bg-red-600 font-semibold';
+                        } else if (!hasDate || isNoColor || !isHardDate) {
                             shipBgClass = `${rowBgClass} text-gray-900 dark:text-slate-100 hover:bg-accent-50 dark:hover:bg-slate-600`;
-                        } else if (shipDay < localTodayStr()) {
+                        } else if (isHardDatePast) {
                             shipBgClass = 'bg-yellow-400 text-gray-900 hover:bg-yellow-500 font-semibold';
                         } else {
                             shipBgClass = 'bg-green-400 text-gray-900 hover:bg-green-500 font-semibold';


### PR DESCRIPTION
## Problem

In the Job Log table, the **Ship Date** and **Start install** columns are a visual pair, but their cell colors didn't match. On dates falling between the two (e.g. today = 07/19, ship 07/17 vs install 07/20), ship showed **yellow (past)** while install still showed **green (future)**. ASAP rows also disagreed (install red, ship green/yellow).

**Root cause:** the two cells computed green/yellow independently in `JobsTableRow.jsx`:
- **Start install** flips on the *install* date crossing today, and only colors *hard* dates (red for ASAP).
- **Ship Date** flipped on the *ship* date crossing today, and colored *any* date (no ASAP branch).

Since ship is defined as ~1 business day *before* install, its date crosses "today" a day earlier, so the two flip on different days.

## Fix

The Ship Date cell now **mirrors the Start install cell exactly**, keying every branch on the *install* date and flags:

- ASAP → red (propagates)
- formula / no-color / no-date → neutral
- hard date past → yellow, today/future → green

Uses `toYmd(localStartInstall)` + `localTodayStr()`, which are equivalent to the install cell's inline today/date computation, so the pair can no longer drift — not even at midnight.

Only `JobsTableRow.jsx` renders the paired colored cells; the card editor and `ReleaseDetailModal` show ship date uncolored, so no other component needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)