### PR TITLE
Add admin Subs page for installer invoice paid tracking

### DIFF
--- a/app/brain/__init__.py
+++ b/app/brain/__init__.py
@@ -44,3 +44,4 @@ from app.brain.projects import routes as projects_routes  # noqa: F401  (registe
 from app.brain.submittal_matching import routes as submittal_matching_routes  # noqa: F401  (registers /submittal-matching endpoints)
 from app.brain.metrics import routes as metrics_routes  # noqa: F401  (registers /metrics endpoints)
 from app.brain.install_schedule import routes as install_schedule_routes  # noqa: F401  (registers /install-schedule endpoints)
+from app.brain.subs import routes as subs_routes  # noqa: F401  (registers /subs endpoints)

--- a/app/brain/subs/__init__.py
+++ b/app/brain/subs/__init__.py
@@ -1,0 +1,12 @@
+"""
+@milehigh-header
+schema_version: 1
+purpose: Admin Subs view — releases assigned to subcontractor installers with
+  installer-invoice paid yes/no tracking (Lexi).
+exports: (none — routes register on brain_bp via side-effect import)
+imports_from: []
+imported_by: [app/brain/__init__.py]
+invariants:
+  - Distinct from Releases.invoiced (MHMW customer billing).
+  - Admin-only endpoints.
+"""

--- a/app/brain/subs/routes.py
+++ b/app/brain/subs/routes.py
@@ -1,0 +1,87 @@
+"""
+@milehigh-header
+schema_version: 1
+purpose: Admin-only HTTP endpoints for the Subs installer-invoice-paid page.
+exports:
+  GET  /brain/subs/releases
+  PATCH /brain/subs/releases/<job>/<release>/installer-invoice-paid
+imports_from: [flask, app.brain, app.auth.utils, app.route_utils, app.brain.subs.service]
+imported_by: [app/brain/__init__.py]
+invariants:
+  - Both routes require admin.
+  - installer_invoice_paid is not Releases.invoiced (customer billing).
+"""
+from flask import request, jsonify
+
+from app.brain import brain_bp
+from app.auth.utils import admin_required
+from app.route_utils import handle_errors
+from app.logging_config import get_logger
+
+from . import service
+
+logger = get_logger(__name__)
+
+
+def _parse_paid_arg(raw):
+    """Parse ?paid=true|false into bool or None (omit / invalid → None = all)."""
+    if raw is None or raw == "":
+        return None
+    lowered = str(raw).strip().lower()
+    if lowered in ("true", "1", "yes"):
+        return True
+    if lowered in ("false", "0", "no"):
+        return False
+    return None
+
+
+@brain_bp.route("/subs/releases", methods=["GET"])
+@admin_required
+@handle_errors("list subs releases")
+def list_subs_releases():
+    """List active releases with an installer, sorted by installer / job / release.
+
+    Query params:
+        paid: true|false (optional) — filter by installer_invoice_paid
+        installer: exact team name (optional)
+    """
+    paid = _parse_paid_arg(request.args.get("paid"))
+    installer = request.args.get("installer") or None
+    if installer is not None:
+        installer = installer.strip() or None
+
+    payload = service.list_subs_releases(paid=paid, installer=installer)
+    return jsonify(payload), 200
+
+
+@brain_bp.route(
+    "/subs/releases/<int:job>/<release>/installer-invoice-paid",
+    methods=["PATCH"],
+)
+@admin_required
+@handle_errors("update installer invoice paid")
+def update_installer_invoice_paid(job, release):
+    """Toggle installer_invoice_paid for a release.
+
+    Request body: { "installer_invoice_paid": true|false }
+    """
+    body = request.get_json(silent=True) or {}
+    if "installer_invoice_paid" not in body:
+        return jsonify({"error": "installer_invoice_paid is required"}), 400
+
+    raw = body.get("installer_invoice_paid")
+    if not isinstance(raw, bool):
+        # Accept common string forms from form-like clients.
+        if isinstance(raw, str) and raw.strip().lower() in ("true", "1", "yes"):
+            raw = True
+        elif isinstance(raw, str) and raw.strip().lower() in ("false", "0", "no"):
+            raw = False
+        else:
+            return jsonify({"error": "installer_invoice_paid must be a boolean"}), 400
+
+    try:
+        result = service.set_installer_invoice_paid(job, release, raw)
+    except ValueError:
+        return jsonify({"error": "Job not found"}), 404
+
+    return jsonify(result), 200

