### PR TITLE
Hide install-window cockpit for shipping-lane Timeline cards

### DIFF
--- a/frontend/src/components/GanttChart.jsx
+++ b/frontend/src/components/GanttChart.jsx
@@ -281,6 +281,7 @@ function GanttChart({ filterComplete = false }) {
     const [isAdmin, setIsAdmin] = useState(false);                  // admins get the schedule cockpit; others the read-only detail modal
     const [orderJob, setOrderJob] = useState(null);                 // {job, release} for a clicked material-order chip
     const [selectedColor, setSelectedColor] = useState(null);       // lane color of the clicked card → modal accent
+    const [selectedIsShip, setSelectedIsShip] = useState(false);    // did the clicked card come from a shipping lane? → hide the install-window cockpit
     const [containerW, setContainerW] = useState(0);                // measured scroll-viewport width → derives colPx
     const [viewStart, setViewStart] = useState(() => mondayOf(todayIso()));
     const [navNonce, setNavNonce] = useState(0);   // bumps each nav so the scroll fires even when viewStart is unchanged
@@ -834,7 +835,7 @@ function GanttChart({ filterComplete = false }) {
                                                             key={`${release.job}-${release.release}`}
                                                             className="rounded shadow-sm px-1.5 py-1 overflow-hidden select-none cursor-pointer text-center hover:opacity-100"
                                                             style={{ backgroundColor: band.color, opacity: 0.9, minHeight: minCardH }}
-                                                            onClick={() => { setSelectedRelease(release.raw); setSelectedColor(band.color); }}
+                                                            onClick={() => { setSelectedRelease(release.raw); setSelectedColor(band.color); setSelectedIsShip(band.isShip); }}
                                                             onMouseMove={(e) => handleMouseMove(e, {
                                                                 type: 'release',
                                                                 job: release.job,
@@ -896,7 +897,7 @@ function GanttChart({ filterComplete = false }) {
                                                         backgroundColor: band.color,
                                                         opacity: 0.9,
                                                     }}
-                                                    onClick={() => { setSelectedRelease(release.raw); setSelectedColor(band.color); }}
+                                                    onClick={() => { setSelectedRelease(release.raw); setSelectedColor(band.color); setSelectedIsShip(band.isShip); }}
                                                     onMouseMove={(e) => handleMouseMove(e, {
                                                         type: 'release',
                                                         job: release.job,
@@ -1016,6 +1017,7 @@ function GanttChart({ filterComplete = false }) {
                     isOpen={!!selectedRelease}
                     release={selectedRelease}
                     accentColor={selectedColor}
+                    showInstallWindow={!selectedIsShip}
                     onClose={() => setSelectedRelease(null)}
                 />
             ) : (

--- a/frontend/src/components/ReleaseCockpitModal.jsx
+++ b/frontend/src/components/ReleaseCockpitModal.jsx
@@ -99,7 +99,10 @@ function DateFlow({ ship, start, comp, days, startAccent = false, compAccent = f
     );
 }
 
-export function ReleaseCockpitModal({ isOpen, onClose, release, accentColor }) {
+// showInstallWindow gates the drag-to-simulate install-window cockpit. It only makes
+// sense for installer/mirror cards (Timeline installer lanes); shipping planning/completed
+// cards pass false so the cockpit is hidden and the modal shows facts/enrichment only.
+export function ReleaseCockpitModal({ isOpen, onClose, release, accentColor, showInstallWindow = true }) {
     const releaseId = release?.id;
     const accent = accentColor || '#6d4aff';
 
@@ -349,7 +352,8 @@ export function ReleaseCockpitModal({ isOpen, onClose, release, accentColor }) {
                 {/* ---- scrollable body ---- */}
                 <div className="p-5 space-y-5 overflow-y-auto">
 
-                    {/* cockpit */}
+                    {/* cockpit — install-window simulation; installer/mirror cards only */}
+                    {showInstallWindow && (
                     <section className="rounded-2xl border border-gray-200 dark:border-slate-600 bg-gray-50 dark:bg-slate-700/40 p-4">
                         <div className="flex items-center gap-2 mb-2.5">
                             <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-gray-400 dark:text-slate-500">Install window · {installer || 'unassigned'}</span>
@@ -447,6 +451,7 @@ export function ReleaseCockpitModal({ isOpen, onClose, release, accentColor }) {
                             </div>
                         )}
                     </section>
+                    )}
 
                     {/* facts */}
                     <section>


### PR DESCRIPTION
## Problem

On the Timeline, admins get `ReleaseCockpitModal` when they click a card. That modal's **Install window** section is a drag-to-simulate install planner (start-install bar, crew dial, comp-ETA preview) — a tool that only makes sense for **installer/mirror cards** (installer lanes).

But clicking a **Shipping Planning** or **Shipping Completed** card opened the same modal, and the cockpit rendered whenever the release had a hard install date. The install-window simulator doesn't belong on a shipping-lane card.

## Fix

- `GanttChart.jsx`: record the clicked card's lane type (`band.isShip`) in state and pass `showInstallWindow={!selectedIsShip}` to `ReleaseCockpitModal`.
- `ReleaseCockpitModal.jsx`: accept `showInstallWindow` (default `true`) and wrap the cockpit `<section>` in it.

Shipping-lane cards now show facts/enrichment only; installer/mirror cards keep the cockpit. The prop defaults to `true`, so the modal is unchanged for any other caller.

Verified both edited files transpile cleanly (esbuild). Note: a full `vite build` fails on an unrelated pre-existing missing dep (`recharts` in `Metrics.jsx`), not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)