### PR TITLE
Align Events, DWL, and Archive pages to Job Log design system

### DIFF
--- a/docs/design/job-log-redesign/CURRENT_STYLING_PIN.md
+++ b/docs/design/job-log-redesign/CURRENT_STYLING_PIN.md
@@ -253,6 +253,27 @@ Tablet may drop BY + Released and renorm remaining widths.
 
 ---
 
+## 7b. Surfaces sharing this system
+
+The Events page and the Drafting Work Load table (Aug 2026 follow-up) reuse the
+Job Log styling wholesale rather than defining their own:
+
+| Concern | Files |
+|---------|-------|
+| Shell (canvas → `bg-surface` p-1.5 gap-1.5, no card/gradient) | `frontend/src/pages/Events.jsx`, `frontend/src/pages/DraftingWorkLoad.jsx` |
+| Lattice (`job-log-table-frame` / `job-log-table` / `job-log-table-scroll`) | `frontend/src/components/EventsList.jsx`, `DraftingWorkLoad.jsx` |
+| Header (`bg-head-bg`, `text-jl-head`, bold `text-ink`, centered, sticky) | same |
+| Bands (`jl-band-a`/`jl-band-b` zebra; DWL HOLD rows stay yellow) | `EventsList.jsx`, `frontend/src/components/TableRow.jsx` |
+| Hover (`jl-row` inset overlay) | same |
+| Type (`text-jl` body, `text-jl-2` secondary, Plex Mono for ids/dates/order #) | `EventsList.jsx`, `TableRow.jsx`, `frontend/src/components/DateCellPill.jsx` |
+| Events-in-modal chrome (surface-2 header, 14px radius, `dc-pop`) | `frontend/src/components/EventsModal.jsx` |
+
+DWL-only intentional deltas: HOLD yellow row override, DRR green Type cell,
+Draft-tab green accent, and the drag-over drop indicator (painted per-cell —
+`<tr>` borders don't render under `border-collapse: separate`).
+
+---
+
 ## 8. Non-negotiables (do not regress)
 
 1. **Print RGB** for bands, stage groups, date flags — keep screen tokens matched.

--- a/docs/design/job-log-redesign/CURRENT_STYLING_PIN.md
+++ b/docs/design/job-log-redesign/CURRENT_STYLING_PIN.md
@@ -255,15 +255,15 @@ Tablet may drop BY + Released and renorm remaining widths.
 
 ## 7b. Surfaces sharing this system
 
-The Events page and the Drafting Work Load table (Aug 2026 follow-up) reuse the
-Job Log styling wholesale rather than defining their own:
+The Events page, the Drafting Work Load table, and the Archive (Aug 2026
+follow-up) reuse the Job Log styling wholesale rather than defining their own:
 
 | Concern | Files |
 |---------|-------|
-| Shell (canvas → `bg-surface` p-1.5 gap-1.5, no card/gradient) | `frontend/src/pages/Events.jsx`, `frontend/src/pages/DraftingWorkLoad.jsx` |
-| Lattice (`job-log-table-frame` / `job-log-table` / `job-log-table-scroll`) | `frontend/src/components/EventsList.jsx`, `DraftingWorkLoad.jsx` |
+| Shell (canvas → `bg-surface` p-1.5 gap-1.5, no card/gradient) | `frontend/src/pages/Events.jsx`, `frontend/src/pages/DraftingWorkLoad.jsx`, `frontend/src/pages/Archive.jsx` |
+| Lattice (`job-log-table-frame` / `job-log-table` / `job-log-table-scroll`) | `frontend/src/components/EventsList.jsx`, `DraftingWorkLoad.jsx`, `Archive.jsx` |
 | Header (`bg-head-bg`, `text-jl-head`, bold `text-ink`, centered, sticky) | same |
-| Bands (`jl-band-a`/`jl-band-b` zebra; DWL HOLD rows stay yellow) | `EventsList.jsx`, `frontend/src/components/TableRow.jsx` |
+| Bands (`jl-band-a`/`jl-band-b` zebra; DWL HOLD rows stay yellow) | `EventsList.jsx`, `frontend/src/components/TableRow.jsx`; Archive rows band via `JobsTableRow` + its own `bandIndexById` (mostly `jl-band-done` grey by nature) |
 | Hover (`jl-row` inset overlay) | same |
 | Type (`text-jl` body, `text-jl-2` secondary, Plex Mono for ids/dates/order #) | `EventsList.jsx`, `TableRow.jsx`, `frontend/src/components/DateCellPill.jsx` |
 | Events-in-modal chrome (surface-2 header, 14px radius, `dc-pop`) | `frontend/src/components/EventsModal.jsx` |

--- a/frontend/src/components/DateCellPill.jsx
+++ b/frontend/src/components/DateCellPill.jsx
@@ -29,7 +29,7 @@ const FILL = {
 
 export default function DateCellPill({ value, tone = 'neutral', interactive = false, title, onClick }) {
     const [fill, hover] = FILL[tone] ?? FILL.neutral;
-    const cls = `inline-flex items-center justify-center min-w-[60px] rounded px-2 py-0.5 text-xs font-semibold tabular-nums leading-none transition-colors ${fill} ${interactive ? `${hover} cursor-pointer` : 'cursor-default'}`;
+    const cls = `inline-flex items-center justify-center min-w-[60px] rounded px-2 py-0.5 text-jl-2 font-mono font-semibold tabular-nums leading-none transition-colors ${fill} ${interactive ? `${hover} cursor-pointer` : 'cursor-default'}`;
     const display = value || '—';
     return interactive
         ? <button type="button" onClick={onClick} title={title} className={cls}>{display}</button>

--- a/frontend/src/components/EventsList.jsx
+++ b/frontend/src/components/EventsList.jsx
@@ -280,25 +280,27 @@ export function EventsList({
 
     return (
         <>
-            <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-                <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-600 shadow-sm overflow-hidden flex-1 min-h-0 flex flex-col">
-                    <div className="overflow-auto flex-1 min-h-0">
-                        <table className="w-full">
-                            <thead className="bg-gradient-to-r from-gray-50 to-accent-50 dark:from-slate-700 dark:to-slate-700">
+            <div className="flex-1 min-h-0 flex flex-col overflow-hidden gap-1.5">
+                {/* Lattice CSS: tokens.css .job-log-table-frame / .job-log-table (separate
+                    borders + --grid lines, per CURRENT_STYLING_PIN §3). */}
+                <div className="job-log-table-frame flex-1 min-h-0 flex flex-col">
+                    <div className="job-log-table-scroll overflow-auto flex-1 min-h-0">
+                        <table className="job-log-table">
+                            <thead className="sticky top-0 z-10">
                                 <tr>
-                                    <th className="px-6 py-4 text-left text-xs font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wider border-b border-gray-200 dark:border-slate-600">Date</th>
-                                    <th className="px-6 py-4 text-left text-xs font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wider border-b border-gray-200 dark:border-slate-600">Source</th>
-                                    <th className="px-6 py-4 text-left text-xs font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wider border-b border-gray-200 dark:border-slate-600">User</th>
-                                    <th className="px-6 py-4 text-left text-xs font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wider border-b border-gray-200 dark:border-slate-600">Identifier</th>
-                                    <th className="px-6 py-4 text-left text-xs font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wider border-b border-gray-200 dark:border-slate-600">Action</th>
-                                    <th className="px-6 py-4 text-left text-xs font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wider border-b border-gray-200 dark:border-slate-600">Payload</th>
-                                    <th className="px-6 py-4 text-left text-xs font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wider border-b border-gray-200 dark:border-slate-600">Undo</th>
+                                    <th style={{ width: '13%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Date</th>
+                                    <th style={{ width: '10%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Source</th>
+                                    <th style={{ width: '9%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">User</th>
+                                    <th style={{ width: '9%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Identifier</th>
+                                    <th style={{ width: '15%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Action</th>
+                                    <th style={{ width: '36%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Payload</th>
+                                    <th style={{ width: '8%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Undo</th>
                                 </tr>
                             </thead>
-                            <tbody className="bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-600">
+                            <tbody>
                                 {events.length === 0 ? (
                                     <tr>
-                                        <td colSpan="7" className="px-6 py-12 text-center">
+                                        <td colSpan="7" className="px-6 py-12 text-center bg-surface">
                                             <div className="text-gray-400 dark:text-slate-500 text-4xl mb-3">📭</div>
                                             <p className="text-gray-500 dark:text-slate-400 font-medium">No events found</p>
                                         </td>
@@ -306,49 +308,50 @@ export function EventsList({
                                 ) : (
                                     events.map((event, index) => {
                                         const uniqueKey = `${event.type}-${event.id}`;
+                                        // White / blue-100 zebra bands, same tokens as the Job Log.
+                                        const bandClass = index % 2 === 0 ? 'jl-band-a' : 'jl-band-b';
                                         return (
                                             <tr
                                                 key={uniqueKey}
-                                                className="hover:bg-accent-50/50 dark:hover:bg-slate-700/50 transition-colors duration-150"
-                                                style={{ animationDelay: `${index * 50}ms` }}
+                                                className={`jl-row ${bandClass}`}
                                             >
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-slate-300">
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-mono text-center text-ink-2">
                                                     {formatDateTime(event.created_at)}
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap">
-                                                    <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold ${getSourceColor(event.source)}`}>
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-center">
+                                                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-jl-2 font-semibold ${getSourceColor(event.source)}`}>
                                                         {event.source}
                                                     </span>
                                                     {isUndoEvent(event) && (
                                                         <span
-                                                            className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-700"
+                                                            className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-700"
                                                             title="Undo event"
                                                         >
                                                             ↶ undo
                                                         </span>
                                                     )}
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-slate-300">
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl text-center text-ink-2">
                                                     {event.user_name || '—'}
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-slate-300">
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-mono text-center text-ink">
                                                     {event.type === 'job'
                                                         ? `${event.job}-${event.release || 'N/A'}`
                                                         : event.submittal_id || 'N/A'
                                                     }
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-slate-100">
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-medium text-center text-ink">
                                                     {event.action}
                                                 </td>
-                                                <td className="px-6 py-4 text-sm">
+                                                <td className="px-2 py-1.5 text-jl">
                                                     {expandedPayload[uniqueKey] ? (
-                                                        <div className="space-y-2">
-                                                            <pre className="bg-gray-50 dark:bg-slate-700 p-3 rounded-lg text-xs overflow-x-auto max-w-md border border-gray-200 dark:border-slate-600 text-gray-900 dark:text-slate-200">
+                                                        <div className="space-y-1.5">
+                                                            <pre className="bg-surface-2 p-2 rounded text-jl-2 font-mono overflow-x-auto max-w-md border border-hairline text-ink">
                                                                 {formatPayload(event.payload)}
                                                             </pre>
                                                             <button
                                                                 onClick={() => togglePayload(uniqueKey)}
-                                                                className="text-xs text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300 font-medium"
+                                                                className="text-jl-2 text-brand hover:underline font-medium"
                                                             >
                                                                 ▲ Collapse
                                                             </button>
@@ -356,13 +359,13 @@ export function EventsList({
                                                     ) : (
                                                         <button
                                                             onClick={() => togglePayload(uniqueKey)}
-                                                            className="text-xs text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300 font-medium"
+                                                            className="text-jl-2 text-brand hover:underline font-medium"
                                                         >
                                                             ▼ View Payload
                                                         </button>
                                                     )}
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl text-center">
                                                     {(() => {
                                                         const { canUndo, reason } = getUndoEligibility(event);
                                                         return (
@@ -370,7 +373,7 @@ export function EventsList({
                                                                 onClick={() => canUndo && setUndoTarget(event)}
                                                                 disabled={!canUndo}
                                                                 title={canUndo ? 'Revert this change' : reason}
-                                                                className={`inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${
+                                                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-jl-2 font-semibold border transition-colors ${
                                                                     canUndo
                                                                         ? 'bg-white dark:bg-slate-700 text-accent-700 dark:text-accent-300 border-accent-300 dark:border-accent-700 hover:bg-accent-50 dark:hover:bg-slate-600 cursor-pointer'
                                                                         : 'bg-gray-50 dark:bg-slate-800 text-gray-400 dark:text-slate-500 border-gray-200 dark:border-slate-700 cursor-not-allowed'
@@ -389,12 +392,10 @@ export function EventsList({
                         </table>
                     </div>
                 </div>
-                <div className="flex items-center justify-between flex-shrink-0 pt-2">
-                    <div className="bg-accent-50 dark:bg-accent-900/30 rounded-lg px-4 py-2 border border-accent-200 dark:border-accent-700">
-                        <p className="text-sm font-semibold text-accent-700 dark:text-accent-300">
-                            Total: <span className="text-accent-900 dark:text-accent-100">{events.length}</span> events
-                        </p>
-                    </div>
+                <div className="flex items-center gap-2 text-xs font-semibold text-gray-700 dark:text-slate-200 flex-shrink-0">
+                    <span>
+                        Total: <span className="text-gray-900 dark:text-slate-100 font-bold">{events.length}</span> events
+                    </span>
                 </div>
             </div>
 

--- a/frontend/src/components/EventsModal.jsx
+++ b/frontend/src/components/EventsModal.jsx
@@ -36,22 +36,22 @@ export function EventsModal({ isOpen, onClose, title = 'Events', submittalId, jo
             onClick={onClose}
         >
             <div
-                className="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-6xl h-[85vh] flex flex-col"
+                className="bg-surface rounded-[14px] shadow-2xl w-full max-w-6xl h-[85vh] flex flex-col dc-pop"
                 onClick={(e) => e.stopPropagation()}
             >
-                <div className="bg-gradient-to-r from-accent-500 to-accent-600 px-6 py-4 rounded-t-xl flex-shrink-0">
+                <div className="bg-surface-2 border-b border-hairline px-4 py-3 rounded-t-[14px] flex-shrink-0">
                     <div className="flex items-center justify-between">
-                        <h2 className="text-xl font-bold text-white">{title}</h2>
+                        <h2 className="text-base font-bold text-ink">{title}</h2>
                         <button
                             onClick={onClose}
-                            className="text-white hover:text-gray-200 dark:hover:text-slate-200 transition-colors text-2xl font-bold leading-none"
+                            className="text-ink-3 hover:text-ink transition-colors text-2xl font-bold leading-none"
                             aria-label="Close"
                         >
                             ×
                         </button>
                     </div>
                 </div>
-                <div className="p-4 flex flex-col flex-1 min-h-0">
+                <div className="p-3 flex flex-col flex-1 min-h-0">
                     <EventsList
                         submittalId={submittalId}
                         jobFilter={jobFilter}

--- a/frontend/src/components/TableRow.jsx
+++ b/frontend/src/components/TableRow.jsx
@@ -214,9 +214,20 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
     const currentStatus = row.submittal_drafting_status ?? row['COMP. STATUS'] ?? '';
     const isHoldStatus = currentStatus === 'HOLD';
 
-    // Alternate row background colors, but override with yellow if status is HOLD
-    const baseRowBgClass = rowIndex % 2 === 0 ? 'bg-white dark:bg-slate-800' : 'bg-gray-200 dark:bg-slate-700';
-    const rowBgClass = isHoldStatus ? 'bg-yellow-200 dark:bg-yellow-900/40' : baseRowBgClass;
+    // White / blue-100 zebra bands (tokens.css jl-band-a/b, same as the Job Log),
+    // overridden with yellow if status is HOLD. The lattice uses border-collapse:
+    // separate, where <tr> backgrounds/borders don't paint — so the band class and
+    // the drag-over drop indicator both ride on every cell via rowBgClass.
+    const baseRowBgClass = rowIndex % 2 === 0 ? 'jl-band-a' : 'jl-band-b';
+    const bandClass = isHoldStatus ? 'bg-yellow-200 dark:bg-yellow-900/40' : baseRowBgClass;
+    const dragOverClass = isDragOver
+        ? `bg-blue-100 dark:bg-blue-900/40 ${dragOverHalf === 'top'
+            ? 'shadow-[inset_0_3px_0_0_#60a5fa]'
+            : dragOverHalf === 'bottom'
+                ? 'shadow-[inset_0_-3px_0_0_#60a5fa]'
+                : ''}`
+        : '';
+    const rowBgClass = isDragOver ? dragOverClass : bandClass;
 
     // Prevent drag start from protected cells
     const handleProtectedCellMouseDown = (e) => {
@@ -237,9 +248,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
     return (
         <>
             <tr
-                className={`${rowBgClass} hover:bg-gray-100 dark:hover:bg-slate-600 transition-all duration-200 border-b border-gray-300 dark:border-slate-600 ${isJumpToHighlight ? JUMP_TO_HIGHLIGHT_CLASS : ''} ${
-                    isDragOver && dragOverHalf === 'top' ? 'border-t-2 border-t-blue-400 dark:border-t-blue-300 bg-blue-50 dark:bg-blue-900/30' : ''
-                } ${isDragOver && dragOverHalf === 'bottom' ? 'border-b-2 border-b-blue-400 dark:border-b-blue-300 bg-blue-50 dark:bg-blue-900/30' : ''}`}
+                className={`jl-row ${isJumpToHighlight ? JUMP_TO_HIGHLIGHT_CLASS : ''}`}
                 data-submittal-id={submittalId}
                 onDragStart={(e) => {
                     // Only allow drag from title cell
@@ -342,7 +351,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle ${rowBgClass} border-r border-gray-300 dark:border-slate-600 text-center dwl-col-order-number`}
+                                className={`px-0.5 py-0.5 align-middle ${rowBgClass} text-center dwl-col-order-number`}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
                             >
@@ -353,7 +362,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                                     onChange={(e) => setOrderNumberValue(e.target.value)}
                                     onBlur={handleOrderNumberBlur}
                                     onKeyDown={handleOrderNumberKeyDown}
-                                    className="w-full px-0.5 py-0 text-xs border-2 border-accent-500 rounded-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 bg-white dark:bg-slate-700 font-medium text-gray-900 dark:text-slate-100"
+                                    className="w-full px-0.5 py-0 text-jl font-mono border-2 border-accent-500 rounded-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 bg-white dark:bg-slate-700 font-medium text-gray-900 dark:text-slate-100"
                                     style={{ minWidth: '30px', maxWidth: '50px' }}
                                 />
                             </td>
@@ -398,13 +407,13 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle ${rowBgClass} border-r border-gray-300 dark:border-slate-600 text-center dwl-col-order-number`}
+                                className={`px-0.5 py-0.5 align-middle ${rowBgClass} text-center dwl-col-order-number`}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
                             >
                                 <div className="flex items-center justify-center gap-1">
-                                    <div 
-                                        className={`px-0.5 py-0 text-xs border rounded-sm font-medium min-w-[20px] max-w-[50px] inline-block transition-colors ${isEditable
+                                    <div
+                                        className={`px-0.5 py-0 text-jl font-mono border rounded-sm font-medium min-w-[20px] max-w-[50px] inline-block transition-colors ${isEditable
                                             ? 'border-gray-300 dark:border-slate-500 bg-gray-50 dark:bg-slate-600 hover:bg-white dark:hover:bg-slate-500 hover:border-accent-400 cursor-text text-gray-700 dark:text-slate-200'
                                             : 'border-gray-200 dark:border-slate-600 bg-gray-100 dark:bg-slate-700 cursor-not-allowed text-gray-500 dark:text-slate-400 opacity-75'
                                             }`}
@@ -436,7 +445,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} border-r border-gray-300 dark:border-slate-600 dwl-col-notes`}
+                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} dwl-col-notes`}
                                 style={{ maxWidth: '350px' }}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
@@ -451,7 +460,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                                     multiline
                                     rows={1}
                                     placeholder="Add notes... (type @ to mention)"
-                                    className="w-full px-1 py-0.5 text-xs border-2 border-accent-500 rounded-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 resize-none shadow-sm transition-all text-center"
+                                    className="w-full px-1 py-0.5 text-jl border-2 border-accent-500 rounded-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 resize-none shadow-sm transition-all text-center"
                                 />
                             </td>
                         );
@@ -465,14 +474,14 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} border-r border-gray-300 dark:border-slate-600 dwl-col-notes`}
+                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} dwl-col-notes`}
                                 style={{ maxWidth: '350px' }}
                                 draggable={false}
                                 onClick={handleNotesFocus}
                                 onMouseDown={handleProtectedCellMouseDown}
                                 title="Click to edit notes"
                             >
-                                <div className={`px-0.5 py-0 text-xs rounded-sm border transition-all min-h-[10px] text-center ${
+                                <div className={`px-0.5 py-0 text-jl rounded-sm border transition-all min-h-[10px] text-center ${
                                     hasNotes
                                         ? 'border-gray-200 dark:border-slate-500 bg-gray-50 dark:bg-slate-600 hover:bg-white dark:hover:bg-slate-500 hover:border-accent-300 text-gray-800 dark:text-slate-200 cursor-text'
                                         : 'border-gray-200 dark:border-slate-500 bg-gray-50/50 dark:bg-slate-600/50 hover:bg-gray-100 dark:hover:bg-slate-500 hover:border-accent-300 text-gray-500 dark:text-slate-400 cursor-text'
@@ -497,7 +506,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} border-r border-gray-300 dark:border-slate-600 dwl-col-procore-status`}
+                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} dwl-col-procore-status`}
                                 style={{ maxWidth: '96px' }}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
@@ -512,7 +521,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                                                 if (!Number.isNaN(statusId)) onProcoreStatusChange(submittalId, statusId);
                                             }
                                         }}
-                                        className="w-full px-0.5 py-0.5 text-xs border border-gray-300 dark:border-slate-500 rounded text-center bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 cursor-pointer"
+                                        className="w-full px-0.5 py-0.5 text-jl border border-gray-300 dark:border-slate-500 rounded text-center bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 cursor-pointer"
                                         title="Select Procore status (updates submittal in Procore)"
                                     >
                                         <option value="">—</option>
@@ -523,7 +532,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                                         ))}
                                     </select>
                                 ) : (
-                                    <span className="text-xs text-gray-700 dark:text-slate-200">{currentProcoreStatus || '—'}</span>
+                                    <span className="text-jl text-gray-700 dark:text-slate-200">{currentProcoreStatus || '—'}</span>
                                 )}
                             </td>
                         );
@@ -537,7 +546,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} border-r border-gray-300 dark:border-slate-600 dwl-col-status`}
+                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} dwl-col-status`}
                                 style={{ maxWidth: '96px' }}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
@@ -549,7 +558,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                                             onStatusChange(submittalId, e.target.value);
                                         }
                                     }}
-                                    className="w-full px-0.5 py-0.5 text-xs border border-gray-300 dark:border-slate-500 rounded text-center bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 cursor-pointer"
+                                    className="w-full px-0.5 py-0.5 text-jl border border-gray-300 dark:border-slate-500 rounded text-center bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-600 cursor-pointer"
                                     title="Select drafting status (HOLD / NEED VIF / STARTED)"
                                 >
                                     <option value="">—</option>
@@ -571,7 +580,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} border-r border-gray-300 dark:border-slate-600 dwl-col-due-date`}
+                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} dwl-col-due-date`}
                                 style={{ maxWidth: '120px' }}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
@@ -585,7 +594,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                                         onClick={canEditDrafterFields ? () => setDueDateModalOpen(true) : undefined}
                                     />
                                 ) : (
-                                    <span className="text-xs text-gray-300 dark:text-slate-600">—</span>
+                                    <span className="text-jl font-mono text-gray-300 dark:text-slate-600">—</span>
                                 )}
                                 {canEditDrafterFields && (
                                     <DateFieldModal
@@ -626,7 +635,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} border-r border-gray-300 dark:border-slate-600 dwl-col-start-install`}
+                                className={`px-0.5 py-0.5 align-middle text-center ${rowBgClass} dwl-col-start-install`}
                                 style={{ maxWidth: '120px' }}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
@@ -640,7 +649,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                                         onClick={canEditStartInstall ? () => setStartInstallModalOpen(true) : undefined}
                                     />
                                 ) : (
-                                    <span className="text-xs text-gray-300 dark:text-slate-600">—</span>
+                                    <span className="text-jl font-mono text-gray-300 dark:text-slate-600">—</span>
                                 )}
                                 {canEditStartInstall && (
                                     <StartInstallDwlModal
@@ -673,7 +682,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-1 py-0.5 whitespace-nowrap text-xs align-middle font-medium ${cellBgClass} border-r border-gray-300 dark:border-slate-600 text-center dwl-col-name`}
+                                className={`px-1 py-0.5 whitespace-nowrap text-jl-2 align-middle font-medium ${cellBgClass} text-center dwl-col-name`}
                                 style={{ maxWidth: '280px' }}
                                 title={fullProjectName ? `${fullProjectName} — Click to view details` : ''}
                             >
@@ -709,7 +718,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-1 py-0.5 ${whitespaceClass} text-xs align-middle font-medium ${cellBgClass} border-r border-gray-300 dark:border-slate-600 text-gray-900 dark:text-slate-100 text-center dwl-col-bic`}
+                                className={`px-1 py-0.5 ${whitespaceClass} text-jl-2 align-middle font-medium ${cellBgClass} text-gray-900 dark:text-slate-100 text-center dwl-col-bic`}
                                 style={{ maxWidth: '180px' }}
                                 title={cellValue}
                             >
@@ -751,7 +760,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-1 py-0.5 whitespace-normal text-xs align-middle font-medium ${cellBgClass} border-r border-gray-300 dark:border-slate-600 text-gray-900 dark:text-slate-100 ${columnClass}`}
+                                className={`px-1 py-0.5 whitespace-normal text-jl align-middle font-medium ${cellBgClass} text-gray-900 dark:text-slate-100 ${columnClass}`}
                                 style={customStyle}
                                 title={cellValue}
                                 draggable={isDraggable}
@@ -784,7 +793,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 whitespace-nowrap text-xs align-middle font-medium ${cellBgClass} border-r border-gray-300 dark:border-slate-600 text-gray-900 dark:text-slate-100 text-center dwl-col-rel`}
+                                className={`px-0.5 py-0.5 whitespace-nowrap text-jl font-mono align-middle font-medium ${cellBgClass} text-gray-900 dark:text-slate-100 text-center dwl-col-rel`}
                                 style={{ maxWidth: '50px' }}
                                 title={cellValue}
                             >
@@ -799,7 +808,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                         return (
                             <td
                                 key={`${row.id}-${column}`}
-                                className={`px-0.5 py-0.5 whitespace-nowrap text-xs align-middle font-medium ${cellBgClass} border-r border-gray-300 dark:border-slate-600 text-center dwl-col-project-number`}
+                                className={`px-0.5 py-0.5 whitespace-nowrap text-jl font-mono align-middle font-medium ${cellBgClass} text-center dwl-col-project-number`}
                                 style={{ maxWidth: '65px' }}
                                 draggable={false}
                                 onMouseDown={handleProtectedCellMouseDown}
@@ -817,7 +826,7 @@ export function TableRow({ row, columns, formatCellValue, onOrderNumberChange, o
                     return (
                         <td
                             key={`${row.id}-${column}`}
-                            className={`px-1 py-0.5 ${whitespaceClass} text-xs align-middle font-medium ${cellBgClass} border-r border-gray-300 dark:border-slate-600 text-gray-900 dark:text-slate-100 ${customWidthClass} ${columnClass} text-center`}
+                            className={`px-1 py-0.5 ${whitespaceClass} text-jl align-middle font-medium ${cellBgClass} text-gray-900 dark:text-slate-100 ${customWidthClass} ${columnClass} text-center`}
                             style={customStyle}
                             title={cellValue}
                         >

--- a/frontend/src/pages/Archive.jsx
+++ b/frontend/src/pages/Archive.jsx
@@ -159,6 +159,23 @@ function Archive() {
         return columnOrder.filter(col => columns.includes(col));
     }, [columns]);
 
+    // Zebra band index per row, counting only rows that aren't complete — a grey
+    // (jl-band-done) row must not consume an alternation step (CURRENT_STYLING_PIN
+    // banding rule; mirrors bandIndexById in JobLogContent). On the Archive nearly
+    // every row is complete, but un-archive-eligible stragglers still zebra right.
+    const bandIndexById = useMemo(() => {
+        const map = new Map();
+        let band = 0;
+        for (const row of displayJobs) {
+            const stage = (row['Stage'] || '').toString().trim().toLowerCase();
+            const done = stage === 'complete'
+                || (row['Job Comp'] || '').toString().trim().toUpperCase() === 'X';
+            map.set(row.id, done ? -1 : band);
+            if (!done) band += 1;
+        }
+        return map;
+    }, [displayJobs]);
+
     const tableColumnCount = columnHeaders.length;
 
     const columnWidthPercents = useMemo(() => {
@@ -174,20 +191,21 @@ function Archive() {
 
     return (
         <div
-            className="w-full h-[calc(100vh_-_var(--app-chrome-h))] bg-gradient-to-br from-slate-50 via-accent-50 to-blue-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 py-2 px-2 3xl:py-4 3xl:px-6 flex flex-col"
+            className="w-full h-[calc(100vh_-_var(--app-chrome-h))] bg-canvas dark:bg-slate-900 flex flex-col"
             style={{
                 width: '100%',
                 minWidth: '100%',
-                paddingLeft: 'max(0.5rem, env(safe-area-inset-left))',
-                paddingRight: 'max(0.5rem, env(safe-area-inset-right))',
-                paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))',
+                paddingLeft: 'env(safe-area-inset-left)',
+                paddingRight: 'env(safe-area-inset-right)',
+                paddingBottom: 'env(safe-area-inset-bottom)',
             }}
         >
             <div className="max-w-full mx-auto w-full h-full flex flex-col" style={{ width: '100%' }}>
-                <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl overflow-hidden flex flex-col h-full">
+                {/* Subtle outer pad + gap between filter and table — no heavy white card (Job Log shell). */}
+                <div className="bg-surface overflow-hidden flex flex-col h-full min-h-0">
 
-                    <div className="p-2 flex flex-col flex-1 min-h-0 space-y-1.5">
-                        <div className="bg-gray-100 dark:bg-slate-700 rounded-lg p-1.5 border border-gray-200 dark:border-slate-600 flex-shrink-0 space-y-1.5">
+                    <div className="p-1.5 flex flex-col flex-1 min-h-0 gap-1.5">
+                        <div className="bg-gray-100 dark:bg-slate-700 rounded-md p-1.5 border border-gray-200/80 dark:border-slate-600 flex-shrink-0 space-y-1.5">
 
                             {/* Minimized project pills — show selected projects when collapsed */}
                             {isFilterMinimized && selectedProjectNames.length > 0 && (
@@ -324,7 +342,7 @@ function Archive() {
                         )}
 
                         {!loading && !fetchError && effectiveView === 'cards' && (
-                            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-xl shadow-sm overflow-hidden flex-1 min-h-0 flex flex-col">
+                            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-xl overflow-hidden flex-1 min-h-0 flex flex-col">
                                 <JobLogCardGrid
                                     jobs={displayJobs}
                                     search={search}
@@ -337,9 +355,11 @@ function Archive() {
                         )}
 
                         {!loading && !fetchError && effectiveView === 'table' && (
-                            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-xl shadow-sm overflow-hidden flex-1 min-h-0 flex flex-col">
+                            // Lattice CSS: tokens.css .job-log-table-frame / .job-log-table
+                            // (separate borders + --grid lines, per CURRENT_STYLING_PIN §3).
+                            <div className="job-log-table-frame flex-1 min-h-0 flex flex-col">
                                 <div className="job-log-table-scroll overflow-auto flex-1">
-                                    <table className="w-full" style={{ borderCollapse: 'collapse', tableLayout: 'fixed', width: '100%' }}>
+                                    <table className="job-log-table">
                                         <thead className="sticky top-0 z-10">
                                             <tr>
                                                 {columnHeaders.map((column) => {
@@ -349,7 +369,7 @@ function Archive() {
                                                     return (
                                                         <th
                                                             key={column}
-                                                            className={`${isReleaseNumber ? 'px-1' : 'px-2'} py-0.5 align-middle text-center text-[11px] font-bold text-gray-900 dark:text-slate-100 bg-gray-100 dark:bg-slate-700 border-r border-gray-300 dark:border-slate-600 shadow-sm`}
+                                                            className={`${isReleaseNumber ? 'px-0.5' : 'px-1'} py-1.5 text-jl-head align-middle text-center font-bold text-ink bg-head-bg leading-tight`}
                                                             style={colWidthPct != null ? { width: `${colWidthPct}%` } : undefined}
                                                         >
                                                             {displayHeader}
@@ -357,7 +377,7 @@ function Archive() {
                                                     );
                                                 })}
                                                 {isAdmin && (
-                                                    <th className="px-1 py-0.5 text-center text-xl font-bold text-gray-900 dark:text-slate-100 uppercase tracking-wider bg-gray-100 dark:bg-slate-700 border-r border-gray-300 dark:border-slate-600 shadow-sm w-8">
+                                                    <th className="px-1 py-0.5 text-center text-xl font-bold text-ink uppercase tracking-wider bg-head-bg w-8">
                                                         ⚙
                                                     </th>
                                                 )}
@@ -368,7 +388,7 @@ function Archive() {
                                                 <tr>
                                                     <td
                                                         colSpan={tableColumnCount + (isAdmin ? 1 : 0)}
-                                                        className="px-6 py-12 text-center text-gray-500 dark:text-slate-400 font-medium bg-white dark:bg-slate-800 rounded-md"
+                                                        className="px-6 py-12 text-center text-gray-500 dark:text-slate-400 font-medium bg-surface"
                                                     >
                                                         {hasJobsData
                                                             ? 'No records match the selected filters.'
@@ -386,6 +406,7 @@ function Archive() {
                                                         formatCellValue={(value, columnName) => formatCellValue(value, columnName)}
                                                         formatDate={formatDate}
                                                         rowIndex={index}
+                                                        bandIndex={bandIndexById.get(row.id) ?? index}
                                                         onDragStart={() => { }}
                                                         onDragOver={() => { }}
                                                         onDragLeave={() => { }}

--- a/frontend/src/pages/DraftingWorkLoad.jsx
+++ b/frontend/src/pages/DraftingWorkLoad.jsx
@@ -282,7 +282,7 @@ function DraftingWorkLoad() {
         <>
             <style>{columnWidthStyles}</style>
             <div
-                className="w-full h-[calc(100vh_-_var(--app-chrome-h))] flex flex-col bg-gradient-to-br from-slate-50 via-accent-50 to-blue-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900"
+                className="w-full h-[calc(100vh_-_var(--app-chrome-h))] flex flex-col bg-canvas dark:bg-slate-900"
                 style={{
                     width: '100%',
                     minWidth: '100%',
@@ -291,11 +291,12 @@ function DraftingWorkLoad() {
                     paddingBottom: 'env(safe-area-inset-bottom)',
                 }}
             >
-                <div className="flex-1 min-h-0 max-w-full mx-auto w-full py-2 px-2 flex flex-col" style={{ width: '100%' }}>
-                    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl overflow-hidden flex flex-col flex-1 min-h-0">
+                <div className="flex-1 min-h-0 max-w-full mx-auto w-full flex flex-col" style={{ width: '100%' }}>
+                    {/* Subtle outer pad + gap between filter and table — no heavy white card (Job Log shell). */}
+                    <div className="bg-surface overflow-hidden flex flex-col flex-1 min-h-0 p-1.5 gap-1.5">
                         {/* Actions + Filters - fixed, do not scroll */}
-                        <div className="flex-shrink-0 p-2">
-                            <div className="bg-gray-100 dark:bg-slate-700 rounded-lg p-1.5 border border-gray-200 dark:border-slate-600 flex-shrink-0 space-y-1.5">
+                        <div className="flex-shrink-0">
+                            <div className="bg-gray-100 dark:bg-slate-700 rounded-md p-1.5 border border-gray-200/80 dark:border-slate-600 flex-shrink-0 space-y-1.5">
                                 {/* Row 2: view mode + primary CTA + Actions + Open/Draft + priority filters */}
                                 <div className="flex items-center gap-1.5 flex-wrap">
                                     <ViewToggle value={viewMode} onChange={setViewMode} accent={isDraftTab ? 'green' : 'blue'} />
@@ -448,7 +449,7 @@ function DraftingWorkLoad() {
                         )}
 
                         {fetchError && !loading && (
-                            <div className="flex-shrink-0 p-2">
+                            <div className="flex-shrink-0">
                                 <AlertMessage
                                     type="error"
                                     title="Unable to load Drafting Work Load data"
@@ -458,7 +459,7 @@ function DraftingWorkLoad() {
                         )}
 
                         {resortError && (
-                            <div className="flex-shrink-0 p-2">
+                            <div className="flex-shrink-0">
                                 <AlertMessage type="error" title="Resort failed" message={resortError} />
                             </div>
                         )}
@@ -475,14 +476,16 @@ function DraftingWorkLoad() {
                         )}
 
                         {!loading && !fetchError && effectiveView === 'table' && (
-                            <div className="flex-1 min-h-0 flex flex-col border border-gray-200 dark:border-slate-600 rounded-xl overflow-hidden bg-white dark:bg-slate-800 min-w-0">
+                            // Lattice CSS: tokens.css .job-log-table-frame / .job-log-table
+                            // (separate borders + --grid lines, per CURRENT_STYLING_PIN §3).
+                            <div className="job-log-table-frame flex-1 min-h-0 flex flex-col min-w-0">
                                 <div
                                     ref={scrollContainerRef}
-                                    className="dwl-table-scroll flex-1 min-h-0 overflow-x-hidden"
+                                    className="dwl-table-scroll job-log-table-scroll flex-1 min-h-0 overflow-x-hidden"
                                     style={{ overflowY: 'auto' }}
                                 >
-                                    <table className="w-full" style={{ borderCollapse: 'collapse', width: '100%', tableLayout: 'fixed' }}>
-                                        <thead className="sticky top-0 z-10 bg-gray-100 dark:bg-slate-700 shadow-sm">
+                                    <table className="job-log-table">
+                                        <thead className="sticky top-0 z-10">
                                             <tr>
                                                 {visibleColumns.map((column) => {
                                                     const isOrderNumber = column === 'ORDER #';
@@ -564,7 +567,7 @@ function DraftingWorkLoad() {
                                                         return (
                                                             <th
                                                                 key={column}
-                                                                className={`${headerPaddingClass} text-center text-xs font-bold text-gray-900 dark:text-slate-100 uppercase tracking-wider bg-gray-100 dark:bg-slate-700 border-r border-gray-300 dark:border-slate-600 ${columnClass}`}
+                                                                className={`${headerPaddingClass} text-center text-jl-head font-bold text-ink bg-head-bg leading-tight ${columnClass}`}
                                                                 style={headerStyle}
                                                             >
                                                                 <ColumnHeaderFilter
@@ -590,7 +593,7 @@ function DraftingWorkLoad() {
                                                         return (
                                                             <th
                                                                 key={column}
-                                                                className={`${headerPaddingClass} text-center text-xs font-bold text-gray-900 dark:text-slate-100 uppercase tracking-wider bg-gray-100 dark:bg-slate-700 border-r border-gray-300 dark:border-slate-600 ${columnClass}`}
+                                                                className={`${headerPaddingClass} text-center text-jl-head font-bold text-ink bg-head-bg leading-tight ${columnClass}`}
                                                                 style={headerStyle}
                                                             >
                                                                 <button
@@ -615,7 +618,7 @@ function DraftingWorkLoad() {
                                                     return (
                                                         <th
                                                             key={column}
-                                                            className={`${headerPaddingClass} text-center text-xs font-bold text-gray-900 dark:text-slate-100 uppercase tracking-wider bg-gray-100 dark:bg-slate-700 border-r border-gray-300 dark:border-slate-600 ${columnClass}`}
+                                                            className={`${headerPaddingClass} text-center text-jl-head font-bold text-ink bg-head-bg leading-tight ${columnClass}`}
                                                             style={headerStyle}
                                                         >
                                                             {column}
@@ -629,7 +632,7 @@ function DraftingWorkLoad() {
                                                 <tr>
                                                     <td
                                                         colSpan={tableColumnCount}
-                                                        className="px-6 py-12 text-center text-gray-500 dark:text-slate-400 font-medium bg-white dark:bg-slate-800 rounded-md"
+                                                        className="px-6 py-12 text-center text-gray-500 dark:text-slate-400 font-medium bg-surface"
                                                     >
                                                         No records match the selected filters.
                                                     </td>

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -88,140 +88,130 @@ function Events() {
         setSearchParams(newParams);
     };
 
+    // Compact toolbar controls, matching the Job Log filter chrome (CURRENT_STYLING_PIN §5).
+    const selectClass = "px-2 py-0.5 text-xs border border-gray-300 dark:border-slate-500 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-slate-600 text-gray-900 dark:text-slate-100";
+    const labelClass = "text-xs font-semibold text-gray-700 dark:text-slate-200 whitespace-nowrap";
+
     return (
-        <div className="w-full h-full flex flex-col bg-gradient-to-br from-slate-50 via-accent-50 to-blue-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900" style={{ width: '100%', minWidth: '100%' }}>
-            <div className="flex-1 min-h-0 max-w-full mx-auto w-full py-2 px-2 flex flex-col" style={{ width: '100%' }}>
-                <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl overflow-hidden flex flex-col flex-1 min-h-0">
-                    {/* Title bar - matches DWL / Job Log */}
-                    <div className="flex-shrink-0 px-4 py-3 bg-gradient-to-r from-accent-500 to-accent-600">
-                        <div className="flex items-center justify-between">
-                            <h1 className="text-3xl font-bold text-white">Job Events</h1>
-                        </div>
-                    </div>
-
-                    <div className="p-2 flex flex-col flex-1 min-h-0 space-y-2">
-                        <div className="bg-gradient-to-r from-gray-50 to-accent-50 dark:from-slate-700 dark:to-slate-700 rounded-xl p-3 border border-gray-200 dark:border-slate-600 shadow-sm flex-shrink-0">
-                            <div className="flex flex-wrap gap-3 items-end">
-                                <div className="flex-1 min-w-[200px]">
-                                    <label className="block text-sm font-semibold text-gray-700 dark:text-slate-200 mb-2">
-                                        📅 Filter by Date
-                                    </label>
-                                    <select
-                                        value={selectedDate}
-                                        onChange={(e) => setSelectedDate(e.target.value)}
-                                        className="w-full px-4 py-2.5 border border-gray-300 dark:border-slate-500 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent bg-white dark:bg-slate-600 dark:text-slate-100 shadow-sm transition-all"
-                                    >
-                                        <option value="">All Dates</option>
-                                        {availableDates.map(date => (
-                                            <option key={date} value={date}>{date}</option>
-                                        ))}
-                                    </select>
-                                </div>
-                                <div className="flex-1 min-w-[200px]">
-                                    <label className="block text-sm font-semibold text-gray-700 dark:text-slate-200 mb-2">
-                                        🔗 Filter by Source
-                                    </label>
-                                    <select
-                                        value={selectedSource}
-                                        onChange={(e) => setSelectedSource(e.target.value)}
-                                        className="w-full px-4 py-2.5 border border-gray-300 dark:border-slate-500 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent bg-white dark:bg-slate-600 dark:text-slate-100 shadow-sm transition-all"
-                                    >
-                                        <option value="">All Sources</option>
-                                        {availableSources.map(source => (
-                                            <option key={source} value={source}>{source}</option>
-                                        ))}
-                                    </select>
-                                </div>
-                                <div className="flex-1 min-w-[200px]">
-                                    <label className="block text-sm font-semibold text-gray-700 dark:text-slate-200 mb-2">
-                                        👤 Filter by User
-                                    </label>
-                                    <select
-                                        value={selectedUser}
-                                        onChange={(e) => setSelectedUser(e.target.value)}
-                                        className="w-full px-4 py-2.5 border border-gray-300 dark:border-slate-500 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent bg-white dark:bg-slate-600 dark:text-slate-100 shadow-sm transition-all"
-                                    >
-                                        <option value="">All Users</option>
-                                        {availableUsers.map(user => (
-                                            <option key={user.id} value={user.id}>{user.name}</option>
-                                        ))}
-                                    </select>
-                                </div>
-                                <div className="min-w-[150px]">
-                                    <label className="block text-sm font-semibold text-gray-700 dark:text-slate-200 mb-2">
-                                        🔢 Results Limit
-                                    </label>
-                                    <input
-                                        type="number"
-                                        min="1"
-                                        max="200"
-                                        value={limit}
-                                        onChange={(e) => {
-                                            const value = e.target.value;
-                                            if (value === '') {
-                                                setLimit(50);
-                                            } else {
-                                                const parsed = parseInt(value, 10);
-                                                if (!isNaN(parsed)) {
-                                                    setLimit(Math.max(1, Math.min(200, parsed)));
-                                                }
-                                            }
-                                        }}
-                                        className="w-full px-4 py-2.5 border border-gray-300 dark:border-slate-500 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent bg-white dark:bg-slate-600 dark:text-slate-100 shadow-sm transition-all"
-                                    />
-                                </div>
-                                <div className="flex items-end">
-                                    <button
-                                        onClick={resetFilters}
-                                        className="px-6 py-2.5 bg-gray-200 dark:bg-slate-600 hover:bg-gray-300 dark:hover:bg-slate-500 text-gray-700 dark:text-slate-200 font-semibold rounded-lg text-sm transition-colors duration-150 shadow-sm hover:shadow border border-gray-300 dark:border-slate-500 flex items-center gap-2"
-                                    >
-                                        <span>🔄</span>
-                                        Reset Filters
-                                    </button>
-                                </div>
+        <div className="w-full h-full flex flex-col bg-canvas dark:bg-slate-900" style={{ width: '100%', minWidth: '100%' }}>
+            <div className="flex-1 min-h-0 max-w-full mx-auto w-full flex flex-col" style={{ width: '100%' }}>
+                {/* Subtle outer pad + gap between filter and table — no heavy white card (Job Log shell). */}
+                <div className="bg-surface overflow-hidden flex flex-col flex-1 min-h-0 p-1.5 gap-1.5">
+                    <div className="bg-gray-100 dark:bg-slate-700 p-1.5 rounded-md border border-gray-200/80 dark:border-slate-600 flex-shrink-0 space-y-1.5">
+                        <div className="flex items-center gap-2 flex-wrap min-w-0">
+                            <h1 className="text-sm font-bold text-ink whitespace-nowrap pr-1">Job Events</h1>
+                            <div className="flex items-center gap-1.5">
+                                <label className={labelClass}>Date:</label>
+                                <select
+                                    value={selectedDate}
+                                    onChange={(e) => setSelectedDate(e.target.value)}
+                                    className={selectClass}
+                                >
+                                    <option value="">All Dates</option>
+                                    {availableDates.map(date => (
+                                        <option key={date} value={date}>{date}</option>
+                                    ))}
+                                </select>
                             </div>
-                            {submittalId && (
-                                <div className="mt-2 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg px-3 py-2 flex items-center justify-between">
-                                    <div className="flex items-center gap-2">
-                                        <span className="text-blue-700 dark:text-blue-300 font-semibold">Filtered by Submittal ID:</span>
-                                        <span className="text-blue-900 dark:text-blue-100 font-mono text-sm">{submittalId}</span>
-                                    </div>
-                                    <button
-                                        onClick={clearSubmittalIdFilter}
-                                        className="text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 font-medium text-sm underline"
-                                    >
-                                        Clear
-                                    </button>
-                                </div>
-                            )}
-                            {(jobFilter || releaseFilter) && (
-                                <div className="mt-2 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg px-3 py-2 flex items-center justify-between">
-                                    <div className="flex items-center gap-2">
-                                        <span className="text-green-700 dark:text-green-300 font-semibold">Filtered by Job:</span>
-                                        <span className="text-green-900 dark:text-green-100 font-mono text-sm">
-                                            {jobFilter}{releaseFilter ? `-${releaseFilter}` : ''}
-                                        </span>
-                                    </div>
-                                    <button
-                                        onClick={clearJobReleaseFilter}
-                                        className="text-green-700 dark:text-green-300 hover:text-green-900 dark:hover:text-green-100 font-medium text-sm underline"
-                                    >
-                                        Clear
-                                    </button>
-                                </div>
-                            )}
+                            <div className="flex items-center gap-1.5">
+                                <label className={labelClass}>Source:</label>
+                                <select
+                                    value={selectedSource}
+                                    onChange={(e) => setSelectedSource(e.target.value)}
+                                    className={selectClass}
+                                >
+                                    <option value="">All Sources</option>
+                                    {availableSources.map(source => (
+                                        <option key={source} value={source}>{source}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div className="flex items-center gap-1.5">
+                                <label className={labelClass}>User:</label>
+                                <select
+                                    value={selectedUser}
+                                    onChange={(e) => setSelectedUser(e.target.value)}
+                                    className={selectClass}
+                                >
+                                    <option value="">All Users</option>
+                                    {availableUsers.map(user => (
+                                        <option key={user.id} value={user.id}>{user.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div className="flex items-center gap-1.5">
+                                <label className={labelClass}>Limit:</label>
+                                <input
+                                    type="number"
+                                    min="1"
+                                    max="200"
+                                    value={limit}
+                                    onChange={(e) => {
+                                        const value = e.target.value;
+                                        if (value === '') {
+                                            setLimit(50);
+                                        } else {
+                                            const parsed = parseInt(value, 10);
+                                            if (!isNaN(parsed)) {
+                                                setLimit(Math.max(1, Math.min(200, parsed)));
+                                            }
+                                        }
+                                    }}
+                                    className={`${selectClass} w-16 font-mono`}
+                                />
+                            </div>
+                            <button
+                                onClick={resetFilters}
+                                className="text-xs text-blue-600 dark:text-blue-400 underline hover:no-underline whitespace-nowrap"
+                                title="Clear date, source, user, limit, and any submittal/job filters."
+                            >
+                                Reset
+                            </button>
                         </div>
-
-                        <EventsList
-                            submittalId={submittalId}
-                            jobFilter={jobFilter}
-                            releaseFilter={releaseFilter}
-                            selectedDate={selectedDate}
-                            selectedSource={selectedSource}
-                            selectedUser={selectedUser}
-                            limit={limit}
-                        />
+                        {(submittalId || jobFilter || releaseFilter) && (
+                            <div className="flex items-center gap-1.5 flex-wrap border-t border-gray-200 dark:border-slate-600 pt-1.5">
+                                <span className="text-xs font-semibold text-gray-500 dark:text-slate-400 whitespace-nowrap">Active filters:</span>
+                                {submittalId && (
+                                    <span className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300 text-xs font-medium">
+                                        <span className="whitespace-nowrap">Submittal: <span className="font-mono">{submittalId}</span></span>
+                                        <button
+                                            type="button"
+                                            onClick={clearSubmittalIdFilter}
+                                            className="flex items-center justify-center w-4 h-4 rounded-full leading-none text-blue-500 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800 hover:text-blue-800 dark:hover:text-blue-100 transition-colors"
+                                            aria-label="Remove submittal filter"
+                                            title="Remove submittal filter"
+                                        >
+                                            ×
+                                        </button>
+                                    </span>
+                                )}
+                                {(jobFilter || releaseFilter) && (
+                                    <span className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300 text-xs font-medium">
+                                        <span className="whitespace-nowrap">Job: <span className="font-mono">{jobFilter}{releaseFilter ? `-${releaseFilter}` : ''}</span></span>
+                                        <button
+                                            type="button"
+                                            onClick={clearJobReleaseFilter}
+                                            className="flex items-center justify-center w-4 h-4 rounded-full leading-none text-blue-500 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800 hover:text-blue-800 dark:hover:text-blue-100 transition-colors"
+                                            aria-label="Remove job filter"
+                                            title="Remove job filter"
+                                        >
+                                            ×
+                                        </button>
+                                    </span>
+                                )}
+                            </div>
+                        )}
                     </div>
+
+                    <EventsList
+                        submittalId={submittalId}
+                        jobFilter={jobFilter}
+                        releaseFilter={releaseFilter}
+                        selectedDate={selectedDate}
+                        selectedSource={selectedSource}
+                        selectedUser={selectedUser}
+                        limit={limit}
+                    />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
Refactors the Events page, Drafting Work Load (DWL), and Archive pages to adopt the Job Log's unified design system (Lattice CSS tokens and shell layout), eliminating redundant gradient backgrounds, card shadows, and custom styling in favor of consistent, maintainable component reuse.

## Key Changes

### Events Page (`frontend/src/pages/Events.jsx`)
- Replaced gradient background (`from-slate-50 via-accent-50 to-blue-50`) with `bg-canvas` token
- Removed heavy white card with rounded corners and shadow; now uses `bg-surface` with subtle `p-1.5 gap-1.5` padding
- Refactored filter toolbar to compact horizontal layout matching Job Log chrome (§5 in CURRENT_STYLING_PIN)
  - Extracted `selectClass` and `labelClass` tokens for consistent form styling
  - Converted stacked filter sections to inline flex layout with smaller padding/gaps
  - Simplified "Reset Filters" button to text-only underline style
- Consolidated active filter badges (Submittal ID, Job) into a single row with close buttons (×) instead of separate colored boxes
- Removed emoji icons from filter labels for cleaner appearance

### EventsList Component (`frontend/src/components/EventsList.jsx`)
- Adopted Lattice CSS table classes: `job-log-table-frame`, `job-log-table-scroll`, `job-log-table`
- Replaced custom header styling with Job Log tokens: `bg-head-bg`, `text-jl-head`, `text-ink`, centered alignment
- Added explicit column widths (13%, 10%, 9%, 9%, 15%, 36%, 8%) for stable layout
- Implemented zebra banding via `jl-band-a`/`jl-band-b` classes (white/blue-100 alternation)
- Updated row styling to use `jl-row` class with hover inset overlay
- Changed cell padding from `px-6 py-4` to `px-2 py-1.5` for compact density
- Applied `text-jl` (body) and `text-jl-2` (secondary) type tokens; dates/IDs in `font-mono`
- Removed custom source badge styling; now uses consistent pill format with smaller padding

### TableRow Component (`frontend/src/components/TableRow.jsx`)
- Replaced hardcoded row background logic with `jl-band-a`/`jl-band-b` tokens
- Preserved HOLD status yellow override (`bg-yellow-200 dark:bg-yellow-900/40`)
- Refactored drag-over drop indicator to paint via inset box-shadow on cells (since `border-collapse: separate` prevents `<tr>` borders from rendering)
- Removed per-cell `border-r` classes (grid lines now handled by Lattice CSS)
- Updated order number and notes cell padding to `px-0.5 py-0.5`
- Applied `text-jl` token to order number input for consistent typography

### DraftingWorkLoad Page (`frontend/src/pages/DraftingWorkLoad.jsx`)
- Replaced gradient background with `bg-canvas` token
- Removed white card shell; now uses `bg-surface` with `p-1.5 gap-1.5` layout
- Updated filter section to use `bg-gray-100 dark:bg-slate-700` with `rounded-md` (not `rounded-lg`)
- Removed padding from filter container (now handled by outer gap)

### Archive Page (`frontend/src/pages/Archive.jsx`)
- Replaced gradient background with `bg-canvas` token
- Removed white card shell; now uses `bg-surface` with `p-1.5 gap-1.5` layout
- Updated filter section styling to match DWL
- Added `bandIndexById` memoized map to track zebra band index per row, skipping "complete" rows (grey `jl-band-done`) so alternation is not consumed by finished jobs
- Adopted Lattice CSS table classes for table view

### EventsModal Component (`frontend/src/components/EventsModal

https://claude.ai/code/session_01NWr3UGu7tTnwwDrmovUqmA