### PR TITLE
Add GC-facing project pipeline and multi-phase lookahead schedule bui…

### DIFF
--- a/app/brain/lookahead/__init__.py
+++ b/app/brain/lookahead/__init__.py
@@ -1,1 +1,18 @@
-"""GC lookahead-schedule ingestion + cross-check (Alta Metro pilot)."""
+"""GC lookahead: inbound PDF cross-check + outbound multi-phase production schedule."""
+
+from app.brain.lookahead.pipeline import get_project_pipeline, classify_install_date
+from app.brain.lookahead.schedule_builder import (
+    build_lookahead_schedule,
+    build_project_lookahead,
+    PAINT_BUSINESS_DAYS,
+    PHASES,
+)
+
+__all__ = [
+    "get_project_pipeline",
+    "classify_install_date",
+    "build_lookahead_schedule",
+    "build_project_lookahead",
+    "PAINT_BUSINESS_DAYS",
+    "PHASES",
+]

--- a/app/brain/lookahead/pipeline.py
+++ b/app/brain/lookahead/pipeline.py
@@ -1,0 +1,272 @@
+"""
+@milehigh-header
+schema_version: 1
+purpose: Read-only project pipeline pull for the GC-facing 3-week production lookahead.
+  Loads every active release for a job plus open drafting (DRR) and open GC-approval
+  submittals, with date-kind classification. Pure DB read; the schedule builder turns
+  this into phase bars.
+exports:
+  get_project_pipeline(job_number): dict envelope {found, job, project_name, releases, drafting, gc_approvals, flags}
+  classify_install_date(rel_like): hard | projected | asap | neutral | missing
+imports_from: [app.models, app.api.helpers, app.logging_config]
+imported_by: [app.brain.lookahead.schedule_builder, tests]
+invariants:
+  - Read-only. Never writes.
+  - Active = not archived and is_active True/NULL (active_releases_filter).
+  - All active work for the job is returned; window filtering is the builder's job.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Optional
+
+from app.api.helpers import DEFAULT_FAB_ORDER, active_releases_filter
+from app.logging_config import get_logger
+from app.models import Releases, Submittals, is_gc_approval_type
+
+logger = get_logger(__name__)
+
+DRR_TYPE = "Drafting Release Review"
+
+# date_kind values — mirror install_schedule.service classification.
+KIND_HARD = "hard"
+KIND_ASAP = "asap"
+KIND_PROJECTED = "projected"
+KIND_NEUTRAL = "neutral"
+KIND_MISSING = "missing"
+
+# Open-ish submittal statuses (case-insensitive). Closed/approved are excluded.
+_CLOSED_STATUSES = frozenset({
+    "closed", "approved", "void", "cancelled", "canceled", "rejected",
+})
+
+
+def _iso(d: Optional[date | datetime]) -> Optional[str]:
+    if d is None:
+        return None
+    if isinstance(d, datetime):
+        return d.date().isoformat()
+    return d.isoformat()
+
+
+def _is_open_status(status: Optional[str]) -> bool:
+    if not status or not str(status).strip():
+        return True
+    return str(status).strip().lower() not in _CLOSED_STATUSES
+
+
+def classify_install_date(rel) -> str:
+    """Label the install date the same way the install schedule / Timeline does."""
+    start = getattr(rel, "start_install", None)
+    if start is None and isinstance(rel, dict):
+        start = rel.get("start_install")
+    asap = getattr(rel, "start_install_asap", False)
+    if isinstance(rel, dict):
+        asap = rel.get("start_install_asap", False)
+    no_color = getattr(rel, "start_install_no_color", False)
+    if isinstance(rel, dict):
+        no_color = rel.get("start_install_no_color", False)
+    formula_tf = getattr(rel, "start_install_formulaTF", None)
+    if isinstance(rel, dict):
+        formula_tf = rel.get("start_install_formulaTF")
+
+    if not start:
+        return KIND_MISSING
+    if asap:
+        return KIND_ASAP
+    if no_color:
+        return KIND_NEUTRAL
+    if formula_tf is False:
+        return KIND_HARD
+    return KIND_PROJECTED
+
+
+def _release_is_complete(r: Releases) -> bool:
+    stage = (r.stage or "").strip().lower()
+    return (
+        stage in ("complete", "install complete")
+        or (r.job_comp or "").strip().upper() == "X"
+        or (r.invoiced or "").strip().upper() == "X"
+    )
+
+
+def _release_row(r: Releases) -> dict[str, Any]:
+    fab_order = r.fab_order
+    unqueued = (
+        fab_order is not None
+        and abs(float(fab_order) - DEFAULT_FAB_ORDER) < 0.001
+        and not _release_is_complete(r)
+    )
+    return {
+        "kind": "release",
+        "release_id": r.id,
+        "job": r.job,
+        "release": r.release,
+        "code": f"{r.job}-{r.release}",
+        "project_name": r.job_name,
+        "description": r.description,
+        "stage": r.stage,
+        "stage_group": r.stage_group,
+        "is_complete": _release_is_complete(r),
+        "fab_hrs": r.fab_hrs,
+        "install_hrs": r.install_hrs,
+        "num_guys": r.num_guys,
+        "fab_order": fab_order,
+        "unqueued": unqueued,
+        "paint_color": r.paint_color,
+        "released": _iso(r.released),
+        "start_install": _iso(r.start_install),
+        "start_install_formulaTF": r.start_install_formulaTF,
+        "start_install_asap": bool(r.start_install_asap),
+        "start_install_no_color": bool(r.start_install_no_color),
+        "date_kind": classify_install_date(r),
+        "ship_date": _iso(r.ship_date),
+        "comp_eta": _iso(r.comp_eta),
+        "installer": r.installer,
+        "pm": r.pm,
+        "drafter": r.by,
+        "job_comp": r.job_comp,
+        "invoiced": r.invoiced,
+        "notes": r.notes,
+    }
+
+
+def _drr_row(s: Submittals) -> dict[str, Any]:
+    return {
+        "kind": "drafting",
+        "submittal_id": s.submittal_id,
+        "project_number": s.project_number,
+        "project_name": s.project_name,
+        "title": s.title,
+        "status": s.status,
+        "type": s.type,
+        "rel": s.rel,
+        "code": f"{s.project_number}-DRR-{s.rel}" if s.rel is not None else f"DRR-{s.submittal_id}",
+        "drafting_status": s.submittal_drafting_status,
+        "ball_in_court": s.ball_in_court,
+        "due_date": _iso(s.due_date),
+        "start_install": _iso(s.start_install),
+        "gc_jobsite_schedule_date": _iso(s.gc_jobsite_schedule_date),
+        "created_at": _iso(s.created_at),
+        "linked_release_id": s.linked_release_id,
+        "link_status": s.link_status or "",
+    }
+
+
+def _gc_approval_row(s: Submittals) -> dict[str, Any]:
+    return {
+        "kind": "gc_approval",
+        "submittal_id": s.submittal_id,
+        "project_number": s.project_number,
+        "project_name": s.project_name,
+        "title": s.title,
+        "status": s.status,
+        "type": s.type,
+        "ball_in_court": s.ball_in_court,
+        "due_date": _iso(s.due_date),
+        "created_at": _iso(s.created_at),
+    }
+
+
+def get_project_pipeline(job_number) -> dict[str, Any]:
+    """Load all active production work for a job number.
+
+    Returns a JSON-safe envelope. ``found`` is False when the job has no active
+    releases and no open submittals under that number.
+    """
+    try:
+        job_int = int(job_number)
+    except (TypeError, ValueError):
+        return {
+            "found": False,
+            "error": f"invalid job number: {job_number!r}",
+            "job": None,
+            "project_name": None,
+            "releases": [],
+            "drafting": [],
+            "gc_approvals": [],
+            "flags": [],
+        }
+
+    job_str = str(job_int)
+
+    release_models = (
+        Releases.query
+        .filter(active_releases_filter(), Releases.job == job_int)
+        .order_by(Releases.release.asc())
+        .all()
+    )
+
+    submittals = (
+        Submittals.query
+        .filter(Submittals.project_number == job_str)
+        .order_by(Submittals.last_updated.desc().nullslast())
+        .all()
+    )
+
+    drafting = []
+    gc_approvals = []
+    for s in submittals:
+        if not _is_open_status(s.status):
+            continue
+        if (s.type or "").strip() == DRR_TYPE:
+            drafting.append(_drr_row(s))
+        elif is_gc_approval_type(s.type):
+            gc_approvals.append(_gc_approval_row(s))
+
+    releases = [_release_row(r) for r in release_models]
+
+    project_name = None
+    if releases:
+        project_name = releases[0].get("project_name")
+    elif drafting:
+        project_name = drafting[0].get("project_name")
+    elif gc_approvals:
+        project_name = gc_approvals[0].get("project_name")
+
+    found = bool(releases or drafting or gc_approvals)
+
+    # Pipeline-level flags (data quality, not schedule math).
+    flags = []
+    for r in releases:
+        if r["unqueued"]:
+            flags.append({
+                "code": "unqueued",
+                "severity": "medium",
+                "release": r["code"],
+                "message": f"{r['code']} is not sequenced in the shop queue yet.",
+            })
+        if r["date_kind"] == KIND_MISSING and not r["is_complete"]:
+            flags.append({
+                "code": "missing_install_date",
+                "severity": "medium",
+                "release": r["code"],
+                "message": f"{r['code']} has no install date set.",
+            })
+    for d in drafting:
+        if not d.get("due_date") and not d.get("start_install"):
+            flags.append({
+                "code": "unscheduled_drafting",
+                "severity": "medium",
+                "release": d["code"],
+                "message": f"Drafting package '{d.get('title') or d['code']}' has no due or install date.",
+            })
+
+    logger.debug(
+        "project_pipeline_loaded",
+        job=job_int,
+        release_count=len(releases),
+        drafting_count=len(drafting),
+        gc_approval_count=len(gc_approvals),
+        found=found,
+    )
+
+    return {
+        "found": found,
+        "job": job_int,
+        "project_name": project_name,
+        "releases": releases,
+        "drafting": drafting,
+        "gc_approvals": gc_approvals,
+        "flags": flags,
+    }

--- a/app/brain/lookahead/schedule_builder.py
+++ b/app/brain/lookahead/schedule_builder.py
@@ -1,0 +1,544 @@
+"""
+@milehigh-header
+schema_version: 1
+purpose: Deterministic GC-facing multi-phase lookahead schedule from a project pipeline.
+  Builds drafting / fabrication / paint / shipping / installation bars for every active
+  release and open DRR. Dates never invent beyond fixed rules: hard green dates win,
+  stored projections next, paint is a provisional 3-business-day estimated bar, ship
+  defaults to one business day before install when unset.
+exports:
+  build_lookahead_schedule(pipeline, weeks=3, today=None): schedule envelope for PDF/agent
+  build_project_lookahead(job_number, weeks=3, today=None): pipeline + schedule convenience
+  PAINT_BUSINESS_DAYS, PHASES
+imports_from: [datetime, app.trello.utils, app.brain.job_log.scheduling.*, app.brain.lookahead.pipeline]
+imported_by: [tests, (future) bb_chat tools]
+invariants:
+  - Pure given (pipeline, today, weeks). No DB writes.
+  - Every phase bar carries date_source in {hard, projected, estimated, missing}.
+  - Paint duration is provisional (PAINT_BUSINESS_DAYS=3) until shop calibration lands.
+  - Install/ship anchors come only from stored dates (or ship = install-1bd). Never invent
+    install from a job-local fab queue — that understates hours_in_front vs the full shop.
+  - All active pipeline rows are included; window is metadata for the Gantt viewport.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any, Optional
+
+from app.brain.job_log.scheduling.calculator import (
+    calculate_install_complete_date,
+    calculate_remaining_fab_hours,
+)
+from app.brain.job_log.scheduling.config import SchedulingConfig
+from app.brain.lookahead.pipeline import (
+    KIND_ASAP,
+    KIND_HARD,
+    KIND_MISSING,
+    KIND_NEUTRAL,
+    KIND_PROJECTED,
+    get_project_pipeline,
+)
+from app.trello.utils import calculate_business_days_before
+
+# Provisional until shop data analysis replaces it (user will re-gap).
+PAINT_BUSINESS_DAYS = 3
+SHIP_LEAD_BUSINESS_DAYS = 1
+# Cap how far back an open DRR drafting bar extends on the Gantt (table keeps full dates later).
+DRAFT_BAR_MAX_BUSINESS_DAYS = 15
+
+PHASE_DRAFTING = "drafting"
+PHASE_FABRICATION = "fabrication"
+PHASE_PAINT = "paint"
+PHASE_SHIPPING = "shipping"
+PHASE_INSTALLATION = "installation"
+
+PHASES = (
+    PHASE_DRAFTING,
+    PHASE_FABRICATION,
+    PHASE_PAINT,
+    PHASE_SHIPPING,
+    PHASE_INSTALLATION,
+)
+
+# GC-facing phase labels (PDF legend / row bars).
+PHASE_LABELS = {
+    PHASE_DRAFTING: "Drafting",
+    PHASE_FABRICATION: "Fabrication",
+    PHASE_PAINT: "Paint",
+    PHASE_SHIPPING: "Shipping",
+    PHASE_INSTALLATION: "Installation",
+}
+
+SOURCE_HARD = "hard"
+SOURCE_PROJECTED = "projected"
+SOURCE_ESTIMATED = "estimated"
+SOURCE_MISSING = "missing"
+
+LEGEND = {
+    SOURCE_HARD: "Committed date",
+    SOURCE_PROJECTED: "Projected from production schedule",
+    SOURCE_ESTIMATED: "Estimated (paint duration is provisional)",
+    SOURCE_MISSING: "No date available",
+}
+
+# Stages at or past which remaining shop work (fab/paint) is done.
+_POST_PAINT = frozenset({
+    "paint complete", "store at mhmw", "ship planning", "ship complete",
+    "install start", "install complete", "complete",
+})
+_POST_FAB = frozenset({
+    "welded qc", "paint start",
+}) | _POST_PAINT
+_POST_SHIP = frozenset({
+    "ship complete", "install start", "install complete", "complete",
+})
+_POST_INSTALL = frozenset({
+    "install complete", "complete",
+})
+
+
+def _parse_date(value) -> Optional[date]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value[:10])
+    return None
+
+
+def _iso(d: Optional[date]) -> Optional[str]:
+    return d.isoformat() if d is not None else None
+
+
+def _stage_key(stage: Optional[str]) -> str:
+    return (stage or "").strip().lower()
+
+
+def _needs_fab(stage: Optional[str], is_complete: bool) -> bool:
+    if is_complete:
+        return False
+    key = _stage_key(stage)
+    if key in _POST_FAB:
+        return False
+    # Remaining hours map: Paint Complete+ are 0; Welded QC / Paint Start still have shop work
+    # that is paint-ish, but fab remaining is already low — still show fab only pre-Welded QC.
+    return key not in _POST_FAB
+
+
+def _needs_paint(stage: Optional[str], is_complete: bool) -> bool:
+    if is_complete:
+        return False
+    return _stage_key(stage) not in _POST_PAINT
+
+
+def _needs_ship(stage: Optional[str], is_complete: bool) -> bool:
+    if is_complete:
+        return False
+    return _stage_key(stage) not in _POST_SHIP
+
+
+def _needs_install(stage: Optional[str], is_complete: bool) -> bool:
+    if is_complete:
+        return False
+    return _stage_key(stage) not in _POST_INSTALL
+
+
+def _gc_stage_label(row: dict) -> str:
+    """Coarse GC-facing status line for a release or drafting package."""
+    if row.get("kind") == "drafting":
+        return "In drafting"
+    if row.get("is_complete"):
+        return "Complete"
+    stage = _stage_key(row.get("stage"))
+    if stage in _POST_INSTALL:
+        return "Complete"
+    if stage in ("install start",):
+        return "Installing"
+    if stage in ("ship complete",):
+        return "Shipped"
+    if stage in ("ship planning", "store at mhmw"):
+        return "Ready to ship"
+    if stage in ("paint start", "paint complete"):
+        return "In paint"
+    if stage in ("welded qc",):
+        return "Fabrication complete — paint / QC"
+    if stage:
+        return "In fabrication"
+    return "Released"
+
+
+def _phase_bar(
+    phase: str,
+    start: Optional[date],
+    end: Optional[date],
+    date_source: str,
+    *,
+    note: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    if start is None and end is None:
+        return None
+    # Normalize: if only one side, treat as a point bar.
+    if start is None:
+        start = end
+    if end is None:
+        end = start
+    if end < start:
+        start, end = end, start
+    bar = {
+        "phase": phase,
+        "label": PHASE_LABELS[phase],
+        "start": _iso(start),
+        "end": _iso(end),
+        "date_source": date_source,
+    }
+    if note:
+        bar["note"] = note
+    return bar
+
+
+def _paint_window(ship: date) -> tuple[date, date]:
+    """Three business days ending the business day before ship."""
+    paint_end = calculate_business_days_before(ship, 1)
+    paint_start = calculate_business_days_before(ship, PAINT_BUSINESS_DAYS)
+    return paint_start, paint_end
+
+
+def _install_source(date_kind: str) -> str:
+    if date_kind == KIND_HARD:
+        return SOURCE_HARD
+    if date_kind == KIND_ASAP:
+        return SOURCE_HARD  # ASAP is an explicit commitment to go ASAP
+    if date_kind == KIND_PROJECTED:
+        return SOURCE_PROJECTED
+    if date_kind == KIND_NEUTRAL:
+        return SOURCE_HARD  # retained date, color suppressed
+    return SOURCE_MISSING
+
+
+def _build_release_phases(
+    row: dict,
+    *,
+    today: date,
+) -> list[dict[str, Any]]:
+    """Build phase bars from **stored** dates only.
+
+    We deliberately do not invent install/fab from a job-local fab-queue projection:
+    hours_in_front requires the full shop queue (see scheduling.service), and a
+    partial queue would paint optimistic GC-facing dates. Missing install stays
+    missing (flagged on the row); fab/paint/ship cascade only when install or
+    ship is known.
+    """
+    phases: list[dict[str, Any]] = []
+    is_complete = bool(row.get("is_complete"))
+    stage = row.get("stage")
+
+    install_start = _parse_date(row.get("start_install"))
+    install_end = _parse_date(row.get("comp_eta"))
+    date_kind = row.get("date_kind") or KIND_MISSING
+    install_src = _install_source(date_kind)
+
+    if install_end is None and install_start is not None:
+        install_end = calculate_install_complete_date(
+            install_start, row.get("install_hrs"), row.get("num_guys")
+        ) or install_start
+
+    # --- Shipping ---
+    ship = _parse_date(row.get("ship_date"))
+    ship_src = SOURCE_HARD if ship else SOURCE_MISSING
+    if ship is None and install_start is not None and _needs_ship(stage, is_complete):
+        ship = calculate_business_days_before(install_start, SHIP_LEAD_BUSINESS_DAYS)
+        ship_src = SOURCE_ESTIMATED
+
+    # --- Paint (provisional 3-day bar, anchored to ship) ---
+    paint_start = paint_end = None
+    paint_src = SOURCE_ESTIMATED
+    if _needs_paint(stage, is_complete) and ship is not None:
+        paint_start, paint_end = _paint_window(ship)
+
+    # --- Fabrication (back-chain only — never invent from a partial shop queue) ---
+    fab_start = fab_end = None
+    fab_src = SOURCE_ESTIMATED
+    if _needs_fab(stage, is_complete):
+        released = _parse_date(row.get("released"))
+
+        if paint_start is not None:
+            fab_end = calculate_business_days_before(paint_start, 1)
+            fab_src = SOURCE_ESTIMATED
+        elif ship is not None:
+            fab_end = calculate_business_days_before(ship, PAINT_BUSINESS_DAYS + 1)
+            fab_src = SOURCE_ESTIMATED
+
+        if fab_end is not None:
+            remaining = calculate_remaining_fab_hours(row.get("fab_hrs"), stage)
+            if remaining > 0.1:
+                days = max(1, int(-(-remaining // SchedulingConfig.FAB_HOURS_PER_DAY)))  # ceil
+                fab_start = calculate_business_days_before(fab_end, max(days - 1, 0))
+            else:
+                fab_start = fab_end
+            # Don't start fab bars before release day (or today) when we have a floor.
+            floor = released or today
+            if fab_start < floor and floor <= fab_end:
+                fab_start = floor
+
+    # Assemble in lifecycle order.
+    if fab_start is not None or fab_end is not None:
+        bar = _phase_bar(PHASE_FABRICATION, fab_start, fab_end, fab_src)
+        if bar:
+            phases.append(bar)
+
+    if paint_start is not None:
+        note = f"Provisional {PAINT_BUSINESS_DAYS}-business-day paint window"
+        bar = _phase_bar(PHASE_PAINT, paint_start, paint_end, paint_src, note=note)
+        if bar:
+            phases.append(bar)
+
+    if ship is not None and _needs_ship(stage, is_complete):
+        bar = _phase_bar(PHASE_SHIPPING, ship, ship, ship_src)
+        if bar:
+            phases.append(bar)
+    elif ship is not None and not is_complete and _stage_key(stage) == "ship complete":
+        # Already shipped — still show the ship point if we have a date.
+        bar = _phase_bar(PHASE_SHIPPING, ship, ship, ship_src or SOURCE_HARD)
+        if bar:
+            phases.append(bar)
+
+    if install_start is not None and _needs_install(stage, is_complete):
+        bar = _phase_bar(
+            PHASE_INSTALLATION,
+            install_start,
+            install_end or install_start,
+            install_src,
+        )
+        if bar:
+            phases.append(bar)
+    elif install_start is not None and is_complete:
+        # Complete work still listed: single install marker for GC context.
+        bar = _phase_bar(
+            PHASE_INSTALLATION,
+            install_start,
+            install_end or install_start,
+            install_src,
+            note="Complete",
+        )
+        if bar:
+            phases.append(bar)
+
+    return phases
+
+
+def _build_drafting_phases(row: dict, *, today: date) -> list[dict[str, Any]]:
+    due = _parse_date(row.get("due_date"))
+    target_install = _parse_date(row.get("start_install"))
+    created = _parse_date(row.get("created_at")) or today
+
+    phases: list[dict[str, Any]] = []
+    draft_end = due or target_install
+    if draft_end is None:
+        # Unscheduled drafting — point bar at today so it still appears on the chart.
+        bar = _phase_bar(
+            PHASE_DRAFTING,
+            today,
+            today,
+            SOURCE_MISSING,
+            note="No due date set",
+        )
+        if bar:
+            phases.append(bar)
+        return phases
+
+    # Cap multi-month open packages so the Gantt stays readable; full history is a PR2 table concern.
+    span_floor = calculate_business_days_before(draft_end, DRAFT_BAR_MAX_BUSINESS_DAYS)
+    draft_start = max(created, span_floor)
+    if draft_start > draft_end:
+        draft_start = draft_end
+    # DRR due / start_install are hard commitments from DWL when set.
+    src = SOURCE_HARD if (due or target_install) else SOURCE_MISSING
+    bar = _phase_bar(PHASE_DRAFTING, draft_start, draft_end, src)
+    if bar:
+        phases.append(bar)
+
+    # If the DRR already carries a planned install, surface it as a future install bar.
+    if target_install is not None:
+        bar = _phase_bar(
+            PHASE_INSTALLATION,
+            target_install,
+            target_install,
+            SOURCE_HARD,
+            note="Planned install (drawings not yet released)",
+        )
+        if bar:
+            phases.append(bar)
+
+    return phases
+
+
+def _row_flags(row: dict, phases: list[dict]) -> list[str]:
+    flags = []
+    if row.get("unqueued"):
+        flags.append("not_in_shop_queue")
+    if row.get("kind") == "release" and not row.get("is_complete"):
+        if row.get("date_kind") == KIND_MISSING and not any(
+            p["phase"] == PHASE_INSTALLATION for p in phases
+        ):
+            flags.append("missing_install_date")
+        if row.get("fab_hrs") is None and any(
+            p["phase"] == PHASE_FABRICATION for p in phases
+        ):
+            flags.append("missing_fab_hours")
+    if row.get("kind") == "drafting":
+        if not row.get("due_date") and not row.get("start_install"):
+            flags.append("unscheduled_drafting")
+    return flags
+
+
+def build_lookahead_schedule(
+    pipeline: dict[str, Any],
+    *,
+    weeks: int = 3,
+    today: Optional[date] = None,
+) -> dict[str, Any]:
+    """Turn a ``get_project_pipeline`` envelope into a GC-facing multi-phase schedule.
+
+    Includes **all** active releases and open drafting packages from the pipeline.
+    ``window`` is the Gantt viewport (default 3 weeks from ``today``); bars outside
+    the window are still present with full dates for the PDF table appendix.
+    """
+    today = today or date.today()
+    try:
+        weeks = max(1, min(int(weeks), 12))
+    except (TypeError, ValueError):
+        weeks = 3
+
+    window_end = today + timedelta(days=weeks * 7)
+
+    if not pipeline or not pipeline.get("found"):
+        return {
+            "found": False,
+            "error": pipeline.get("error") if pipeline else "no pipeline",
+            "job": pipeline.get("job") if pipeline else None,
+            "project_name": pipeline.get("project_name") if pipeline else None,
+            "audience": "gc",
+            "window": {
+                "start": _iso(today),
+                "end": _iso(window_end),
+                "weeks": weeks,
+            },
+            "generated_on": _iso(today),
+            "rows": [],
+            "summary": {
+                "release_count": 0,
+                "drafting_count": 0,
+                "gc_approval_open_count": 0,
+                "phase_bar_count": 0,
+                "hard_install_dates": 0,
+                "projected_install_dates": 0,
+                "missing_install_dates": 0,
+                "row_count": 0,
+            },
+            "legend": LEGEND,
+            "phase_order": list(PHASES),
+            "phase_labels": dict(PHASE_LABELS),
+            "assumptions": {
+                "paint_business_days": PAINT_BUSINESS_DAYS,
+                "ship_lead_business_days": SHIP_LEAD_BUSINESS_DAYS,
+                "paint_note": "Paint duration is a provisional estimate pending shop calibration.",
+            },
+            "flags": list(pipeline.get("flags") or []) if pipeline else [],
+        }
+
+    releases = list(pipeline.get("releases") or [])
+    drafting = list(pipeline.get("drafting") or [])
+
+    rows: list[dict[str, Any]] = []
+
+    # Drafting first (upstream of fab), then releases by install date then code.
+    for d in drafting:
+        phases = _build_drafting_phases(d, today=today)
+        rows.append({
+            "kind": "drafting",
+            "code": d.get("code"),
+            "title": d.get("title") or d.get("code"),
+            "stage_label": _gc_stage_label(d),
+            "status": d.get("status"),
+            "rel": d.get("rel"),
+            "submittal_id": d.get("submittal_id"),
+            "phases": phases,
+            "flags": _row_flags(d, phases),
+        })
+
+    def _release_sort_key(r: dict):
+        si = _parse_date(r.get("start_install")) or date.max
+        return (r.get("is_complete") is True, si, r.get("code") or "")
+
+    for r in sorted(releases, key=_release_sort_key):
+        phases = _build_release_phases(r, today=today)
+        rows.append({
+            "kind": "release",
+            "code": r.get("code"),
+            "title": r.get("description") or r.get("code"),
+            "stage_label": _gc_stage_label(r),
+            "stage": r.get("stage"),
+            "date_kind": r.get("date_kind"),
+            "start_install": r.get("start_install"),
+            "ship_date": r.get("ship_date"),
+            "comp_eta": r.get("comp_eta"),
+            "is_complete": r.get("is_complete"),
+            "phases": phases,
+            "flags": _row_flags(r, phases),
+        })
+
+    hard_n = sum(1 for r in releases if r.get("date_kind") == KIND_HARD)
+    proj_n = sum(1 for r in releases if r.get("date_kind") == KIND_PROJECTED)
+    miss_n = sum(
+        1 for r in releases
+        if r.get("date_kind") == KIND_MISSING and not r.get("is_complete")
+    )
+    phase_bar_count = sum(len(row["phases"]) for row in rows)
+
+    return {
+        "found": True,
+        "job": pipeline.get("job"),
+        "project_name": pipeline.get("project_name"),
+        "audience": "gc",
+        "window": {
+            "start": _iso(today),
+            "end": _iso(window_end),
+            "weeks": weeks,
+        },
+        "generated_on": _iso(today),
+        "rows": rows,
+        "summary": {
+            "release_count": len(releases),
+            "drafting_count": len(drafting),
+            "gc_approval_open_count": len(pipeline.get("gc_approvals") or []),
+            "phase_bar_count": phase_bar_count,
+            "hard_install_dates": hard_n,
+            "projected_install_dates": proj_n,
+            "missing_install_dates": miss_n,
+            "row_count": len(rows),
+        },
+        "legend": LEGEND,
+        "phase_order": list(PHASES),
+        "phase_labels": dict(PHASE_LABELS),
+        "assumptions": {
+            "paint_business_days": PAINT_BUSINESS_DAYS,
+            "ship_lead_business_days": SHIP_LEAD_BUSINESS_DAYS,
+            "paint_note": "Paint duration is a provisional estimate pending shop calibration.",
+        },
+        "flags": list(pipeline.get("flags") or []),
+        "gc_approvals": pipeline.get("gc_approvals") or [],
+    }
+
+
+def build_project_lookahead(
+    job_number,
+    *,
+    weeks: int = 3,
+    today: Optional[date] = None,
+) -> dict[str, Any]:
+    """Convenience: load pipeline from DB and build the GC-facing schedule."""
+    pipeline = get_project_pipeline(job_number)
+    return build_lookahead_schedule(pipeline, weeks=weeks, today=today)

--- a/tests/lookahead/test_pipeline.py
+++ b/tests/lookahead/test_pipeline.py
@@ -1,0 +1,161 @@
+"""Project pipeline pull — active releases + open drafting for a job."""
+from datetime import date
+
+from app.brain.lookahead.pipeline import (
+    classify_install_date,
+    get_project_pipeline,
+    KIND_HARD,
+    KIND_MISSING,
+    KIND_PROJECTED,
+)
+from app.models import Releases, Submittals, db
+
+
+def _release(job=500, release="100", **kw):
+    defaults = dict(
+        job=job,
+        release=release,
+        job_name="Novel Flatiron",
+        description=f"Scope {release}",
+        stage="Released",
+        stage_group="FABRICATION",
+        fab_hrs=40.0,
+        install_hrs=16.0,
+        fab_order=10.0,
+        is_active=True,
+        is_archived=False,
+        start_install_asap=False,
+        start_install_no_color=False,
+    )
+    defaults.update(kw)
+    return Releases(**defaults)
+
+
+def _drr(project_number="500", submittal_id="s1", **kw):
+    defaults = dict(
+        submittal_id=submittal_id,
+        project_number=str(project_number),
+        project_name="Novel Flatiron",
+        title="Building A Rails",
+        status="Open",
+        type="Drafting Release Review",
+        submittal_drafting_status="STARTED",
+        rel=200,
+    )
+    defaults.update(kw)
+    return Submittals(**defaults)
+
+
+def test_classify_install_date_kinds():
+    from app.brain.lookahead.pipeline import KIND_ASAP, KIND_NEUTRAL
+
+    assert classify_install_date({
+        "start_install": date(2026, 8, 1),
+        "start_install_formulaTF": False,
+        "start_install_asap": False,
+        "start_install_no_color": False,
+    }) == KIND_HARD
+    assert classify_install_date({
+        "start_install": date(2026, 8, 1),
+        "start_install_formulaTF": True,
+    }) == KIND_PROJECTED
+    assert classify_install_date({"start_install": None}) == KIND_MISSING
+    assert classify_install_date({
+        "start_install": date(2026, 8, 1),
+        "start_install_asap": True,
+    }) == KIND_ASAP
+    assert classify_install_date({
+        "start_install": date(2026, 8, 1),
+        "start_install_formulaTF": False,
+        "start_install_no_color": True,
+    }) == KIND_NEUTRAL
+
+
+def test_pipeline_empty_job(app):
+    with app.app_context():
+        out = get_project_pipeline(999)
+        assert out["found"] is False
+        assert out["job"] == 999
+        assert out["releases"] == []
+        assert out["drafting"] == []
+
+
+def test_pipeline_invalid_job():
+    out = get_project_pipeline("not-a-number")
+    assert out["found"] is False
+    assert "error" in out
+
+
+def test_pipeline_job_500_shaped(app):
+    with app.app_context():
+        db.session.add_all([
+            _release(
+                release="615",
+                description="SE Canopy Embed Mods",
+                stage="Ship Planning",
+                stage_group="READY_TO_SHIP",
+                start_install=date(2026, 8, 5),
+                start_install_formulaTF=False,
+                ship_date=date(2026, 8, 4),
+                comp_eta=date(2026, 8, 6),
+                fab_order=5.0,
+            ),
+            _release(
+                release="650",
+                description="RFI 256 Added Beam",
+                stage="Released",
+                start_install=None,
+                start_install_formulaTF=None,
+                fab_order=80.555,  # unqueued default
+            ),
+            _release(
+                release="999",
+                description="Archived noise",
+                is_archived=True,
+                start_install=date(2026, 7, 1),
+                start_install_formulaTF=False,
+            ),
+            _drr(submittal_id="drr-1", title="Stair Core 3", rel=300, due_date=date(2026, 8, 10)),
+            _drr(
+                submittal_id="drr-closed",
+                title="Closed package",
+                status="Closed",
+                rel=301,
+            ),
+            Submittals(
+                submittal_id="gc-1",
+                project_number="500",
+                project_name="Novel Flatiron",
+                title="Guardrails for GC",
+                status="Open",
+                type="Submittal for GC  Approval",
+                submittal_drafting_status="",
+            ),
+        ])
+        db.session.commit()
+
+        out = get_project_pipeline(500)
+        assert out["found"] is True
+        assert out["job"] == 500
+        assert out["project_name"] == "Novel Flatiron"
+
+        codes = {r["code"] for r in out["releases"]}
+        assert codes == {"500-615", "500-650"}
+        assert "500-999" not in codes  # archived excluded
+
+        by_code = {r["code"]: r for r in out["releases"]}
+        assert by_code["500-615"]["date_kind"] == KIND_HARD
+        assert by_code["500-615"]["ship_date"] == "2026-08-04"
+        assert by_code["500-650"]["date_kind"] == KIND_MISSING
+        assert by_code["500-650"]["unqueued"] is True
+
+        assert len(out["drafting"]) == 1
+        assert out["drafting"][0]["title"] == "Stair Core 3"
+        assert out["drafting"][0]["due_date"] == "2026-08-10"
+
+        assert len(out["gc_approvals"]) == 1
+        assert out["gc_approvals"][0]["title"] == "Guardrails for GC"
+
+        flag_codes = {f["code"] for f in out["flags"]}
+        assert "unqueued" in flag_codes
+        assert "missing_install_date" in flag_codes

--- a/tests/lookahead/test_schedule_builder.py
+++ b/tests/lookahead/test_schedule_builder.py
@@ -1,0 +1,377 @@
+"""GC-facing multi-phase lookahead schedule builder (pure + DB convenience)."""
+from datetime import date
+
+from app.brain.lookahead.schedule_builder import (
+    PAINT_BUSINESS_DAYS,
+    PHASE_DRAFTING,
+    PHASE_FABRICATION,
+    PHASE_INSTALLATION,
+    PHASE_PAINT,
+    PHASE_SHIPPING,
+    SOURCE_ESTIMATED,
+    SOURCE_HARD,
+    build_lookahead_schedule,
+    build_project_lookahead,
+)
+from app.brain.lookahead.pipeline import get_project_pipeline
+from app.models import Releases, Submittals, db
+from app.trello.utils import calculate_business_days_before
+
+
+TODAY = date(2026, 7, 25)
+
+
+def _pipeline(**kw):
+    base = {
+        "found": True,
+        "job": 500,
+        "project_name": "Novel Flatiron",
+        "releases": [],
+        "drafting": [],
+        "gc_approvals": [],
+        "flags": [],
+    }
+    base.update(kw)
+    return base
+
+
+def _release_row(**kw):
+    base = {
+        "kind": "release",
+        "release_id": 1,
+        "job": 500,
+        "release": "100",
+        "code": "500-100",
+        "project_name": "Novel Flatiron",
+        "description": "Bld A Structural Steel",
+        "stage": "Released",
+        "stage_group": "FABRICATION",
+        "is_complete": False,
+        "fab_hrs": 80.0,
+        "install_hrs": 16.0,
+        "num_guys": 2.0,
+        "fab_order": 10.0,
+        "unqueued": False,
+        "paint_color": None,
+        "released": "2026-07-01",
+        "start_install": "2026-08-10",
+        "start_install_formulaTF": False,
+        "start_install_asap": False,
+        "start_install_no_color": False,
+        "date_kind": "hard",
+        "ship_date": None,
+        "comp_eta": "2026-08-11",
+        "installer": None,
+        "pm": "Bill",
+        "drafter": None,
+        "job_comp": None,
+        "invoiced": None,
+        "notes": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_not_found_pipeline():
+    out = build_lookahead_schedule(
+        {"found": False, "job": 500, "project_name": None, "flags": []},
+        weeks=3,
+        today=TODAY,
+    )
+    assert out["found"] is False
+    assert out["rows"] == []
+    assert out["window"]["weeks"] == 3
+    assert out["audience"] == "gc"
+
+
+def test_hard_date_release_builds_full_cascade():
+    """Hard install → estimated ship (−1bd) → 3-day paint → fab back-chain."""
+    out = build_lookahead_schedule(
+        _pipeline(releases=[_release_row()]),
+        weeks=3,
+        today=TODAY,
+    )
+    assert out["found"] is True
+    assert out["job"] == 500
+    assert out["summary"]["release_count"] == 1
+    assert out["assumptions"]["paint_business_days"] == PAINT_BUSINESS_DAYS
+
+    row = out["rows"][0]
+    assert row["kind"] == "release"
+    assert row["code"] == "500-100"
+    assert row["stage_label"] == "In fabrication"
+
+    by_phase = {p["phase"]: p for p in row["phases"]}
+    assert PHASE_INSTALLATION in by_phase
+    assert by_phase[PHASE_INSTALLATION]["start"] == "2026-08-10"
+    assert by_phase[PHASE_INSTALLATION]["end"] == "2026-08-11"
+    assert by_phase[PHASE_INSTALLATION]["date_source"] == SOURCE_HARD
+
+    # Ship = 1 business day before 2026-08-10 (Mon) → Fri 2026-08-07
+    expected_ship = calculate_business_days_before(date(2026, 8, 10), 1)
+    assert by_phase[PHASE_SHIPPING]["start"] == expected_ship.isoformat()
+    assert by_phase[PHASE_SHIPPING]["date_source"] == SOURCE_ESTIMATED
+
+    # Paint: 3 business days ending day before ship
+    paint_end = calculate_business_days_before(expected_ship, 1)
+    paint_start = calculate_business_days_before(expected_ship, PAINT_BUSINESS_DAYS)
+    assert by_phase[PHASE_PAINT]["start"] == paint_start.isoformat()
+    assert by_phase[PHASE_PAINT]["end"] == paint_end.isoformat()
+    assert by_phase[PHASE_PAINT]["date_source"] == SOURCE_ESTIMATED
+    assert "provisional" in by_phase[PHASE_PAINT]["note"].lower()
+
+    assert PHASE_FABRICATION in by_phase
+    assert by_phase[PHASE_FABRICATION]["end"] <= by_phase[PHASE_PAINT]["start"]
+    # Back-chained fab is estimated, never "projected from production schedule".
+    assert by_phase[PHASE_FABRICATION]["date_source"] == SOURCE_ESTIMATED
+
+
+def test_hard_ship_date_used_when_present():
+    out = build_lookahead_schedule(
+        _pipeline(releases=[_release_row(
+            ship_date="2026-08-06",
+            start_install="2026-08-10",
+            comp_eta="2026-08-12",
+        )]),
+        weeks=3,
+        today=TODAY,
+    )
+    by_phase = {p["phase"]: p for p in out["rows"][0]["phases"]}
+    assert by_phase[PHASE_SHIPPING]["start"] == "2026-08-06"
+    assert by_phase[PHASE_SHIPPING]["date_source"] == SOURCE_HARD
+    # Even with a hard ship, fab is back-chained → estimated.
+    assert by_phase[PHASE_FABRICATION]["date_source"] == SOURCE_ESTIMATED
+
+
+def test_missing_install_does_not_invent_cascade():
+    """No stored install/ship → no optimistic queue-projected install or paint/ship."""
+    out = build_lookahead_schedule(
+        _pipeline(releases=[_release_row(
+            start_install=None,
+            comp_eta=None,
+            ship_date=None,
+            date_kind="missing",
+            start_install_formulaTF=None,
+            fab_hrs=200.0,
+        )]),
+        weeks=3,
+        today=TODAY,
+    )
+    phases = {p["phase"] for p in out["rows"][0]["phases"]}
+    assert PHASE_INSTALLATION not in phases
+    assert PHASE_SHIPPING not in phases
+    assert PHASE_PAINT not in phases
+    assert PHASE_FABRICATION not in phases
+    assert "missing_install_date" in out["rows"][0]["flags"]
+
+
+def test_paint_complete_stage_omits_fab_and_paint():
+    out = build_lookahead_schedule(
+        _pipeline(releases=[_release_row(
+            stage="Paint Complete",
+            stage_group="READY_TO_SHIP",
+            ship_date="2026-08-06",
+            start_install="2026-08-10",
+            start_install_formulaTF=False,
+            date_kind="hard",
+        )]),
+        weeks=3,
+        today=TODAY,
+    )
+    phases = {p["phase"] for p in out["rows"][0]["phases"]}
+    assert PHASE_FABRICATION not in phases
+    assert PHASE_PAINT not in phases
+    assert PHASE_SHIPPING in phases
+    assert PHASE_INSTALLATION in phases
+
+
+def test_complete_release_still_listed():
+    out = build_lookahead_schedule(
+        _pipeline(releases=[_release_row(
+            release="50",
+            code="500-50",
+            description="Already installed embeds",
+            stage="Complete",
+            is_complete=True,
+            start_install="2026-06-01",
+            comp_eta="2026-06-03",
+            date_kind="neutral",
+            start_install_no_color=True,
+            start_install_formulaTF=False,
+        )]),
+        weeks=3,
+        today=TODAY,
+    )
+    assert out["summary"]["release_count"] == 1
+    row = out["rows"][0]
+    assert row["stage_label"] == "Complete"
+    assert row["is_complete"] is True
+
+
+def test_open_drr_drafting_bar():
+    out = build_lookahead_schedule(
+        _pipeline(drafting=[{
+            "kind": "drafting",
+            "submittal_id": "d1",
+            "code": "500-DRR-300",
+            "title": "Stair Core 3",
+            "status": "Open",
+            "rel": 300,
+            "due_date": "2026-08-08",
+            "start_install": "2026-08-20",
+            "created_at": "2026-07-10",
+        }]),
+        weeks=3,
+        today=TODAY,
+    )
+    assert out["summary"]["drafting_count"] == 1
+    row = out["rows"][0]
+    assert row["kind"] == "drafting"
+    assert row["stage_label"] == "In drafting"
+    by_phase = {p["phase"]: p for p in row["phases"]}
+    assert by_phase[PHASE_DRAFTING]["end"] == "2026-08-08"
+    assert by_phase[PHASE_DRAFTING]["date_source"] == SOURCE_HARD
+    assert by_phase[PHASE_INSTALLATION]["start"] == "2026-08-20"
+    assert "not yet released" in by_phase[PHASE_INSTALLATION]["note"].lower()
+
+
+def test_old_drr_drafting_bar_is_clamped():
+    """Multi-month open DRRs don't paint a year-long drafting bar on the Gantt."""
+    out = build_lookahead_schedule(
+        _pipeline(drafting=[{
+            "kind": "drafting",
+            "submittal_id": "d-old",
+            "code": "500-DRR-50",
+            "title": "Long-lived package",
+            "status": "Open",
+            "rel": 50,
+            "due_date": "2026-08-15",
+            "start_install": None,
+            "created_at": "2025-01-01",
+        }]),
+        weeks=3,
+        today=TODAY,
+    )
+    bar = out["rows"][0]["phases"][0]
+    assert bar["phase"] == PHASE_DRAFTING
+    assert bar["end"] == "2026-08-15"
+    # Must start after the ancient created_at.
+    assert bar["start"] > "2025-01-01"
+    assert bar["start"] <= bar["end"]
+
+
+def test_unscheduled_drafting_flag():
+    out = build_lookahead_schedule(
+        _pipeline(drafting=[{
+            "kind": "drafting",
+            "submittal_id": "d2",
+            "code": "500-DRR-301",
+            "title": "Mystery package",
+            "status": "Open",
+            "rel": 301,
+            "due_date": None,
+            "start_install": None,
+            "created_at": "2026-07-01",
+        }]),
+        weeks=3,
+        today=TODAY,
+    )
+    row = out["rows"][0]
+    assert "unscheduled_drafting" in row["flags"]
+    by_phase = {p["phase"]: p for p in row["phases"]}
+    assert by_phase[PHASE_DRAFTING]["date_source"] == "missing"
+
+
+def test_all_active_work_included_not_window_filtered():
+    """Rows outside the 3-week window still appear (all active work)."""
+    far = _release_row(
+        release="900",
+        code="500-900",
+        description="Far-future package",
+        start_install="2026-12-01",
+        comp_eta="2026-12-03",
+        date_kind="hard",
+        start_install_formulaTF=False,
+    )
+    out = build_lookahead_schedule(
+        _pipeline(releases=[far]),
+        weeks=3,
+        today=TODAY,
+    )
+    assert out["window"]["start"] == "2026-07-25"
+    assert out["window"]["end"] == "2026-08-15"  # +21 days
+    assert out["rows"][0]["code"] == "500-900"
+    assert any(p["phase"] == PHASE_INSTALLATION for p in out["rows"][0]["phases"])
+
+
+def test_build_project_lookahead_db(app):
+    with app.app_context():
+        db.session.add(Releases(
+            job=500,
+            release="615",
+            job_name="Novel Flatiron",
+            description="SE Canopy",
+            stage="Weld Complete",
+            stage_group="FABRICATION",
+            fab_hrs=40.0,
+            install_hrs=8.0,
+            fab_order=4.0,
+            start_install=date(2026, 8, 12),
+            start_install_formulaTF=False,
+            start_install_asap=False,
+            start_install_no_color=False,
+            ship_date=date(2026, 8, 11),
+            comp_eta=date(2026, 8, 13),
+            is_active=True,
+            is_archived=False,
+        ))
+        db.session.add(Submittals(
+            submittal_id="drr-500-1",
+            project_number="500",
+            project_name="Novel Flatiron",
+            title="Open DRR package",
+            status="Open",
+            type="Drafting Release Review",
+            submittal_drafting_status="STARTED",
+            rel=400,
+            due_date=date(2026, 8, 5),
+        ))
+        db.session.commit()
+
+        out = build_project_lookahead(500, weeks=3, today=TODAY)
+        assert out["found"] is True
+        assert out["project_name"] == "Novel Flatiron"
+        kinds = {r["kind"] for r in out["rows"]}
+        assert "release" in kinds
+        assert "drafting" in kinds
+        assert out["summary"]["release_count"] == 1
+        assert out["summary"]["drafting_count"] == 1
+        assert out["legend"]["hard"] == "Committed date"
+        assert out["audience"] == "gc"
+
+
+def test_pipeline_feeds_builder_roundtrip(app):
+    with app.app_context():
+        db.session.add(Releases(
+            job=500,
+            release="1",
+            job_name="Novel Flatiron",
+            description="Embeds",
+            stage="Released",
+            fab_hrs=20.0,
+            install_hrs=8.0,
+            fab_order=3.0,
+            start_install=date(2026, 8, 4),
+            start_install_formulaTF=True,  # projected
+            start_install_asap=False,
+            start_install_no_color=False,
+            is_active=True,
+            is_archived=False,
+        ))
+        db.session.commit()
+
+        pipe = get_project_pipeline(500)
+        out = build_lookahead_schedule(pipe, weeks=3, today=TODAY)
+        assert out["summary"]["projected_install_dates"] == 1
+        by_phase = {p["phase"]: p for p in out["rows"][0]["phases"]}
+        assert by_phase[PHASE_INSTALLATION]["date_source"] == "projected"


### PR DESCRIPTION
…lder.

Read-only get_project_pipeline loads active releases, open DRRs, and GC approvals for a job. build_lookahead_schedule turns that into drafting / fabrication / paint / shipping / installation bars using stored green and projected dates, provisional 3-day paint estimates, and ship = install-1bd when unset. Does not invent dates from a job-local fab queue. Unit tests cover job-500-shaped fixtures. PDF export and Carmen tools come next.