### PR TITLE
Fix 404 on /admin/metrics and /admin/submittal-matching SPA routes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -407,6 +407,8 @@ def create_app():
     # in frontend/src/App.jsx.
     SPA_PATHS_UNDER_API_PREFIX = {
         "admin/fc-collection",
+        "admin/metrics",
+        "admin/submittal-matching",
     }
 
     def is_api_route(path):


### PR DESCRIPTION
## Problem
`/admin/metrics` (and `/admin/submittal-matching`) return a **404 on hard load/refresh**, even though both are React pages registered in `frontend/src/App.jsx` and the metrics backend (PR #288) is fully merged and its `ai_usage` table is live in prod.

**Root cause:** `admin_bp` is registered at `url_prefix="/admin"`, and the SPA catch-all in `app/__init__.py` treats `admin/` as a server-side API prefix. Only `admin/fc-collection` was allowlisted to fall through to the SPA, so any hard load of the other admin React pages was routed to `admin_bp` (which has no such route) and 404'd. In-app client-side navigation would have worked — but there's no nav link, so the pages were unreachable.

## Fix
Add the two missing React admin pages to `SPA_PATHS_UNDER_API_PREFIX`:

```python
SPA_PATHS_UNDER_API_PREFIX = {
    "admin/fc-collection",
    "admin/metrics",
    "admin/submittal-matching",
}
```

## Verification
Exercised the real routing via `app.test_client()`:

| path | result |
|---|---|
| `/admin/metrics` | 200 `text/html` (SPA) |
| `/admin/submittal-matching` | 200 `text/html` (SPA) |
| `/admin/fc-collection` | 200 `text/html` (unchanged) |
| `/admin/does-not-exist` | 404 (unknown admin paths still 404) |

## Notes
- Code-only change — no migration. The `ai_usage` table and backfilled data are already in prod; this just makes the dashboard reachable once deployed.
- Follow-up worth considering: there's still **no nav link** to `/admin/metrics`, so it's only reachable by URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)