### PR TITLE
Add submittal status drift audit and reconcile script

### DIFF
--- a/docs/submittal-status-drift.md
+++ b/docs/submittal-status-drift.md
@@ -1,0 +1,212 @@
+# Submittal status drift — findings and remediation
+
+**Scanned:** 2026-07-28, read-only, against production.
+**Trigger:** client reported the Drafting Work Load showing submittals as Open
+that were already closed in Procore.
+**Verdict:** confirmed, and larger than the two rows reported — but it is a
+*historical backlog that has stopped growing*, not an active leak.
+
+Reproduce any figure below with `scripts/reconcile_status_drift.py` (dry-run is
+the default and touches nothing).
+
+---
+
+## 1. Headline numbers
+
+| Measure | Count |
+|---|---|
+| DB rows with `status='Open'` at scan time | 249 |
+| …of those, **Closed in Procore** (stale) | **131** (53%) |
+| …genuinely in sync | 117 |
+| Ball-in-court-only drift among still-open rows | 0 |
+| Rows unscannable (missing `procore_project_id`) | 1 (`65206107`) |
+
+**Every single drift is the same shape: `Open` → `Closed`.** No other status
+transition drifted in either direction.
+
+### The reverse direction is clean
+
+A second scan walked **all 46 Procore projects / 3,892 submittals** and compared
+Procore's Open set against ours:
+
+| Check | Result |
+|---|---|
+| Open in Procore, Closed in our DB | **0** |
+| Open in Procore, missing from our DB entirely | **0** |
+
+This is the reassuring half. **No work has silently dropped out of anyone's
+queue.** The failure mode is strictly *"we missed a close,"* never *"we lost a
+job."* Drafters may see finished work they should ignore; they will not have
+live work hidden from them.
+
+---
+
+## 2. The drift stopped in May
+
+Of the 130 stale rows still outstanding, sorted by when Procore actually closed
+them:
+
+| Age of the missed close | Stale rows |
+|---|---|
+| Under 30 days | **0** |
+| 30–90 days | 25 |
+| 90–180 days | 54 |
+| Over 180 days | 51 |
+
+- Oldest missed close: **2025-12-15**
+- Newest missed close: **2026-05-22**
+
+**Nothing closed in Procore after 2026-05-22 is stale.** Close events have been
+landing correctly for roughly nine weeks. That reframes the problem: this is a
+backlog to be cleared once, not a bug to be chased. Whatever broke the webhook
+path appears to have been fixed sometime around late May.
+
+> **Before running the cleanup, re-run the dry-run scan.** If the newest
+> `closed_at` has moved past 2026-05-22, the leak has reopened and the fix
+> belongs in the webhook path first — clearing the backlog would just mask it.
+
+---
+
+## 3. Blast radius is small
+
+Order slots are what actually distort the DWL. Only **two** stale rows still
+hold one:
+
+| Job | Submittal | Drafter | Order held |
+|---|---|---|---|
+| 480 | `67501266` — Structural Steel Beams Area 3 | Gary Almeida | 5.0 |
+| 560 | `68843528` — Loose Lintels | Bill O'Neill | 0.7 |
+
+Plus `68843525` ("Cabanas", job 560, Gary Almeida, order 0.9), which is stale
+and holds slot 0.9.
+
+The other ~127 have `order_number = NULL`. They are clutter in the Open list —
+visually noisy, not queue-blocking.
+
+### Concentration
+
+| Ball-in-court | Stale rows |
+|---|---|
+| Dalton Rauer | 83 |
+| Colton Arendt | 33 |
+| Gary Almeida | 5 |
+| Rourke Alvarado | 3 |
+| Rich Losasso | 2 |
+| Danny Riddell | 2 |
+| David Servold | 1 |
+| Bill O'Neill | 1 |
+
+Two drafters carry 116 of 130. Worth checking whether their queues share a
+Procore project or notification path that the others don't.
+
+### By job
+
+| Job | Stale | Job | Stale | Job | Stale |
+|---|---|---|---|---|---|
+| 440 | 22 | 340 | 5 | 510 | 2 |
+| 170 | 18 | 480 | 5 | 610 | 2 |
+| 410 | 11 | 190 | 4 | 900 | 2 |
+| 330 | 8 | 320 | 4 | 290 | 1 |
+| 450 | 8 | 380 | 4 | 470 | 1 |
+| 500 | 7 | 390 | 3 | 490 | 1 |
+| 370 | 6 | 550 | 3 | 530 | 1 |
+| | | 560 | 3 | 545 | 1 |
+| | | 999 | 3 | 590 | 1 |
+
+---
+
+## 4. What was already fixed
+
+One row was reconciled on 2026-07-28 — the one the client pointed at directly:
+
+**`62145570`, job 380 Marshall Pointe, "Garage - Roof Canopy"**
+
+| Field | Before | After |
+|---|---|---|
+| `status` | `Open` | `Closed` |
+| `ball_in_court` | `Gary Almeida` | `Brian Panning, Gary Almeida, David Servold` |
+| `order_number` | `None` | `None` (unchanged) |
+
+Procore had closed it **2026-03-24** — stale for over four months. A
+`SubmittalEvents` row was written with `backfill: True` and reason
+`"reconcile_status_drift: Procore is source of truth"`, tagged `source=Brain`
+so it reads as a correction rather than a Procore echo. Compress was suppressed,
+so no drafter queue was renumbered.
+
+Command used:
+
+```bash
+ENVIRONMENT=production .venv/bin/python -m scripts.reconcile_status_drift \
+  --only 62145570 --no-compress --apply
+```
+
+### The second reported row was a false alarm
+
+`73364625` (job 560, "Building B Structural Steel") was **already Closed** in the
+DB — closed correctly by a Procore webhook on 2026-07-08. The client's screenshot
+predated that. Nothing to fix.
+
+---
+
+## 5. Remediation — the run to schedule
+
+The remaining 130 clear in one pass:
+
+```bash
+# Always dry-run first — confirm the count and that closed_at still tops out in May.
+ENVIRONMENT=production .venv/bin/python -m scripts.reconcile_status_drift \
+  --report /tmp/status_reconcile.json
+
+# Then commit.
+ENVIRONMENT=production .venv/bin/python -m scripts.reconcile_status_drift --apply
+```
+
+For each drifted row the script sets `status` to Procore's value, clears
+`order_number` when the row leaves Open (freeing the DWL slot, same rule as
+`check_and_update_submittal`), syncs `ball_in_court` when it also drifted, and
+writes a `backfill: True` `SubmittalEvents` row.
+
+**Drop `--no-compress` on the full run.** Compress renumbers each affected
+drafter's remaining Open queue — urgency 0.1–0.9 packed to the high end, regular
+renumbered 1..N preserving order, identical math to the DWL "Resort" button.
+Doing that *once, after every slot is freed* is correct. Doing it per-row (as a
+`--only` run would) shuffles a drafter's queue under them for no benefit, which
+is why the single-row fix above suppressed it.
+
+Expected compress effects, from the 2026-07-28 dry-run:
+
+- **Gary Almeida** — urgency 0.5–0.8 → 0.6–0.9; regular 8, 9 → 2, 3
+- **Colton Arendt** — 5, 7, 8, 9, 10… → 2, 3, 4, 5, 6…
+- **Danny Riddell** — urgency 0.2–0.9 → 0.1–0.8; regular 3, 4, 7, 8, 19, 22, 33… → 2, 3, 4, 5, 6, 7, 8…
+- **Rourke Alvarado** — 5, 6, 7 → 1, 2, 3
+- Dalton Rauer, David Servold, Rich Losasso, Bill O'Neill — single-row shifts
+
+Tell the affected drafters before running it. Their queue positions will move.
+
+### Script flags added 2026-07-28
+
+- `--only ID[,ID…]` — scan and reconcile named submittals only
+- `--no-compress` — close and clear without renumbering any queue
+
+---
+
+## 6. Follow-ups this surfaced
+
+1. **Root cause is unconfirmed.** We know close events stopped being missed
+   around 2026-05-22; we do not know what fixed it. Until that is understood,
+   the leak could reopen silently. Worth a look at webhook delivery history
+   (`get_webhook_deliveries`) over Dec 2025 – May 2026.
+
+2. **There is no drift alarm.** This was found because a client noticed. A
+   periodic read-only scan emitting a count would have caught it in December.
+   The dry-run path is cheap and already written.
+
+3. **`65206107` has no `procore_project_id`** and cannot be scanned at all.
+   Needs manual attention.
+
+4. **Audit-log divergence, separate issue.** `72974122` (job 560) has
+   `last_updated = 2026-07-08 19:59` but no `SubmittalEvents` row newer than
+   2026-07-07 — the row was updated without an event being written. The row
+   value is correct; the event stream under-records. This matches the known
+   Procore event-divergence behaviour under rapid BIC re-flips and is *not* part
+   of the status drift above.