--- a/app/brain/subs/service.py
+++ b/app/brain/subs/service.py
@@ -1,0 +1,158 @@
+"""
+@milehigh-header
+schema_version: 1
+purpose: Query and update helpers for the admin Subs installer-invoice-paid page.
+exports:
+  list_subs_releases: Active assigned releases, sorted by installer / job / release
+  set_installer_invoice_paid: Toggle paid flag + audit event (no-op if unchanged)
+imports_from: [app.models, app.services.job_event_service, app.logging_config]
+imported_by: [app/brain/subs/routes.py]
+invariants:
+  - Only active, non-archived releases with a non-empty installer appear in the list.
+  - installer_invoice_paid is independent of Releases.invoiced (customer billing).
+  - No Trello / outbox / scheduling cascade.
+"""
+from datetime import datetime
+from typing import Optional
+
+from app.models import Releases, db
+from app.services.job_event_service import JobEventService
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _serialize_release(rel: Releases) -> dict:
+    return {
+        "id": rel.id,
+        "job": rel.job,
+        "release": rel.release,
+        "job_name": rel.job_name,
+        "description": rel.description,
+        "installer": rel.installer,
+        "stage": rel.stage,
+        "start_install": rel.start_install.isoformat() if rel.start_install else None,
+        "job_comp": rel.job_comp,
+        "installer_invoice_paid": bool(rel.installer_invoice_paid),
+    }
+
+
+def _active_assigned_base_query():
+    """Active, non-archived releases with a non-empty installer."""
+    return Releases.query.filter(
+        Releases.is_archived.is_(False),
+        # Treat NULL is_active as active (legacy rows).
+        (Releases.is_active.is_(None)) | (Releases.is_active.is_(True)),
+        Releases.installer.isnot(None),
+        Releases.installer != "",
+    )
+
+
+def list_subs_releases(
+    *,
+    paid: Optional[bool] = None,
+    installer: Optional[str] = None,
+) -> dict:
+    """Return active releases with an installer, sorted for the Subs page.
+
+    Args:
+        paid: If True/False, filter by installer_invoice_paid; None = all.
+        installer: Exact installer team name filter; None = all.
+
+    `installers` is always the full distinct set of active assigned teams so
+    filter chips stay stable when paid/installer filters shrink the table.
+    """
+    # Stable roster for the installer dropdown (ignore paid/installer filters).
+    installer_names = {
+        name
+        for (name,) in _active_assigned_base_query()
+        .with_entities(Releases.installer)
+        .distinct()
+        .all()
+        if name
+    }
+
+    q = _active_assigned_base_query()
+
+    if paid is not None:
+        q = q.filter(Releases.installer_invoice_paid.is_(paid))
+
+    if installer:
+        q = q.filter(Releases.installer == installer)
+
+    rows = q.order_by(
+        Releases.installer.asc(),
+        Releases.job.asc(),
+        Releases.release.asc(),
+    ).all()
+
+    releases = [_serialize_release(r) for r in rows]
+    installers = sorted(installer_names)
+
+    return {"releases": releases, "installers": installers}
+
+
+def set_installer_invoice_paid(
+    job: int,
+    release: str,
+    paid: bool,
+    *,
+    source: str = "Brain",
+) -> dict:
+    """Set installer_invoice_paid on a release. No-op (no event) if unchanged.
+
+    Returns:
+        dict with status, installer_invoice_paid, and optional event_id.
+
+    Raises:
+        ValueError: release not found.
+    """
+    job_record = Releases.query.filter_by(job=job, release=release).first()
+    if not job_record:
+        raise ValueError(f"Job {job}-{release} not found")
+
+    old = bool(job_record.installer_invoice_paid)
+    new = bool(paid)
+
+    if old == new:
+        logger.debug(
+            "installer_invoice_paid_unchanged",
+            job=job,
+            release=release,
+            installer_invoice_paid=new,
+        )
+        return {
+            "status": "success",
+            "installer_invoice_paid": new,
+            "event_id": None,
+            "changed": False,
+        }
+
+    event = JobEventService.create_and_close(
+        job=job,
+        release=release,
+        action="update_installer_invoice_paid",
+        source=source,
+        payload={"from": old, "to": new},
+    )
+
+    job_record.installer_invoice_paid = new
+    job_record.last_updated_at = datetime.utcnow()
+    job_record.source_of_update = source
+    db.session.commit()
+
+    logger.info(
+        "installer_invoice_paid_updated",
+        job=job,
+        release=release,
+        from_value=old,
+        to_value=new,
+        event_id=event.id if event else None,
+    )
+
+    return {
+        "status": "success",
+        "installer_invoice_paid": new,
+        "event_id": event.id if event else None,
+        "changed": True,
+    }

--- a/app/models.py
+++ b/app/models.py
@@ -492,6 +492,11 @@ class Releases(db.Model):
     # card description ("**Number of Guys:** N"); treated as 2 when absent.
     # comp_eta = start_install + ceil(install_hrs / (num_guys * 8)) business days.
     num_guys = db.Column(db.Float, nullable=True)
+    # Whether the subcontractor installer's invoice for this release has been paid.
+    # Distinct from `invoiced` (MHMW customer billing). Toggled on the admin Subs page.
+    installer_invoice_paid = db.Column(
+        db.Boolean, nullable=False, default=False, server_default='0'
+    )
     comp_eta = db.Column(db.Date)  # Changed from String to Date
     job_comp = db.Column(db.String(8))
     invoiced = db.Column(db.String(8))
@@ -550,6 +555,7 @@ class Releases(db.Model):
             "ship_date": self.ship_date,
             "installer": self.installer,
             "num_guys": self.num_guys,
+            "installer_invoice_paid": bool(self.installer_invoice_paid),
             "comp_eta": self.comp_eta,
             "job_comp": self.job_comp,
             "invoiced": self.invoiced,

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -1112,8 +1112,10 @@ gating formalizes existing behavior rather than imposing new behavior.
 > we can elevate."* Matches what he told Lexi — *"probably not a ton of data,
 > it'll just be who's assigned."*
 
-**State:** Nothing built. Installer assignment exists on releases;
-`ProjectManager` exists.
+**State:** **v1 shipped (admin Subs page + paid flag).** Installer assignment
+exists on releases; `/subs` lists active assigned releases grouped by installer
+with a yes/no `installer_invoice_paid` toggle (distinct from Job Log `invoiced`
+customer billing). OCIP not built yet. `ProjectManager` exists.
 
 **What Lexi asked for**, twice and unprompted: *"You'd go up here and click subs.
 You'd get a list of all your subcontractors. And what they're doing. And all the
@@ -1121,13 +1123,13 @@ jobs that they're currently assigned to."* — *"That's what I need."* With
 paid/not-paid per line. She'd take a paid yes/no flag on the release *"as a
 start, at a minimum,"* but the tab is the real ask.
 
