### PR TITLE
Harden FC PDF viewer URL fallback and refetch logic

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -96,8 +96,8 @@ def init_scheduler(app):
 
     # --- Nightly FC PDF Pack retry worker (2:00 AM Mountain Time) ---
     # Procore's Final PDF Pack can land up to ~24h after a release hits the
-    # job log; this catches the misses by retrying releases with NULL
-    # viewer_url that were released within the last 7 days.
+    # job log; this catches the misses by retrying active releases with a
+    # NULL/empty viewer_url inside the worker's LOOKBACK_DAYS window.
     # Pinned to America/Denver so the fire time tracks MT through DST,
     # independent of the Render container's UTC clock.
     def fc_pdf_retry():
@@ -106,7 +106,7 @@ def init_scheduler(app):
             try:
                 retry_missing_fc_viewer_urls(trigger="cron")
             except Exception as e:
-                logger.error("FC PDF retry job failed", error=str(e), exc_info=True)
+                logger.error("fc_retry_job_failed", error=str(e), exc_info=True)
 
     scheduler.add_job(
         func=fc_pdf_retry,

--- a/app/procore/fc_retry_worker.py
+++ b/app/procore/fc_retry_worker.py
@@ -114,7 +114,7 @@ def _persist_viewer_url(release_id, job, release, viewer_url, card_id, submittal
             add_procore_link(card_id, viewer_url)
         except Exception as link_err:
             logger.warning(
-                "FC retry: persisted viewer_url but failed to add Trello link",
+                "fc_retry_trello_link_failed",
                 job=job, release=release, error=str(link_err),
             )
 
@@ -127,7 +127,7 @@ def _process_release(project_id, release_id, job, release, card_id, all_submitta
     try:
         final_pdfs = get_final_pdf_viewers(project_id, matching)
     except Exception as exc:
-        logger.exception("FC retry: final_pdf_viewers raised", job=job, release=release)
+        logger.exception("fc_retry_final_pdf_fetch_failed", job=job, release=release)
         _safe_rollback()
         return "errored", {**base, "error": f"final pdf fetch raised: {exc}"}
     if not final_pdfs:
@@ -140,7 +140,7 @@ def _process_release(project_id, release_id, job, release, card_id, all_submitta
             release_id, job, release, viewer_url, card_id, submittal_id=submittal_id
         )
     except Exception as exc:
-        logger.exception("FC retry: persist failed", job=job, release=release)
+        logger.exception("fc_retry_persist_failed", job=job, release=release)
         _safe_rollback()
         return "errored", {**base, "error": f"persist failed: {exc}"}
     return "succeeded", {**base, "viewer_url": viewer_url, "submittal_id": submittal_id}
@@ -162,7 +162,7 @@ def _process_candidates(candidates, project_map, buckets):
         try:
             all_submittals = fetch_all_submittals(project_id)
         except Exception as exc:
-            logger.exception("FC retry: submittals fetch raised", project_id=project_id)
+            logger.exception("fc_retry_submittals_fetch_failed", project_id=project_id)
             for release_id, job, release, _ in group:
                 buckets["errored"].append({
                     "job": job, "release": release,
@@ -175,7 +175,7 @@ def _process_candidates(candidates, project_map, buckets):
                 project_id, release_id, job, release, card_id, all_submittals
             )
             buckets[bucket].append(entry)
-            logger.debug("FC retry per-release", job=job, release=release, bucket=bucket)
+            logger.debug("fc_retry_release_processed", job=job, release=release, bucket=bucket)
             if idx < len(group) - 1:
                 time.sleep(PER_RELEASE_SLEEP_SECONDS)
 
@@ -208,7 +208,7 @@ def retry_missing_fc_viewer_urls(trigger="cron"):
 
     candidates = _candidate_snapshot()
     logger.info(
-        "FC retry worker starting",
+        "fc_retry_started",
         trigger=trigger, candidates=len(candidates), lookback_days=LOOKBACK_DAYS,
     )
 
@@ -218,7 +218,7 @@ def retry_missing_fc_viewer_urls(trigger="cron"):
         try:
             company_id = get_companies_list()
         except Exception as exc:
-            logger.exception("FC retry: company lookup raised")
+            logger.exception("fc_retry_company_lookup_failed")
             company_id = None
             company_error = f"company lookup raised: {exc}"
         else:
@@ -231,7 +231,7 @@ def retry_missing_fc_viewer_urls(trigger="cron"):
             try:
                 project_map = fetch_all_projects(company_id)
             except Exception as exc:
-                logger.exception("FC retry: project listing raised")
+                logger.exception("fc_retry_project_listing_failed")
                 for _rid, job, release, _ in candidates:
                     buckets["errored"].append({
                         "job": job, "release": release,
@@ -260,7 +260,7 @@ def retry_missing_fc_viewer_urls(trigger="cron"):
     db.session.commit()
 
     logger.info(
-        "FC retry worker finished",
+        "fc_retry_finished",
         trigger=trigger, run_id=run.id, candidates=run.candidates,
         succeeded=run.succeeded, still_missing=run.still_missing,
         errored=run.errored, duration_ms=duration_ms,

--- a/app/procore/procore.py
+++ b/app/procore/procore.py
@@ -335,6 +335,14 @@ def fetch_all_submittals(project_id):
                         "fetch_all_submittals_fallback_failed", project_id=project_id
                     )
                     return []
+            # Mid-pagination failure: return what we have, but say so — a
+            # silently truncated list reads as "no matching FC submittal".
+            logger.warning(
+                "fetch_all_submittals_page_error",
+                project_id=project_id,
+                page=page,
+                count=len(all_rows),
+            )
             break
         all_rows.extend(batch)
         if len(batch) < per_page:
@@ -540,11 +548,9 @@ def _normalize_viewer_url(viewer_url):
     return f"https://app.procore.com/{viewer_url}"
 
 
-def _viewer_results_from_workflow(project_id, submittal_id, title, approver_ids):
+def _viewer_results_from_workflow(attachments, submittal_id, title, approver_ids):
     """Match workflow_data attachments to Final PDF Pack approver ids."""
     results = []
-    workflow_data = get_workflow_data(project_id, submittal_id)
-    attachments = workflow_data.get("attachments") if isinstance(workflow_data, dict) else []
     approver_set = set(approver_ids)
     for att in attachments or []:
         if not isinstance(att, dict):
@@ -563,12 +569,11 @@ def _viewer_results_from_workflow(project_id, submittal_id, title, approver_ids)
     return results
 
 
-def _viewer_results_from_workflow_fallback(project_id, submittal_id, title):
-    """When distribution metadata is missing after an FC update, take any
-    workflow attachment that looks like a Final PDF / has a viewer_url on a
-    PDF-ish name. Prefer names containing 'final'."""
-    workflow_data = get_workflow_data(project_id, submittal_id)
-    attachments = workflow_data.get("attachments") if isinstance(workflow_data, dict) else []
+def _viewer_results_from_workflow_fallback(attachments, submittal_id, title):
+    """When distribution metadata is missing after an FC update, take a
+    workflow attachment that looks like a Final PDF. Prefer names containing
+    'final'; accept other PDF-ish names. Never link attachments that are
+    neither (photos, markups) — a wrong link is worse than a gray one."""
     scored = []
     for att in attachments or []:
         if not isinstance(att, dict):
@@ -577,13 +582,12 @@ def _viewer_results_from_workflow_fallback(project_id, submittal_id, title):
         if not full:
             continue
         name = (att.get("name") or "").lower()
-        # Prefer final-pack-ish names; accept other PDFs as last resort.
         if "final" in name:
             score = 0
         elif name.endswith(".pdf") or "pdf" in name:
             score = 1
         else:
-            score = 2
+            continue
         scored.append((score, {
             "title": title,
             "submittal_id": submittal_id,
@@ -602,9 +606,10 @@ def get_final_pdf_viewers(project_id, submittals):
     List endpoints often omit or stale ``last_distributed_submittal`` after an
     FC set update (BUG-1 graying). For each match we:
       1. Read Final PDF Pack approver ids from the list payload
-      2. If missing, re-fetch the full submittal by id
-      3. Match workflow_data attachments by approver_id
-      4. If still empty, fall back to workflow PDF attachments with a viewer_url
+      2. Fetch workflow_data once; match attachments by approver_id
+      3. If unmatched (ids missing OR stale after a re-distribute), re-fetch
+         the full submittal by id and match again with the fresh ids
+      4. If still empty, fall back to final/PDF-named workflow attachments
     """
     final_results = []
 
@@ -614,10 +619,21 @@ def get_final_pdf_viewers(project_id, submittals):
         submittal_id = sub["id"]
         title = sub.get("title")
 
+        workflow_data = get_workflow_data(project_id, submittal_id)
+        attachments = (
+            workflow_data.get("attachments") if isinstance(workflow_data, dict) else []
+        )
+
         approver_ids = _final_pdf_approver_ids(sub)
-        detail = None
-        if not approver_ids:
-            # List payload incomplete / FC just re-distributed — get the detail.
+        matched = (
+            _viewer_results_from_workflow(attachments, submittal_id, title, approver_ids)
+            if approver_ids
+            else []
+        )
+
+        if not matched:
+            # List payload thin OR its approver ids are stale after an FC
+            # re-distribute — get the detail and retry with fresh ids.
             try:
                 detail = get_submittal_by_id(project_id, submittal_id)
             except Exception:
@@ -628,22 +644,22 @@ def get_final_pdf_viewers(project_id, submittals):
                 )
                 detail = None
             if isinstance(detail, dict):
-                approver_ids = _final_pdf_approver_ids(detail)
                 if detail.get("title"):
                     title = detail.get("title")
+                detail_ids = _final_pdf_approver_ids(detail)
+                if detail_ids:
+                    matched = _viewer_results_from_workflow(
+                        attachments, submittal_id, title, detail_ids
+                    )
 
-        if approver_ids:
-            matched = _viewer_results_from_workflow(
-                project_id, submittal_id, title, approver_ids
-            )
-            if matched:
-                final_results.extend(matched)
-                continue
+        if matched:
+            final_results.extend(matched)
+            continue
 
         # FC update left distribution metadata empty but attachments still have
         # viewer_urls — better a best-effort link than a permanent gray button.
         fallback = _viewer_results_from_workflow_fallback(
-            project_id, submittal_id, title
+            attachments, submittal_id, title
         )
         if fallback:
             logger.info(

--- a/backfill_fc_drawing_viewer_urls.py
+++ b/backfill_fc_drawing_viewer_urls.py
@@ -21,42 +21,19 @@ from collections import defaultdict
 from app import create_app
 from app.models import Releases, db
 from app.config import Config as cfg
+# Shared with the app + nightly retry worker so there is exactly one
+# collection code path: paginated submittal fetch, tolerant type matching.
 from app.procore.procore import (
     get_access_token,
     _request_json,
     _normalize_title,
     _identifier_matches,
+    _is_for_construction,
+    fetch_all_projects,
+    fetch_all_submittals,
+    submittals_for_release,
     get_final_pdf_viewers,
 )
-
-
-def fetch_all_projects(company_id):
-    """Fetch every Procore project in one call. Returns {job_number_str: project_id}."""
-    url = f"{cfg.PROD_PROCORE_BASE_URL}/rest/v1.1/projects?company_id={company_id}"
-    headers = {
-        "Authorization": f"Bearer {get_access_token()}",
-        "Procore-Company-Id": str(company_id),
-    }
-    projects = _request_json(url, headers=headers) or []
-    return {p["project_number"]: p["id"] for p in projects}
-
-
-def fetch_all_submittals(project_id):
-    """Fetch every submittal for a project in one call (unfiltered)."""
-    url = f"{cfg.PROD_PROCORE_BASE_URL}/rest/v1.1/projects/{project_id}/submittals"
-    headers = {"Authorization": f"Bearer {get_access_token()}"}
-    result = _request_json(url, headers=headers)
-    return result if isinstance(result, list) else []
-
-
-def submittals_for_release(all_submittals, job, release):
-    """Filter a pre-fetched submittal list for a specific job-release identifier."""
-    identifier = f"{job}-{release}".strip().lower()
-    return [
-        s for s in all_submittals
-        if _identifier_matches(identifier, _normalize_title(s.get("title", "")))
-        and s.get("type", {}).get("name") == "For Construction"
-    ]
 
 
 def run_backfill(dry_run=False, filter_job=None, commit_every=50, delay=0.25, refresh_submittal_id=False):
@@ -230,10 +207,7 @@ def run_compare(filter_job=None, delay=0.25):
         # ── 4. Compare matching per project ────────────────────────────────────
         for project_id, proj_records in groups.items():
             all_submittals = fetch_all_submittals(project_id)
-            fc_submittals = [
-                s for s in all_submittals
-                if (s.get("type") or {}).get("name") == "For Construction"
-            ]
+            fc_submittals = [s for s in all_submittals if _is_for_construction(s)]
             print(f"Project {project_id} — {len(proj_records)} release(s), {len(fc_submittals)} FC submittal(s)")
             if delay:
                 time.sleep(delay)

--- a/docs/pr-review-bug1-fc-procore-link.md
+++ b/docs/pr-review-bug1-fc-procore-link.md
@@ -262,4 +262,68 @@ Please specifically answer:
 
 ---
 
+## 12. Second-pass review findings (Claude, 2026-08-06)
+
+Findings confirmed against the code on `claude/procorel-ink-bug-review-rw52et`
+(commit `50d207e`). Every factual claim in §§2–6 checked out: the UI gray
+condition is gated on truthy `viewer_url` exactly where §10 says
+(`ReleaseNumberLink.jsx:37`, `JobsTableRow.jsx:1372`,
+`PdfVersionHistoryModal.jsx:330`); the candidate-filter widening matches
+`active_releases_filter` semantics and the `Releases` column types
+(`released` is `Date`, `last_updated_at` is `DateTime`); the cron entry,
+pagination, detail refetch, and PK-first persist are all as described.
+`pytest tests/procore/` and the full suite pass.
+
+**Checklist answers (§9):**
+
+1. **Fallback (R1): keep, with two tightenings applied in this review.**
+   (a) The detail refetch now also runs when the *list* payload has approver
+   ids that fail to match workflow attachments — previously stale ids after a
+   re-distribute skipped detail entirely and jumped straight to the name-based
+   fallback. (b) The fallback no longer accepts arbitrary attachments: only
+   `final`-named or PDF-ish names qualify; photos/markups are refused (a wrong
+   link is worse than a gray one). `workflow_data` is now fetched once per
+   submittal instead of up to twice.
+2. **Dual code path: yes — fixed.** `backfill_fc_drawing_viewer_urls.py`
+   redefined an *unpaginated* `fetch_all_submittals` plus a strict
+   `submittals_for_release` that raised `AttributeError` on string/None `type`
+   payloads. It now imports the shared paginated/tolerant versions from
+   `app.procore.procore`. No other writers of `viewer_url` exist
+   (`card_creation.py` and `/procore/add-link` both go through the shared
+   hardened path).
+3. **Persist by id: yes for the worker.** The first-attempt path
+   (`add_procore_link_to_trello_card`) still resolves by `(job, release)`
+   `.first()`, but it runs at creation time when a wrapped duplicate cannot
+   yet exist for that identifier, so left as-is; flag if a paste-time
+   collision is ever observed.
+4. **No open-redirect concern.** `viewer_url` values come from Procore API
+   responses, not user input; only path-relative values are prefixed, and a
+   protocol-relative `//host` value would still resolve under
+   `https://app.procore.com//…`.
+5. **Re-collect non-empty URLs: defer.** Agree with §3.F — a refresh feature
+   with its own staleness signal (compare `last_distributed_submittal`
+   timestamps), not a retry-worker tweak.
+6. **No regression** to identifier tightness (word-boundary
+   `_identifier_matches` unchanged, covered by tests) or FC gating
+   (`_is_for_construction` excludes DRR/GC Approval; `startswith` breadth is
+   acceptable — no colliding Procore type names in use).
+7. **Logging: procore.py events comply; the worker's did not.** Sentence-style
+   event names (`"FC retry worker starting"`, `"FC retry: persist failed"`, …)
+   pre-dated this PR but the ratchet applies to touched files — renamed to
+   structured events (`fc_retry_started`, `fc_retry_persist_failed`,
+   `fc_retry_finished`, …). Ops note: grep for `fc_retry_` after deploy, not
+   "FC retry". Also added the missing `fetch_all_submittals_page_error`
+   warning when pagination dies mid-stream — a silently truncated list
+   otherwise reads as "no matching FC submittal" (still_missing) instead of
+   an error.
+
+**Risk asks:** R5 — keep 30 days (correctness over thrift, per doc). R2 —
+the single workflow fetch per submittal (above) removes the double-fetch;
+per-project detail caps not needed at MHMW volumes.
+
+New tests: stale-list-approver-ids resolved via detail refetch; fallback
+refuses non-PDF attachments. 15 FC viewer tests total, all passing.
+
+---
+
 *Written for PR ship with Workstream 3 bug pile. Elevate to Claude with this file + the procore/fc_retry diffs as the review package.*

--- a/tests/procore/test_fc_viewer_url.py
+++ b/tests/procore/test_fc_viewer_url.py
@@ -123,7 +123,8 @@ class TestGetFinalPdfViewers:
                 ]
             },
         }
-        # Approver ids don't match — fall back to final-named PDF attachment.
+        # Approver ids don't match and detail refetch doesn't help — fall
+        # back to the final-named PDF attachment.
         wf = {
             "attachments": [
                 {
@@ -133,10 +134,58 @@ class TestGetFinalPdfViewers:
                 },
             ]
         }
-        with patch("app.procore.procore.get_workflow_data", return_value=wf):
+        with patch("app.procore.procore.get_submittal_by_id", return_value=None), \
+             patch("app.procore.procore.get_workflow_data", return_value=wf):
             results = get_final_pdf_viewers(55, [sub])
         assert len(results) >= 1
         assert results[0]["viewer_url"] == "https://app.procore.com/fallback/1"
+
+    def test_detail_refetch_when_list_approver_ids_stale(self):
+        """After an FC re-distribute the list payload can carry the OLD
+        approver ids; the detail has the fresh ones that match workflow."""
+        stale = {
+            "id": 4004,
+            "title": "410-111",
+            "last_distributed_submittal": {
+                "distributed_responses": [
+                    {"response_name": "Final PDF Pack", "submittal_approver_id": 5},
+                ]
+            },
+        }
+        detail = {
+            "id": 4004,
+            "title": "410-111",
+            "last_distributed_submittal": {
+                "distributed_responses": [
+                    {"response_name": "Final PDF Pack", "submittal_approver_id": 21},
+                ]
+            },
+        }
+        wf = {
+            "attachments": [
+                {"approver_id": 21, "name": "fc set.pdf", "viewer_url": "/v/21"},
+            ]
+        }
+        with patch("app.procore.procore.get_submittal_by_id", return_value=detail) as detail_fn, \
+             patch("app.procore.procore.get_workflow_data", return_value=wf):
+            results = get_final_pdf_viewers(55, [stale])
+        detail_fn.assert_called_once_with(55, 4004)
+        assert len(results) == 1
+        assert results[0]["viewer_url"] == "https://app.procore.com/v/21"
+        assert results[0]["approver_id"] == 21
+
+    def test_fallback_refuses_non_pdf_attachments(self):
+        """Fallback must never link arbitrary attachments (photos, markups)."""
+        thin = {"id": 5005, "title": "410-112"}
+        wf = {
+            "attachments": [
+                {"approver_id": 1, "name": "site photo.jpg", "viewer_url": "/v/photo"},
+            ]
+        }
+        with patch("app.procore.procore.get_submittal_by_id", return_value=None), \
+             patch("app.procore.procore.get_workflow_data", return_value=wf):
+            results = get_final_pdf_viewers(55, [thin])
+        assert results == []
 
 
 class TestSubmittalsForRelease:


### PR DESCRIPTION
## Summary
Refactors the Final PDF Pack viewer URL resolution pipeline to fix stale approver ID handling and tighten fallback attachment filtering. The core issue: after an FC re-distribute, the list payload can carry old approver IDs that fail to match workflow attachments, causing the fallback to incorrectly accept non-PDF attachments (photos, markups) as a last resort.

## Key Changes

**Procore submittal collection (backfill_fc_drawing_viewer_urls.py)**
- Removes duplicate `fetch_all_projects`, `fetch_all_submittals`, and `submittals_for_release` implementations
- Now imports the shared, paginated, tolerant versions from `app.procore.procore`
- Ensures a single code path for all submittal collection (backfill, nightly retry worker, card creation)

**Viewer URL resolution pipeline (app/procore/procore.py)**
- Refactors `_viewer_results_from_workflow()` and `_viewer_results_from_workflow_fallback()` to accept pre-fetched `attachments` instead of calling `get_workflow_data()` internally
- Fetches `workflow_data` once per submittal in `get_final_pdf_viewers()` and reuses it across both primary and fallback paths
- **Stale list approver IDs**: When list payload IDs fail to match workflow attachments, now triggers a detail refetch to get fresh IDs (previously skipped detail and jumped straight to fallback)
- **Fallback attachment filtering**: Fallback now refuses non-PDF attachments entirely (photos, markups); only accepts `final`-named or PDF-ish names. A wrong link is worse than a gray button
- Adds `fetch_all_submittals_page_error` warning when pagination fails mid-stream (prevents silent truncation from reading as "no matching FC submittal")

**Logging standardization (app/procore/fc_retry_worker.py, app/__init__.py)**
- Renames sentence-style event names to structured format:
  - `"FC retry worker starting"` → `"fc_retry_started"`
  - `"FC retry: persist failed"` → `"fc_retry_persist_failed"`
  - `"FC retry: final_pdf_viewers raised"` → `"fc_retry_final_pdf_fetch_failed"`
  - And 5 others (see diff for full list)
- Enables ops to grep for `fc_retry_` events consistently

**Tests (tests/procore/test_fc_viewer_url.py)**
- Adds `test_detail_refetch_when_list_approver_ids_stale()`: verifies detail refetch resolves fresh IDs after an FC re-distribute
- Adds `test_fallback_refuses_non_pdf_attachments()`: confirms fallback rejects photos/markups
- Updates existing test comment to reflect the new detail-refetch behavior

## Implementation Details
- Workflow data is now fetched exactly once per submittal, eliminating the previous double-fetch when both primary and fallback paths were attempted
- The detail refetch now runs in two scenarios: (1) list payload has no approver IDs, or (2) list payload IDs exist but fail to match any workflow attachments (stale after re-distribute)
- Fallback scoring logic simplified: `final`-named → score 0, other PDFs → score 1, non-PDFs → skip entirely (was score 2, now rejected)
- All changes are backward-compatible; no schema or API contract changes

https://claude.ai/code/session_016itb6hbojbk1sV7V8QVM9M