--- a/scripts/reconcile_status_drift.py
+++ b/scripts/reconcile_status_drift.py
@@ -1,0 +1,450 @@
+"""
+Reconcile Open-in-DB / Closed-in-Procore (and other status) drift.
+
+What this does
+--------------
+1. Scan every submittal with DB status='Open' against live Procore.
+2. When Procore status != DB status:
+   - set DB status to Procore truth
+   - if new status is not Open: clear order_number (frees the DWL slot —
+     same rule as check_and_update_submittal)
+   - optionally sync ball_in_court when it also drifted
+   - write a SubmittalEvents row marked backfill=True for the audit trail
+3. For every drafter whose Open queue lost an ordered/urgent slot, compress:
+   - urgency (0.1–0.9): pack into the high end of the ladder (compress_orders)
+   - regular (>=1): renumber 1..N preserving relative order (compress_ordered /
+     same math as DWL "Resort")
+
+"Clear orders + compress Gary's queue" means:
+  Zombies were still holding slots like Gary order 0.9 and 5.0. Closing them
+  sets order_number=NULL. Compress then renumbers the *remaining Open* items
+  so Gary's queue is contiguous again, e.g. urgency 0.5–0.8 → 0.6–0.9 and
+  regular 1, 8, 9 → 1, 2, 3.
+
+Usage
+-----
+    ENVIRONMENT=production python -m scripts.reconcile_status_drift
+    ENVIRONMENT=production python -m scripts.reconcile_status_drift --apply
+    ENVIRONMENT=production python -m scripts.reconcile_status_drift --apply --report /tmp/status_reconcile.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+# Never boot the prod scheduler from a one-off script.
+os.environ.pop("IS_RENDER_SCHEDULER", None)
+os.environ.pop("WERKZEUG_RUN_MAIN", None)
+os.environ.setdefault("ENVIRONMENT", "production")
+
+from app import create_app
+from app.models import Submittals, SubmittalEvents, db
+from app.procore.procore import get_submittal_by_id
+from app.procore.helpers import parse_ball_in_court_from_submittal
+from app.brain.drafting_work_load.engine import SubmittalOrderingEngine
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _status_name(raw: Any) -> Optional[str]:
+    if isinstance(raw, dict):
+        return (raw.get("name") or raw.get("status") or raw.get("value") or None)
+    if isinstance(raw, str):
+        return raw.strip() or None
+    return None
+
+
+def _norm(value: Optional[str]) -> str:
+    return value if value is not None else ""
+
+
+def _backfill_hash(action: str, submittal_id: str, payload: dict) -> str:
+    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    raw = f"{action}:{submittal_id}:{payload_json}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def fetch_procore(project_id: str, submittal_id: str) -> dict:
+    raw = get_submittal_by_id(project_id, submittal_id)
+    if not isinstance(raw, dict):
+        return {"error": f"Procore returned {type(raw).__name__}: {raw!r}"}
+
+    parsed = parse_ball_in_court_from_submittal(raw) or {}
+    status = _status_name(raw.get("status"))
+    return {
+        "status": str(status).strip() if status else None,
+        "ball_in_court": parsed.get("ball_in_court"),
+        "title": raw.get("title"),
+        "closed_at": raw.get("closed_at"),
+        "current_revision": raw.get("current_revision"),
+    }
+
+
+def scan_open_for_drift(
+    sleep_s: float = 0.05,
+    only_ids: Optional[Set[str]] = None,
+) -> List[dict]:
+    """Return drift rows for every Open DB submittal that disagrees with Procore.
+
+    only_ids restricts the scan to specific submittal_ids (surgical reconcile).
+    """
+    query = Submittals.query.filter(Submittals.status == "Open")
+    if only_ids:
+        query = query.filter(Submittals.submittal_id.in_(sorted(only_ids)))
+    opens = query.order_by(Submittals.project_number, Submittals.id).all()
+
+    if only_ids:
+        found = {rec.submittal_id for rec in opens}
+        for missing in sorted(only_ids - found):
+            print(f"  NOTE: {missing} is not an Open row in the DB — nothing to reconcile")
+    drifts: List[dict] = []
+    errors: List[dict] = []
+    in_sync = 0
+
+    print(f"Scanning {len(opens)} Open submittals against Procore…")
+    for i, rec in enumerate(opens, 1):
+        if not rec.procore_project_id:
+            errors.append({
+                "submittal_id": rec.submittal_id,
+                "error": "missing procore_project_id",
+            })
+            continue
+        try:
+            view = fetch_procore(rec.procore_project_id, rec.submittal_id)
+        except Exception as e:
+            errors.append({
+                "submittal_id": rec.submittal_id,
+                "project_number": rec.project_number,
+                "error": f"{type(e).__name__}: {e}",
+            })
+            if sleep_s:
+                time.sleep(sleep_s)
+            continue
+
+        if "error" in view:
+            errors.append({
+                "submittal_id": rec.submittal_id,
+                "project_number": rec.project_number,
+                "error": view["error"],
+            })
+            if sleep_s:
+                time.sleep(sleep_s)
+            continue
+
+        status_drift = _norm(rec.status) != _norm(view["status"])
+        bic_drift = _norm(rec.ball_in_court) != _norm(view["ball_in_court"])
+
+        if not status_drift and not bic_drift:
+            in_sync += 1
+        else:
+            drifts.append({
+                "submittal_id": rec.submittal_id,
+                "procore_project_id": rec.procore_project_id,
+                "project_number": rec.project_number,
+                "title": rec.title,
+                "db_status": rec.status,
+                "procore_status": view["status"],
+                "db_bic": rec.ball_in_court,
+                "procore_bic": view["ball_in_court"],
+                "db_order": rec.order_number,
+                "status_drift": status_drift,
+                "bic_drift": bic_drift,
+                "closed_at": view.get("closed_at"),
+                "current_revision": view.get("current_revision"),
+            })
+
+        if i % 50 == 0 or i == len(opens):
+            print(f"  … {i}/{len(opens)}  drifts={len(drifts)}  in_sync={in_sync}  errors={len(errors)}")
+        if sleep_s:
+            time.sleep(sleep_s)
+
+    return drifts, errors, in_sync
+
+
+def apply_status_drifts(drifts: List[dict], apply: bool) -> Tuple[List[dict], Set[str]]:
+    """
+    Apply status (and accompanying BIC) fixes for status-drifted rows.
+    Returns (applied_rows, drafter_bics_to_compress).
+    """
+    applied: List[dict] = []
+    compress_bics: Set[str] = set()
+
+    status_drifts = [d for d in drifts if d["status_drift"]]
+    print(f"\nStatus drifts to reconcile: {len(status_drifts)}")
+
+    for d in status_drifts:
+        rec = Submittals.query.filter_by(submittal_id=d["submittal_id"]).first()
+        if rec is None:
+            d["action"] = "missing_row"
+            applied.append(d)
+            continue
+
+        old_status = rec.status
+        old_order = rec.order_number
+        old_bic = rec.ball_in_court
+        new_status = d["procore_status"]
+        new_bic = d["procore_bic"]
+
+        # Any single-drafter queue that owned this Open row may need compress after
+        # the row leaves Open (even if its order was already null — siblings may have gaps).
+        if old_bic and "," not in old_bic:
+            compress_bics.add(old_bic)
+
+        payload: Dict[str, Any] = {
+            "status": {"old": old_status, "new": new_status},
+            "backfill": True,
+            "reason": "reconcile_status_drift: Procore is source of truth",
+        }
+        will_clear_order = _norm(new_status) != "Open" and old_order is not None
+        if will_clear_order:
+            payload["order_number"] = {"old": old_order, "new": None}
+
+        # Sync BIC only when status is also drifting on this pass (keep surgical).
+        will_sync_bic = d["bic_drift"]
+        if will_sync_bic:
+            payload["ball_in_court"] = {"old": old_bic, "new": new_bic}
+
+        action_row = {
+            **d,
+            "old_order": old_order,
+            "will_clear_order": will_clear_order,
+            "will_sync_bic": will_sync_bic,
+            "action": "would_update" if not apply else "updated",
+        }
+
+        print(
+            f"  {'APPLY' if apply else 'would'}  {d['submittal_id']}  "
+            f"job={d['project_number']}  {(d['title'] or '')[:40]!r}"
+        )
+        print(f"         status  {old_status!r} -> {new_status!r}")
+        if will_clear_order:
+            print(f"         order   {old_order!r} -> None  (free slot)")
+        if will_sync_bic:
+            print(f"         BIC     {old_bic!r} -> {new_bic!r}")
+
+        if apply:
+            rec.status = new_status
+            if will_clear_order:
+                rec.order_number = None
+            if will_sync_bic:
+                rec.ball_in_court = new_bic
+                rec.last_bic_update = datetime.utcnow()
+            rec.last_updated = datetime.utcnow()
+
+            event = SubmittalEvents(
+                submittal_id=rec.submittal_id,
+                action="updated",
+                payload=payload,
+                payload_hash=_backfill_hash("updated", rec.submittal_id, payload),
+                source="Brain",
+                is_system_echo=False,
+                created_at=datetime.utcnow(),
+            )
+            db.session.add(event)
+            action_row["event_payload"] = payload
+
+        applied.append(action_row)
+
+    if apply and applied:
+        db.session.commit()
+        print(f"  committed {sum(1 for a in applied if a.get('action') == 'updated')} status updates")
+
+    return applied, compress_bics
+
+
+def compress_drafter_queue(
+    ball_in_court: str,
+    apply: bool,
+    exclude_ids: Optional[Set[str]] = None,
+) -> List[dict]:
+    """
+    Compress Open submittals for one single-assignee drafter:
+      urgency slots + regular 1..N (same as DWL Resort for regular).
+
+    exclude_ids: submittals that are about to leave Open (dry-run) or were just
+    closed — never include them in the compress set.
+    """
+    exclude_ids = exclude_ids or set()
+    rows = (
+        Submittals.query.filter(
+            Submittals.ball_in_court == ball_in_court,
+            Submittals.status == "Open",
+        ).all()
+    )
+    rows = [s for s in rows if s.submittal_id not in exclude_ids]
+    data = [{"submittal_id": s.submittal_id, "order_number": s.order_number} for s in rows]
+    urgent_updates = SubmittalOrderingEngine.compress_orders(data)
+    # Re-read dicts after urgent so regular math sees current numbers (engine is pure;
+    # apply both against original data is fine — zones don't overlap).
+    regular_updates = SubmittalOrderingEngine.compress_ordered_submittals(data)
+
+    by_id = {s.submittal_id: s for s in rows}
+    result = []
+    for sid, new_order in urgent_updates + regular_updates:
+        rec = by_id.get(sid)
+        if rec is None:
+            continue
+        old = rec.order_number
+        result.append({
+            "submittal_id": sid,
+            "ball_in_court": ball_in_court,
+            "old_order": old,
+            "new_order": new_order,
+        })
+        print(
+            f"  {'APPLY' if apply else 'would'} compress  {sid}  "
+            f"{ball_in_court}: {old!r} -> {new_order!r}"
+        )
+        if apply:
+            rec.order_number = new_order
+            rec.last_updated = datetime.utcnow()
+            payload = {
+                "resort": True,
+                "order_number": {"old": old, "new": new_order},
+                "backfill": True,
+                "reason": "reconcile_status_drift: compress after zombie close",
+            }
+            db.session.add(SubmittalEvents(
+                submittal_id=sid,
+                action="updated",
+                payload=payload,
+                payload_hash=_backfill_hash("updated", sid, payload),
+                source="Brain",
+                is_system_echo=False,
+                created_at=datetime.utcnow(),
+            ))
+
+    if apply and result:
+        db.session.commit()
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--apply", action="store_true", help="Commit changes (default: dry-run)")
+    parser.add_argument(
+        "--also-bic-only",
+        action="store_true",
+        help="Also report Open rows with BIC drift but matching Open status (not applied)",
+    )
+    parser.add_argument("--report", metavar="PATH", help="Write JSON report")
+    parser.add_argument("--sleep", type=float, default=0.05, help="Seconds between Procore GETs")
+    parser.add_argument(
+        "--only",
+        metavar="IDS",
+        help="Comma-separated submittal_ids: scan and reconcile ONLY these rows",
+    )
+    parser.add_argument(
+        "--no-compress",
+        action="store_true",
+        help="Close/clear only — never renumber a drafter's remaining Open queue",
+    )
+    args = parser.parse_args()
+    only_ids = {s.strip() for s in args.only.split(",") if s.strip()} if args.only else None
+
+    app = create_app()
+    with app.app_context():
+        mode = "APPLY" if args.apply else "DRY-RUN"
+        print(f"Mode: {mode}")
+        print(f"DB: {app.config.get('SQLALCHEMY_DATABASE_URI', '').split('@')[-1]}")
+
+        if only_ids:
+            print(f"Scope: ONLY {', '.join(sorted(only_ids))}")
+        if args.no_compress:
+            print("Compress: DISABLED (--no-compress)")
+
+        drifts, errors, in_sync = scan_open_for_drift(sleep_s=args.sleep, only_ids=only_ids)
+
+        status_drifts = [d for d in drifts if d["status_drift"]]
+        bic_only = [d for d in drifts if d["bic_drift"] and not d["status_drift"]]
+
+        print("\n=== STATUS DRIFT (Open in DB, different in Procore) ===")
+        for d in status_drifts:
+            print(
+                f"  job={d['project_number']:>4}  ord={str(d['db_order']):>6}  "
+                f"{d['submittal_id']}  {(d['title'] or '')[:40]}"
+            )
+            print(
+                f"         status {d['db_status']!r} -> {d['procore_status']!r}  "
+                f"BIC {d['db_bic']!r} -> {d['procore_bic']!r}  "
+                f"closed_at={d.get('closed_at')}"
+            )
+
+        if args.also_bic_only and bic_only:
+            print(f"\n=== BIC-ONLY DRIFT (status still Open both sides): {len(bic_only)} ===")
+            for d in bic_only[:40]:
+                print(
+                    f"  job={d['project_number']:>4}  {d['submittal_id']}  "
+                    f"BIC {d['db_bic']!r} -> {d['procore_bic']!r}  {(d['title'] or '')[:35]}"
+                )
+            if len(bic_only) > 40:
+                print(f"  … +{len(bic_only) - 40} more")
+
+        if errors:
+            print(f"\n=== FETCH ERRORS ({len(errors)}) ===")
+            for e in errors[:20]:
+                print(f"  {e}")
+
+        print(
+            f"\nSummary: in_sync={in_sync}  status_drift={len(status_drifts)}  "
+            f"bic_only={len(bic_only)}  errors={len(errors)}"
+        )
+
+        applied, compress_bics = apply_status_drifts(status_drifts, apply=args.apply)
+
+        # IDs leaving Open must not be renumbered (dry-run still sees them as Open).
+        leaving_open_ids = {
+            d["submittal_id"]
+            for d in status_drifts
+            if _norm(d.get("procore_status")) != "Open"
+        }
+
+        compress_results = []
+        if args.no_compress:
+            if compress_bics:
+                print(
+                    f"\n(compress skipped by --no-compress; would have touched: "
+                    f"{', '.join(sorted(compress_bics))})"
+                )
+        else:
+            for bic in sorted(compress_bics):
+                print(f"\n=== Compress Open queue: {bic!r} ===")
+                compress_results.extend(
+                    compress_drafter_queue(bic, apply=args.apply, exclude_ids=leaving_open_ids)
+                )
+            if not compress_bics:
+                print("\n(no single-drafter queues to compress)")
+
+        report = {
+            "mode": mode,
+            "ran_at": datetime.utcnow().isoformat() + "Z",
+            "in_sync": in_sync,
+            "status_drifts": status_drifts,
+            "bic_only_drifts": bic_only if args.also_bic_only else f"{len(bic_only)} (pass --also-bic-only)",
+            "errors": errors,
+            "applied": applied,
+            "compress": compress_results,
+        }
+
+        if args.report:
+            with open(args.report, "w") as f:
+                json.dump(report, f, indent=2, default=str)
+            print(f"\nWrote report → {args.report}")
+
+        if not args.apply and status_drifts:
+            print("\nRe-run with --apply to commit status closes, order clears, and compress.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The client reported the Drafting Work Load showing submittals as Open that Procore had already closed. A read-only scan of production on 2026-07-28 confirmed it at scale: 131 of 249 Open rows (53%) are Closed in Procore.

The drift is one-directional. A reverse scan across all 46 Procore projects / 3,892 submittals found zero cases of work Open in Procore but closed or missing on our side, so nothing has dropped out of a drafter's queue -- we miss closes, we never lose jobs.

It has also stopped growing. Bucketing the stale rows by when Procore actually closed them, nothing closed after 2026-05-22 is stale; close events have landed correctly for ~9 weeks. This is a backlog to clear once, not an active leak. The doc gates the cleanup on re-confirming that, since clearing the backlog would mask a reopened leak.

Only 3 stale rows still hold a DWL order slot; the rest have a null order_number and are list clutter rather than queue blockers.

docs/submittal-status-drift.md records the findings, the blast radius, the remediation command, and the follow-ups (root cause unconfirmed, no drift alarm exists, one unscannable row).

scripts/reconcile_status_drift.py sets DB status to Procore truth, frees the order slot when a row leaves Open, syncs ball_in_court when it also drifted, and writes a backfill-marked SubmittalEvents row. Dry-run is the default. Two flags added for surgical use:

  --only ID[,ID...]  reconcile named submittals only
  --no-compress      close and clear without renumbering any queue

Compress renumbers a drafter's remaining Open queue, which is correct once after every slot is freed but disruptive per-row -- hence the flag.

Applied so far: 62145570 (job 380, "Garage - Roof Canopy"), stale since 2026-03-24, reconciled with compress suppressed. The other row the client reported, 73364625, was already correctly Closed. The remaining 130 are left for a scheduled run.