-**Column-by-column data reality — this is why v1 is easy:**
+**Column-by-column data reality:**
 
 | Column | Source | v1? |
 |---|---|---|
-| Sub → releases → projects | **Exists** — installer field on releases | ✅ |
-| Paid / not-paid | **No source in the Brain.** QuickBooks, or manual entry | ✖ later |
-| OCIP flag | **New column on `Projects`** + someone to set it | ✅ cheap |
+| Sub → releases → projects | **Exists** — installer field on releases | ✅ shipped |
+| Paid / not-paid | **`releases.installer_invoice_paid`** (manual yes/no on `/subs`) | ✅ shipped |
+| OCIP flag | **New column on `Projects`** + someone to set it | ✖ later |
 
 **The OCIP piece is where the value is, and it's one column plus a rule:** flag
 which projects carry controlled insurance, surface which subs are assigned to
@@ -1151,14 +1153,13 @@ don't."* Daniel's read: the tool has to exist first — *"once you have your
 system, then you can go out there and get on their ass."*
 
 **Plan:**
-1. Subs tab: subcontractor → releases → projects, from existing assignment data.
+1. ~~Subs tab: subcontractor → releases → projects, from existing assignment data.~~ **Done** (`/subs`, admin-only).
 2. OCIP flag on `Projects`; surface unenrolled subs on flagged projects.
-3. **Ship rough v1 to Lexi *and* Bill together** — Bill needs the same picture
-   to push PMs on assignment discipline.
+3. ~~**Ship rough v1 to Lexi *and* Bill together**~~ — still collect feedback.
 4. Lexi emails back useful / not useful.
-5. Paid status and QuickBooks later.
+5. ~~Paid status~~ done (manual flag); QuickBooks later.
 
-**Effort:** S–M for v1.
+**Effort:** S–M for v1 (paid slice done); OCIP remains.
 
 ---
 

--- a/docs/ops-planning.md
+++ b/docs/ops-planning.md
@@ -191,7 +191,7 @@ of standard details to snip from (Bill lukewarm — MHMW already has symbols).
 | Fab-hours overload check: daily, weekly, or by stage? | open | Tee-time v1 |
 | How do we handle origination overlap for in-flight projects? | open | New project ingestion |
 | What's the admin vs non-admin line on the projects page? | open | Projects page GA |
-| Does the paid flag live on the release or only in the subs view? | Daniel | Subs view v1 |
+| Does the paid flag live on the release or only in the subs view? | Daniel | **Resolved:** on the release (`installer_invoice_paid`); `/subs` is the admin UI |
 | Does Lexi want to be on Katie's invoicing report? | Lexi | No |
 
 ---

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,7 @@ import InvoicingReport from './pages/InvoicingReport';
 import RentalReports from './pages/RentalReports';
 import Metrics from './pages/Metrics';
 import InstallSchedule from './pages/InstallSchedule';
+import Subs from './pages/Subs';
 import { checkAuth } from './utils/auth';
 import './App.css';
 
@@ -89,6 +90,7 @@ function AppContent() {
               <Route path="install-schedule" element={<InstallSchedule />} />
               <Route path="invoicing-report" element={<InvoicingReport />} />
               <Route path="rental-reports" element={<RentalReports />} />
+              <Route path="subs" element={<Subs />} />
               <Route path="admin/fc-collection" element={<FcCollection />} />
               <Route path="admin/submittal-matching" element={<SubmittalMatching />} />
               <Route path="admin/metrics" element={<Metrics />} />

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -151,6 +151,7 @@ function AppShellInner({ isAuthenticated }) {
             {navBtn('/install-schedule', 'Install Schedule')}
             {canSeeReport && navBtn('/invoicing-report', 'Invoicing')}
             {/* Rentals nav removed 2026-07-12 (company change) — /rental-reports route + backend stay for direct URL / re-enable */}
+            {isAdmin && navBtn('/subs', 'Subs')}
             {isAdmin && navBtn('/meetings', 'Meetings')}
             {isAdmin && navIconBtn('/board', 'Bug Tracker', (
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>

--- a/frontend/src/components/MobileNavDrawer.jsx
+++ b/frontend/src/components/MobileNavDrawer.jsx
@@ -26,6 +26,7 @@ const NAV_ITEMS = [
 
 // Rentals nav removed 2026-07-12 (company change) — route + backend intact.
 const ADMIN_ITEMS = [
+    { label: 'Subs', path: '/subs' },
     { label: 'Meetings', path: '/meetings' },
     { label: 'Bug Tracker', path: '/board' },
     { label: 'Submittal Matching', path: '/admin/submittal-matching' },

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -82,6 +82,7 @@ export default function Sidebar({ isAuthenticated, isAdmin, canSeeReport, onLogo
     ...NAV_ITEMS,
     ...(canSeeReport ? [{ label: 'Invoicing', path: '/invoicing-report', icon: ICONS.invoicing }] : []),
     ...(isAdmin ? [
+      { label: 'Subs', path: '/subs', icon: ICONS.invoicing },
       { label: 'Meetings', path: '/meetings', icon: ICONS.meetings },
       { label: 'Bug Tracker', path: '/board', icon: ICONS.bug },
     ] : []),

--- a/frontend/src/pages/Subs.jsx
+++ b/frontend/src/pages/Subs.jsx
@@ -1,0 +1,310 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: Admin Subs page — active releases assigned to subcontractor installers,
+ *   grouped by installer, with a yes/no toggle for installer invoice paid.
+ *   Distinct from Job Log "Invoiced" (MHMW customer billing).
+ * exports:
+ *   Subs: Page component (admin-gated).
+ * imports_from: [react, ../utils/auth, ../services/subsApi]
+ * imported_by: [App.jsx]
+ * invariants:
+ *   - Renders an access message (no fetch) unless the authenticated user is_admin.
+ *   - Server enforces admin; optimistic toggle reverts on error.
+ */
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { checkAuth } from '../utils/auth';
+import { fetchSubsReleases, updateInstallerInvoicePaid } from '../services/subsApi';
+
+const PAID_FILTERS = [
+    { key: 'all', label: 'All', paid: undefined },
+    { key: 'unpaid', label: 'Unpaid', paid: false },
+    { key: 'paid', label: 'Paid', paid: true },
+];
+
+const fmtDate = (iso) => {
+    if (!iso) return '—';
+    const d = new Date(`${iso}T00:00:00`);
+    return Number.isNaN(d.getTime())
+        ? iso
+        : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' });
+};
+
+function PaidToggle({ paid, busy, onChange }) {
+    return (
+        <div className="inline-flex rounded-md border border-gray-200 dark:border-slate-600 overflow-hidden text-xs font-medium">
+            <button
+                type="button"
+                disabled={busy}
+                onClick={() => onChange(false)}
+                className={`px-2.5 py-1 transition-colors ${
+                    !paid
+                        ? 'bg-amber-100 text-amber-900 dark:bg-amber-500/25 dark:text-amber-100'
+                        : 'bg-white text-gray-500 hover:bg-gray-50 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700'
+                } ${busy ? 'opacity-60 cursor-wait' : ''}`}
+            >
+                No
+            </button>
+            <button
+                type="button"
+                disabled={busy}
+                onClick={() => onChange(true)}
+                className={`px-2.5 py-1 border-l border-gray-200 dark:border-slate-600 transition-colors ${
+                    paid
+                        ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-500/25 dark:text-emerald-100'
+                        : 'bg-white text-gray-500 hover:bg-gray-50 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700'
+                } ${busy ? 'opacity-60 cursor-wait' : ''}`}
+            >
+                Yes
+            </button>
+        </div>
+    );
+}
+
+function groupByInstaller(releases) {
+    const map = new Map();
+    for (const r of releases) {
+        const key = r.installer || 'Unassigned';
+        if (!map.has(key)) map.set(key, []);
+        map.get(key).push(r);
+    }
+    return [...map.entries()]; // already sorted by API
+}
+
+export default function Subs() {
+    const [authorized, setAuthorized] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [releases, setReleases] = useState([]);
+    const [installers, setInstallers] = useState([]);
+    const [paidFilter, setPaidFilter] = useState('all');
+    const [installerFilter, setInstallerFilter] = useState('');
+    const [busyKey, setBusyKey] = useState(null);
+
+    useEffect(() => {
+        checkAuth().then((user) => setAuthorized(!!(user && user.is_admin)));
+    }, []);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const paidOpt = PAID_FILTERS.find((f) => f.key === paidFilter)?.paid;
+            const data = await fetchSubsReleases({
+                paid: paidOpt,
+                installer: installerFilter || undefined,
+            });
+            setReleases(data.releases || []);
+            setInstallers(data.installers || []);
+        } catch (e) {
+            setError(e?.response?.data?.error || e.message || 'Failed to load subs');
+        } finally {
+            setLoading(false);
+        }
+    }, [paidFilter, installerFilter]);
+
+    useEffect(() => {
+        if (authorized) load();
+    }, [authorized, load]);
+
+    const groups = useMemo(() => groupByInstaller(releases), [releases]);
+
+    const totals = useMemo(() => {
+        const unpaid = releases.filter((r) => !r.installer_invoice_paid).length;
+        return { total: releases.length, unpaid, paid: releases.length - unpaid };
+    }, [releases]);
+
+    const rowKey = (r) => `${r.job}-${r.release}`;
+
+    const handleToggle = async (row, nextPaid) => {
+        if (boolEq(row.installer_invoice_paid, nextPaid)) return;
+        const key = rowKey(row);
+        setBusyKey(key);
+        setError(null);
+        const prev = row.installer_invoice_paid;
+        setReleases((list) =>
+            list.map((r) =>
+                rowKey(r) === key ? { ...r, installer_invoice_paid: nextPaid } : r,
+            ),
+        );
+        try {
+            await updateInstallerInvoicePaid(row.job, row.release, nextPaid);
+        } catch (e) {
+            setReleases((list) =>
+                list.map((r) =>
+                    rowKey(r) === key ? { ...r, installer_invoice_paid: prev } : r,
+                ),
+            );
+            setError(e?.response?.data?.error || e.message || 'Failed to update paid status');
+        } finally {
+            setBusyKey(null);
+        }
+    };
+
+    if (authorized === null) {
+        return <div className="p-6 text-gray-500 dark:text-slate-400">Loading…</div>;
+    }
+    if (!authorized) {
+        return (
+            <div className="p-6 text-gray-600 dark:text-slate-300">
+                Subs is available to admins only.
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex-1 min-h-0 overflow-auto">
+            <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6">
+                <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 mb-5">
+                    <div>
+                        <h1 className="text-xl font-semibold text-gray-900 dark:text-slate-100">
+                            Subs
+                        </h1>
+                        <p className="mt-1 text-sm text-gray-500 dark:text-slate-400">
+                            Active releases by installer. Mark whether the subcontractor invoice is paid.
+                        </p>
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-slate-400 tabular-nums">
+                        {totals.total} release{totals.total === 1 ? '' : 's'}
+                        {totals.total > 0 && (
+                            <span className="ml-2">
+                                · <span className="text-amber-700 dark:text-amber-300">{totals.unpaid} unpaid</span>
+                                {' · '}
+                                <span className="text-emerald-700 dark:text-emerald-300">{totals.paid} paid</span>
+                            </span>
+                        )}
+                    </div>
+                </div>
+
+                {/* Filters */}
+                <div className="flex flex-wrap items-center gap-2 mb-4">
+                    <div className="inline-flex rounded-lg border border-gray-200 dark:border-slate-600 overflow-hidden text-sm">
+                        {PAID_FILTERS.map((f) => (
+                            <button
+                                key={f.key}
+                                type="button"
+                                onClick={() => setPaidFilter(f.key)}
+                                className={`px-3 py-1.5 ${
+                                    paidFilter === f.key
+                                        ? 'bg-accent-500 text-white'
+                                        : 'bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700'
+                                } ${f.key !== 'all' ? 'border-l border-gray-200 dark:border-slate-600' : ''}`}
+                            >
+                                {f.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    <select
+                        value={installerFilter}
+                        onChange={(e) => setInstallerFilter(e.target.value)}
+                        className="text-sm rounded-lg border border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 px-3 py-1.5"
+                    >
+                        <option value="">All installers</option>
+                        {installers.map((name) => (
+                            <option key={name} value={name}>{name}</option>
+                        ))}
+                    </select>
+
+                    <button
+                        type="button"
+                        onClick={load}
+                        disabled={loading}
+                        className="text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 disabled:opacity-50"
+                    >
+                        Refresh
+                    </button>
+                </div>
+
+                {error && (
+                    <div className="mb-4 rounded-lg border border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/40 text-red-800 dark:text-red-200 text-sm px-3 py-2">
+                        {error}
+                    </div>
+                )}
+
+                {loading && releases.length === 0 ? (
+                    <div className="text-sm text-gray-500 dark:text-slate-400 py-8">Loading…</div>
+                ) : releases.length === 0 ? (
+                    <div className="rounded-lg border border-dashed border-gray-300 dark:border-slate-600 px-4 py-10 text-center text-sm text-gray-500 dark:text-slate-400">
+                        No assigned installers on active releases.
+                    </div>
+                ) : (
+                    <div className="space-y-6">
+                        {groups.map(([installer, rows]) => {
+                            const unpaidCount = rows.filter((r) => !r.installer_invoice_paid).length;
+                            return (
+                                <section key={installer}>
+                                    <div className="sticky top-0 z-10 -mx-1 px-1 py-2 bg-[#f8fafc]/90 dark:bg-slate-900/90 backdrop-blur flex items-baseline justify-between gap-2 border-b border-gray-200 dark:border-slate-700 mb-2">
+                                        <h2 className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+                                            {installer}
+                                        </h2>
+                                        <span className="text-xs text-gray-500 dark:text-slate-400 tabular-nums">
+                                            {unpaidCount} unpaid · {rows.length} total
+                                        </span>
+                                    </div>
+
+                                    <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+                                        <table className="w-full text-sm">
+                                            <thead>
+                                                <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-slate-400 border-b border-gray-100 dark:border-slate-700">
+                                                    <th className="px-3 py-2 font-medium">Job</th>
+                                                    <th className="px-3 py-2 font-medium">Rel</th>
+                                                    <th className="px-3 py-2 font-medium">Job name</th>
+                                                    <th className="px-3 py-2 font-medium hidden md:table-cell">Description</th>
+                                                    <th className="px-3 py-2 font-medium hidden sm:table-cell">Stage</th>
+                                                    <th className="px-3 py-2 font-medium hidden lg:table-cell">Start install</th>
+                                                    <th className="px-3 py-2 font-medium text-right">Invoice paid</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {rows.map((r) => {
+                                                    const key = rowKey(r);
+                                                    return (
+                                                        <tr
+                                                            key={key}
+                                                            className="border-t border-gray-100 dark:border-slate-700/60 hover:bg-gray-50/80 dark:hover:bg-slate-700/30"
+                                                        >
+                                                            <td className="px-3 py-2 tabular-nums text-gray-900 dark:text-slate-100 font-medium">
+                                                                {r.job}
+                                                            </td>
+                                                            <td className="px-3 py-2 tabular-nums text-gray-700 dark:text-slate-200">
+                                                                {r.release}
+                                                            </td>
+                                                            <td className="px-3 py-2 text-gray-800 dark:text-slate-200 max-w-[12rem] truncate" title={r.job_name || ''}>
+                                                                {r.job_name || '—'}
+                                                            </td>
+                                                            <td className="px-3 py-2 text-gray-600 dark:text-slate-300 hidden md:table-cell max-w-[14rem] truncate" title={r.description || ''}>
+                                                                {r.description || '—'}
+                                                            </td>
+                                                            <td className="px-3 py-2 text-gray-600 dark:text-slate-300 hidden sm:table-cell">
+                                                                {r.stage || '—'}
+                                                            </td>
+                                                            <td className="px-3 py-2 text-gray-600 dark:text-slate-300 hidden lg:table-cell tabular-nums">
+                                                                {fmtDate(r.start_install)}
+                                                            </td>
+                                                            <td className="px-3 py-2 text-right">
+                                                                <PaidToggle
+                                                                    paid={!!r.installer_invoice_paid}
+                                                                    busy={busyKey === key}
+                                                                    onChange={(next) => handleToggle(r, next)}
+                                                                />
+                                                            </td>
+                                                        </tr>
+                                                    );
+                                                })}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </section>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function boolEq(a, b) {
+    return !!a === !!b;
+}

--- a/frontend/src/services/subsApi.js
+++ b/frontend/src/services/subsApi.js
@@ -1,0 +1,36 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: HTTP calls for the admin Subs page (installer invoice paid tracking).
+ * exports:
+ *   fetchSubsReleases: List active assigned releases + distinct installers
+ *   updateInstallerInvoicePaid: Toggle paid yes/no for a job-release
+ * imports_from: [axios, ../utils/api]
+ * imported_by: [pages/Subs.jsx]
+ * invariants:
+ *   - withCredentials sends the session cookie; admin is enforced server-side.
+ *   - This is NOT the customer-billing `invoiced` field on the job log.
+ */
+import axios from 'axios';
+import { API_BASE_URL } from '../utils/api';
+
+axios.defaults.withCredentials = true;
+const BASE = `${API_BASE_URL}/brain/subs`;
+
+export async function fetchSubsReleases({ paid, installer } = {}) {
+    const params = new URLSearchParams();
+    if (paid === true) params.set('paid', 'true');
+    if (paid === false) params.set('paid', 'false');
+    if (installer) params.set('installer', installer);
+    const qs = params.toString();
+    const { data } = await axios.get(`${BASE}/releases${qs ? `?${qs}` : ''}`);
+    return data; // { releases, installers }
+}
+
+export async function updateInstallerInvoicePaid(job, release, installerInvoicePaid) {
+    const { data } = await axios.patch(
+        `${BASE}/releases/${job}/${encodeURIComponent(release)}/installer-invoice-paid`,
+        { installer_invoice_paid: !!installerInvoicePaid },
+    );
+    return data;
+}

--- a/migrations/add_installer_invoice_paid_to_releases.py
+++ b/migrations/add_installer_invoice_paid_to_releases.py
@@ -1,0 +1,209 @@
+"""
+Add `installer_invoice_paid` boolean to the releases table.
+
+Tracks whether the subcontractor installer's invoice for a release has been
+paid. Distinct from `invoiced` (MHMW customer billing). Used by the admin
+Subs page (Lexi).
+
+Usage:
+    python migrations/add_installer_invoice_paid_to_releases.py
+    python migrations/add_installer_invoice_paid_to_releases.py --database-url postgresql://...
+
+Safety properties (Postgres) — never freeze the table:
+  - Idempotent `ADD COLUMN IF NOT EXISTS` so no schema reflection is needed.
+  - One AUTOCOMMIT connection: each DDL is its own implicit transaction, so the
+    ACCESS EXCLUSIVE lock is held only for the instant the statement runs.
+  - `lock_timeout` makes a blocked ALTER fail fast instead of queueing behind
+    live traffic; auto-retries with backoff.
+  - Metadata-only ADD COLUMN (boolean with constant default) — instant on modern Postgres.
+  - DB URL is masked in logs (never print credentials).
+"""
+import argparse
+import os
+import sys
+import time
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_SQLITE_PATH = os.path.join(ROOT_DIR, "instance", "jobs.sqlite")
+
+LOCK_TIMEOUT = "5s"
+STATEMENT_TIMEOUT = "30s"
+LOCK_RETRIES = 4
+RETRY_BASE_SECONDS = 3
+
+load_dotenv()
+
+
+def normalize_sqlite_path(path: str) -> str:
+    if not os.path.isabs(path):
+        path = os.path.join(ROOT_DIR, path)
+    return f"sqlite:///{path}"
+
+
+def _coerce_url(value: str) -> str:
+    value = value.strip()
+    if value.startswith("postgres://"):
+        return value.replace("postgres://", "postgresql://", 1)
+    if value.startswith(("postgresql://", "mysql://", "mariadb://", "sqlite://")):
+        return value
+    return normalize_sqlite_path(value)
+
+
+def infer_database_url(cli_url: str = None) -> str:
+    """Figure out which database to hit, honoring CLI and ENVIRONMENT."""
+    if cli_url:
+        return _coerce_url(cli_url)
+
+    environment = (os.environ.get("ENVIRONMENT") or "local").strip().lower()
+
+    if environment == "production":
+        value = os.environ.get("PRODUCTION_DATABASE_URL") or os.environ.get("DATABASE_URL")
+        if not value:
+            raise ValueError(
+                "ENVIRONMENT=production but neither PRODUCTION_DATABASE_URL nor "
+                "DATABASE_URL is set (refusing to guess; pass --database-url)."
+            )
+        return _coerce_url(value)
+
+    if environment == "sandbox":
+        value = os.environ.get("SANDBOX_DATABASE_URL") or os.environ.get("DATABASE_URL")
+        if not value:
+            raise ValueError(
+                "ENVIRONMENT=sandbox but neither SANDBOX_DATABASE_URL nor "
+                "DATABASE_URL is set (refusing to guess; pass --database-url)."
+            )
+        return _coerce_url(value)
+
+    candidates = [
+        os.environ.get("LOCAL_DATABASE_URL"),
+        os.environ.get("DATABASE_URL"),
+        os.environ.get("SQLALCHEMY_DATABASE_URI"),
+        os.environ.get("JOBS_DB_URL"),
+        os.environ.get("JOBS_SQLITE_PATH"),
+    ]
+    for value in candidates:
+        if value:
+            return _coerce_url(value)
+
+    return normalize_sqlite_path(DEFAULT_SQLITE_PATH)
+
+
+def _mask(url: str) -> str:
+    """Render a connection URL for logging without leaking the password."""
+    try:
+        u = urlparse(url)
+        if u.hostname:
+            user = f"{u.username}@" if u.username else ""
+            return f"{u.scheme}://{user}{u.hostname}/{u.path.lstrip('/')}"
+    except Exception:
+        pass
+    return url.split("@")[-1] if "@" in url else url
+
+
+def _is_lock_timeout(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "lock" in msg and ("timeout" in msg or "not available" in msg or "55p03" in msg)
+
+
+def _run_with_retry(conn, sql: str, label: str) -> None:
+    """Execute one idempotent DDL statement, retrying on lock_timeout with backoff."""
+    for attempt in range(1, LOCK_RETRIES + 1):
+        try:
+            conn.execute(text(sql))
+            print(f"✓ {label}")
+            return
+        except OperationalError as exc:
+            if _is_lock_timeout(exc) and attempt < LOCK_RETRIES:
+                delay = RETRY_BASE_SECONDS * attempt
+                print(
+                    f"  ⏳ '{label}' couldn't get the lock (attempt {attempt}/{LOCK_RETRIES}); "
+                    f"retrying in {delay}s — nothing committed, app keeps running"
+                )
+                time.sleep(delay)
+                continue
+            raise
+
+
+def _migrate_postgres(engine) -> bool:
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        conn.execute(text(f"SET lock_timeout = '{LOCK_TIMEOUT}'"))
+        conn.execute(text(f"SET statement_timeout = '{STATEMENT_TIMEOUT}'"))
+
+        if conn.execute(text("SELECT to_regclass('releases')")).scalar() is None:
+            print("✗ Table 'releases' does not exist. Run the base schema first.")
+            return False
+
+        try:
+            _run_with_retry(
+                conn,
+                "ALTER TABLE releases "
+                "ADD COLUMN IF NOT EXISTS installer_invoice_paid BOOLEAN NOT NULL DEFAULT FALSE",
+                "releases.installer_invoice_paid",
+            )
+        except OperationalError as exc:
+            if _is_lock_timeout(exc):
+                print(
+                    f"✗ Gave up after {LOCK_RETRIES} attempts: could not get the lock on "
+                    "'releases' — the table is under sustained load. Nothing was committed.\n"
+                    "  Re-run during a quieter window."
+                )
+                return False
+            raise
+    return True
+
+
+def _migrate_sqlite(engine) -> bool:
+    inspector = inspect(engine)
+    if "releases" not in inspector.get_table_names():
+        print("✗ Table 'releases' does not exist. Run the base schema first.")
+        return False
+    existing = {c["name"] for c in inspector.get_columns("releases")}
+
+    with engine.begin() as conn:
+        if "installer_invoice_paid" not in existing:
+            conn.execute(text(
+                "ALTER TABLE releases "
+                "ADD COLUMN installer_invoice_paid BOOLEAN NOT NULL DEFAULT 0"
+            ))
+            print("✓ releases.installer_invoice_paid")
+        else:
+            print("releases.installer_invoice_paid already exists, skipping")
+    return True
+
+
+def migrate(database_url: str = None) -> bool:
+    db_url = infer_database_url(database_url)
+    print(f"Connecting to database: {_mask(db_url)}")
+
+    engine = create_engine(db_url)
+    try:
+        if engine.dialect.name == "sqlite":
+            return _migrate_sqlite(engine)
+        return _migrate_postgres(engine)
+    except ProgrammingError as exc:
+        print(f"✗ Database error during migration: {exc}")
+        return False
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"✗ Unexpected error: {exc}")
+        return False
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Add installer_invoice_paid boolean to the releases table."
+    )
+    parser.add_argument(
+        "--database-url",
+        help="Override database URL (otherwise inferred from env or defaults).",
+    )
+    args = parser.parse_args()
+
+    success = migrate(args.database_url)
+    sys.exit(0 if success else 1)

--- a/tests/brain/test_subs_invoice_paid.py
+++ b/tests/brain/test_subs_invoice_paid.py
@@ -1,0 +1,184 @@
+"""Tests for the admin Subs installer-invoice-paid page API."""
+from datetime import date
+
+import pytest
+
+from app.models import Releases, ReleaseEvents, db
+from tests.conftest import make_release
+
+
+def _seed(app):
+    """Three assigned active rows, one unassigned, one archived, one inactive."""
+    with app.app_context():
+        make_release(
+            100, "1", job_name="Alpha",
+            installer="Saul 2", stage="Install Complete",
+            start_install=date(2026, 6, 1), job_comp="X",
+            is_active=True, is_archived=False,
+        )
+        make_release(
+            200, "2", job_name="Bravo",
+            installer="Octavio", stage="Install Start",
+            start_install=date(2026, 6, 10),
+            is_active=True, is_archived=False,
+            installer_invoice_paid=True,
+        )
+        make_release(
+            150, "3", job_name="Charlie",
+            installer="Octavio", stage="Install Complete",
+            is_active=True, is_archived=False,
+        )
+        # Should be excluded: no installer
+        make_release(
+            300, "9", job_name="Unassigned",
+            installer=None, is_active=True, is_archived=False,
+        )
+        # Should be excluded: archived
+        make_release(
+            400, "1", job_name="Archived",
+            installer="Oscar", is_active=True, is_archived=True,
+        )
+        # Should be excluded: inactive
+        make_release(
+            500, "1", job_name="Inactive",
+            installer="Oscar", is_active=False, is_archived=False,
+        )
+        db.session.commit()
+
+
+class TestListSubsReleases:
+    def test_unauthenticated_returns_401(self, client, app):
+        _seed(app)
+        resp = client.get("/brain/subs/releases")
+        assert resp.status_code == 401
+
+    def test_non_admin_returns_403(self, non_admin_client, app):
+        _seed(app)
+        resp = non_admin_client.get("/brain/subs/releases")
+        assert resp.status_code == 403
+
+    def test_admin_list_filters_and_sorts(self, admin_client, app):
+        _seed(app)
+        resp = admin_client.get("/brain/subs/releases")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        releases = data["releases"]
+        # Only the three active assigned rows
+        assert len(releases) == 3
+        keys = [(r["installer"], r["job"], r["release"]) for r in releases]
+        assert keys == [
+            ("Octavio", 150, "3"),
+            ("Octavio", 200, "2"),
+            ("Saul 2", 100, "1"),
+        ]
+        assert data["installers"] == ["Octavio", "Saul 2"]
+        # Paid flag preserved
+        by_job = {r["job"]: r for r in releases}
+        assert by_job[200]["installer_invoice_paid"] is True
+        assert by_job[100]["installer_invoice_paid"] is False
+
+    def test_paid_filter(self, admin_client, app):
+        _seed(app)
+        unpaid = admin_client.get("/brain/subs/releases?paid=false").get_json()["releases"]
+        paid = admin_client.get("/brain/subs/releases?paid=true").get_json()["releases"]
+        assert {r["job"] for r in unpaid} == {100, 150}
+        assert {r["job"] for r in paid} == {200}
+
+    def test_installer_filter(self, admin_client, app):
+        _seed(app)
+        data = admin_client.get("/brain/subs/releases?installer=Octavio").get_json()
+        assert {r["job"] for r in data["releases"]} == {150, 200}
+        # installers roster stays full so the dropdown doesn't collapse
+        assert data["installers"] == ["Octavio", "Saul 2"]
+
+
+class TestUpdateInstallerInvoicePaid:
+    def test_unauthenticated_returns_401(self, client, app):
+        _seed(app)
+        resp = client.patch(
+            "/brain/subs/releases/100/1/installer-invoice-paid",
+            json={"installer_invoice_paid": True},
+        )
+        assert resp.status_code == 401
+
+    def test_non_admin_returns_403(self, non_admin_client, app):
+        _seed(app)
+        resp = non_admin_client.patch(
+            "/brain/subs/releases/100/1/installer-invoice-paid",
+            json={"installer_invoice_paid": True},
+        )
+        assert resp.status_code == 403
+
+    def test_missing_release_returns_404(self, admin_client, app):
+        _seed(app)
+        resp = admin_client.patch(
+            "/brain/subs/releases/999/Z/installer-invoice-paid",
+            json={"installer_invoice_paid": True},
+        )
+        assert resp.status_code == 404
+
+    def test_missing_body_field_returns_400(self, admin_client, app):
+        _seed(app)
+        resp = admin_client.patch(
+            "/brain/subs/releases/100/1/installer-invoice-paid",
+            json={},
+        )
+        assert resp.status_code == 400
+
+    def test_toggle_true_then_false_writes_events(self, admin_client, app):
+        _seed(app)
+
+        resp = admin_client.patch(
+            "/brain/subs/releases/100/1/installer-invoice-paid",
+            json={"installer_invoice_paid": True},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "success"
+        assert body["installer_invoice_paid"] is True
+        assert body["changed"] is True
+        assert body["event_id"] is not None
+
+        with app.app_context():
+            r = Releases.query.filter_by(job=100, release="1").one()
+            assert r.installer_invoice_paid is True
+            events = ReleaseEvents.query.filter_by(
+                job=100, release="1", action="update_installer_invoice_paid"
+            ).all()
+            assert len(events) == 1
+            assert events[0].payload == {"from": False, "to": True}
+
+        resp2 = admin_client.patch(
+            "/brain/subs/releases/100/1/installer-invoice-paid",
+            json={"installer_invoice_paid": False},
+        )
+        assert resp2.status_code == 200
+        assert resp2.get_json()["installer_invoice_paid"] is False
+
+        with app.app_context():
+            r = Releases.query.filter_by(job=100, release="1").one()
+            assert r.installer_invoice_paid is False
+            events = ReleaseEvents.query.filter_by(
+                job=100, release="1", action="update_installer_invoice_paid"
+            ).order_by(ReleaseEvents.id).all()
+            assert len(events) == 2
+            assert events[1].payload == {"from": True, "to": False}
+
+    def test_same_value_is_noop_no_event(self, admin_client, app):
+        _seed(app)
+        # Seed row 200 already paid=True
+        resp = admin_client.patch(
+            "/brain/subs/releases/200/2/installer-invoice-paid",
+            json={"installer_invoice_paid": True},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["changed"] is False
+        assert body["event_id"] is None
+        assert body["installer_invoice_paid"] is True
+
+        with app.app_context():
+            events = ReleaseEvents.query.filter_by(
+                job=200, release="2", action="update_installer_invoice_paid"
+            ).all()
+            assert events == []


### PR DESCRIPTION
## Summary
- Adds admin-only **Subs** page (`/subs`) listing active releases with an assigned installer, grouped by installer, with a Yes/No **invoice paid** toggle.
- New `releases.installer_invoice_paid` boolean (distinct from Job Log `invoiced` customer billing) plus safe migration and audit events.
- API: `GET /brain/subs/releases` and `PATCH .../installer-invoice-paid` (admin-only); 11 tests cover auth, filters, sort, and toggle/no-op.

## Deploy note
Run before/with deploy:
```bash
python migrations/add_installer_invoice_paid_to_releases.py
```

## Test plan
- [ ] Run migration on sandbox/local DB
- [ ] As admin: open **Subs** nav → see releases grouped by installer
- [ ] Toggle Yes/No paid; reload page and confirm persistence
- [ ] Filter All / Unpaid / Paid and by installer
- [ ] As non-admin: no **Subs** nav item; API returns 403
- [ ] Confirm Job Log **Invoiced** column behavior unchanged
- [ ] `pytest tests/brain/test_subs_invoice_paid.py -v`