### PR TITLE
Backup infrastructure: proven offsite Postgres backups to R2

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -148,6 +148,24 @@ class Config:
             os.path.dirname(PDF_STORAGE_ROOT.rstrip("/")), "photos"
         )
 
+    # Supplier-order email attachments and ingested GC lookahead PDFs. Both were
+    # read by their features but never defined here, so config.get() returned
+    # None and they fell back to <repo>/app/storage/... — inside the deployed
+    # code tree, which is wiped on every deploy. Derive them from the PDF root
+    # like PHOTO_STORAGE_ROOT above so one mounted disk implies all its
+    # children and a forgotten env var cannot route data onto ephemeral disk.
+    MATERIAL_ORDER_STORAGE_ROOT = os.environ.get("MATERIAL_ORDER_STORAGE_ROOT")
+    if not MATERIAL_ORDER_STORAGE_ROOT and PDF_STORAGE_ROOT:
+        MATERIAL_ORDER_STORAGE_ROOT = os.path.join(
+            os.path.dirname(PDF_STORAGE_ROOT.rstrip("/")), "order_attachments"
+        )
+
+    LOOKAHEAD_PDF_STORAGE_ROOT = os.environ.get("LOOKAHEAD_PDF_STORAGE_ROOT")
+    if not LOOKAHEAD_PDF_STORAGE_ROOT and PDF_STORAGE_ROOT:
+        LOOKAHEAD_PDF_STORAGE_ROOT = os.path.join(
+            os.path.dirname(PDF_STORAGE_ROOT.rstrip("/")), "lookahead"
+        )
+
     # Sunbelt rental report discrepancy thresholds. A rental is flagged a
     # cost/duration outlier once accrued cost (weeks on rent * week_rate) reaches
     # SUNBELT_COST_OUTLIER_USD, or it has been on rent SUNBELT_DURATION_OUTLIER_DAYS.

--- a/docs/backup-and-dr-runbook.md
+++ b/docs/backup-and-dr-runbook.md
@@ -1,0 +1,322 @@
+# Backup & Disaster-Recovery Runbook
+
+Status: **proposed**. Companion design doc:
+[`data-architecture.md`](./data-architecture.md).
+
+This is the operational half: exact procedures for backing up and restoring the
+database and file assets, recovery-objective targets, and a repeatable
+backup/recovery **test plan**. It assumes the object store from the design doc is
+**Cloudflare R2** (`r2://milehigh-data/`, S3-compatible) — substitute any
+S3-compatible bucket by swapping the endpoint.
+
+> ⚠️ **Nothing in here has been provisioned yet.** Render's managed backups,
+> persistent-disk mounts, and any scheduled job are configured in the Render
+> dashboard, which is outside this repo. Treat the "Render dashboard" steps as a
+> checklist for a human with dashboard access.
+
+---
+
+## 0. Recovery objectives
+
+Confirm these; they drive every schedule below.
+
+| Objective | Target | Hard floor |
+|---|---|---|
+| **RPO** — max acceptable data loss | ~5 min (PITR) | 24 h (nightly dump) |
+| **RTO** — max time to full restore | < 2 h | < 1 business day |
+
+Rationale: the operational DB (`releases`, `submittals`, events, outbox) is the
+crown jewel; a day's loss of job-log edits would be painful but recoverable from
+Trello/Procore/human memory, so 24 h is the floor and PITR pulls the real target
+down to minutes. Blob assets (PDFs/photos) are not reconstructable, so once on
+R2 their RPO equals the write (near-zero).
+
+---
+
+## 1. What we protect
+
+| Asset | Where it lives | Backup mechanism | Priority |
+|---|---|---|---|
+| **Postgres** (all app + lake-bronze data) | Render managed PG per env | Managed PITR **+** `pg_dump → R2` | P0 |
+| **Blob assets** (PDF/photo/attachment) | `*_STORAGE_ROOT` (disk) → R2 | Persistent disk + R2 (store of record) | P1 |
+| **Render service config** | Render dashboard only | `render.yaml` in git (to adopt) | P1 |
+| **Secrets / env vars** | Render env only | Access-controlled inventory + vault export | P1 |
+| **Source code** | GitHub | Clones + optional mirror to R2 | P2 |
+| **App logs** | `logs/app.log` + stdout | Ship stdout to a log sink (existing) | P3 |
+
+---
+
+## 2. Database backups
+
+### 2.1 Layer 1 — Render managed PITR (primary)
+
+**One-time, in the Render dashboard**, for the production Postgres instance (and
+sandbox if you want it protected):
+
+1. Ensure the instance is on a **paid plan** that includes point-in-time recovery
+   / automated backups (free-tier instances do not).
+2. Confirm the backup retention window shown in the dashboard meets §0 (e.g. 7
+   days PITR).
+3. Record, in this file under §7, the exact plan and retention window in force.
+
+Recovery from this layer is a dashboard operation ("restore to a point in time"),
+which provisions a **new** database. See §5.1.
+
+### 2.2 Layer 2 — logical `pg_dump` to R2 (offsite, portable)
+
+This is defense-in-depth: a self-contained logical dump that lives outside
+Render and can be restored anywhere. It reuses the exact dump flags already
+proven in `migrations/copy_prod_to_sandbox.sh` (`-Fc --no-owner --no-acl`).
+
+**Manual dump + upload** (what the scheduled job automates):
+
+```bash
+# Requires: pg_dump (v16+ to match Render PG), awscli or rclone configured for R2.
+# DATABASE_URL / PRODUCTION_DATABASE_URL comes from the Render env or your .env.
+STAMP=$(date -u +%Y-%m-%dT%H%MZ)
+OUT="/tmp/milehigh-prod-${STAMP}.dump"
+
+pg_dump --no-owner --no-acl -Fc "$PRODUCTION_DATABASE_URL" -f "$OUT"
+
+# Upload to R2 (S3-compatible endpoint). Example with awscli:
+aws s3 cp "$OUT" \
+  "s3://milehigh-data/backups/postgres/prod/$(date -u +%Y/%m/%d)/$(basename "$OUT")" \
+  --endpoint-url "$R2_ENDPOINT"
+
+rm -f "$OUT"          # never leave dumps (they contain all data) on the box
+```
+
+**Do**: mask credentials in any logs (log the DB host, never the URI — same rule
+as `app/__init__.py`). **Never** print `$PRODUCTION_DATABASE_URL`.
+
+**Where to schedule it** (pick one):
+
+- **Render Cron Job service** (recommended) — a separate Render "Cron Job" that
+  runs the script daily. Keeps it off the web dyno and independent of app health.
+- **APScheduler in-process** — technically possible (the app already runs
+  APScheduler), but a backup should not depend on the web service being healthy,
+  so a separate cron is better.
+- **External scheduler** (GitHub Actions on a schedule) — works, but then the
+  prod DB URL must be a CI secret; acceptable if the Render cron option is
+  unavailable.
+
+**Retention (R2 lifecycle rules on the `backups/postgres/` prefix):**
+
+| Tier | Keep |
+|---|---|
+| Daily | 14 days |
+| Weekly (Sunday) | 8 weeks |
+| Monthly (1st) | 12 months |
+| Procore-exit / annual snapshot | indefinite, **object-lock** (immutable) |
+
+Enable **bucket versioning** and, for the monthly/annual tier, **object-lock** so
+a compromised credential cannot delete history.
+
+### 2.3 Verifying a dump without restoring
+
+A dump that won't list is worthless. The cron should assert the dump is readable
+before it uploads:
+
+```bash
+pg_restore --list "$OUT" > /dev/null && echo "dump OK" || { echo "CORRUPT DUMP"; exit 1; }
+```
+
+---
+
+## 3. Blob-asset backups
+
+Blobs are the PDFs, photos, and material-order attachments written under
+`PDF_STORAGE_ROOT` / `PHOTO_STORAGE_ROOT` / `MATERIAL_ORDER_STORAGE_ROOT`.
+
+**Preferred end state (design doc §2.2):** the app writes blobs directly to R2
+via the storage swap-points, so they are *already* backed up (versioned, offsite).
+No separate blob backup job needed.
+
+**Until that migration lands**, if blobs live on a mounted Render persistent
+disk, back the disk up nightly:
+
+```bash
+# On a box with the disk mounted at /var/data:
+STAMP=$(date -u +%Y-%m-%dT%H%MZ)
+tar -C /var/data -cf - pdfs photos order-attachments \
+  | zstd -q -o "/tmp/blobs-${STAMP}.tar.zst"
+aws s3 cp "/tmp/blobs-${STAMP}.tar.zst" \
+  "s3://milehigh-data/backups/disk/prod/$(date -u +%Y/%m/%d)/blobs-${STAMP}.tar.zst" \
+  --endpoint-url "$R2_ENDPOINT"
+rm -f "/tmp/blobs-${STAMP}.tar.zst"
+```
+
+Retention: mirror the DB daily/weekly tiers (14 days / 8 weeks). Blobs are
+append-mostly and content-addressed (attachments are sha256-keyed), so an
+incremental `aws s3 sync` of the disk into `assets/` is a cheaper alternative to
+tarballs once volume grows.
+
+> **Consistency note:** DB rows are the index into the blobs. When you back up,
+> the dump and the blob copy should be close in time; on restore, a blob
+> referenced by a row must exist. The restore drill (§6) checks for dangling
+> references.
+
+---
+
+## 4. Config, secrets, and code (see design doc §6)
+
+- **`render.yaml`** — adopt an Infrastructure-as-Code Blueprint so the service,
+  disk mount, and cron are in git. Until then, keep a manual export of the
+  service settings attached to this runbook.
+- **Secrets inventory** — maintain a names-only checklist of required env vars per
+  environment (`PRODUCTION_DATABASE_URL`, `SANDBOX_DATABASE_URL`, Procore/Trello/
+  Graph/Anthropic/Recall creds, `R2_ENDPOINT` + access keys, `*_STORAGE_ROOT`).
+  Never commit values. Hold an encrypted vault export off-platform.
+- **Code mirror** — optional weekly `git clone --mirror` bundle to
+  `r2://milehigh-data/backups/code/`, or a mirror to a second git host.
+
+---
+
+## 5. Recovery procedures
+
+### 5.1 Restore the database from Render PITR (fastest, in-Render)
+
+1. Render dashboard → the Postgres instance → **Recovery / Restore** → pick the
+   timestamp (just before the incident).
+2. Render provisions a **new** database instance with a new connection string.
+3. Update the affected environment's `*_DATABASE_URL` env var to the new instance
+   and redeploy (or repoint), OR promote per Render's flow.
+4. Validate with §5.3.
+
+Use this for accidental deletes, bad migrations, or corruption where Render itself
+is healthy. RTO: typically well under an hour.
+
+### 5.2 Restore the database from an R2 `pg_dump` (portable, out-of-Render)
+
+Use when you need a copy outside Render, when PITR window has passed, or during a
+Render-wide outage (restore into any Postgres).
+
+```bash
+# 1. Fetch the chosen dump from R2
+aws s3 cp "s3://milehigh-data/backups/postgres/prod/2026/07/23/milehigh-prod-2026-07-23T0700Z.dump" \
+  /tmp/restore.dump --endpoint-url "$R2_ENDPOINT"
+
+# 2. Sanity-check it lists
+pg_restore --list /tmp/restore.dump | head
+
+# 3. Restore into the TARGET database (a fresh/empty one, or a wiped sandbox).
+#    --clean --if-exists lets it replace objects; drop this on a truly empty DB.
+pg_restore --no-owner --no-acl --clean --if-exists -d "$TARGET_DATABASE_URL" /tmp/restore.dump
+
+# 4. Run outstanding migrations in documented order (M1..M6) if the dump predates them.
+# 5. Validate with §5.3, then rm -f /tmp/restore.dump
+```
+
+⚠️ **Never** restore into production over live data without a fresh dump of the
+current state first — even a corrupt present is worth capturing before overwrite.
+
+### 5.3 Post-restore validation (both paths)
+
+```bash
+# Row counts for the key tables (mirror of copy_prod_to_sandbox.sh's check)
+psql "$TARGET_DATABASE_URL" <<'EOF'
+  SELECT 'users' AS t, COUNT(*) FROM users
+  UNION ALL SELECT 'releases', COUNT(*) FROM releases
+  UNION ALL SELECT 'submittals', COUNT(*) FROM submittals
+  UNION ALL SELECT 'release_events', COUNT(*) FROM release_events
+  UNION ALL SELECT 'submittal_events', COUNT(*) FROM submittal_events
+  UNION ALL SELECT 'raw_source_records', COUNT(*) FROM raw_source_records
+  ORDER BY t;
+EOF
+```
+
+Then: (1) compare counts against the source (prod, or the pre-incident figure);
+(2) boot the app against the restored DB and load the Job Log + a submittal; (3)
+if blobs were restored, spot-check that a PDF/photo referenced by a restored row
+opens. Dangling-reference check (rows pointing at missing blobs) is part of the
+drill in §6.
+
+### 5.4 Restore blob assets
+
+```bash
+aws s3 cp "s3://milehigh-data/backups/disk/prod/2026/07/23/blobs-....tar.zst" \
+  /tmp/blobs.tar.zst --endpoint-url "$R2_ENDPOINT"
+zstd -dc /tmp/blobs.tar.zst | tar -C /var/data -xf -   # onto the mounted disk
+```
+
+If blobs already live in R2 `assets/` (target architecture), there is nothing to
+restore — repoint the app's storage config at the bucket.
+
+---
+
+## 6. Backup & recovery TEST PLAN
+
+**Principle: an untested backup is a guess.** This drill proves the whole chain —
+dump → offsite → restore → app works — in a safe environment. It deliberately
+reuses the sandbox path already proven by `migrations/copy_prod_to_sandbox.sh`,
+but **sourced from a backup artifact in R2**, which is what makes it a *recovery*
+test and not just a clone.
+
+### 6.1 Environment
+
+Target the **sandbox** database (`SANDBOX_DATABASE_URL`). It is the designed-safe
+target, is already wiped/reloaded routinely, and `TESTING=1` guarantees the test
+suite itself never touches it. **Never run the drill against production.**
+
+### 6.2 Cadence
+
+- **Once now**, immediately after this plan lands (establishes the baseline).
+- **Quarterly** thereafter.
+- **After** any change to the backup pipeline, the schema-migration process, or
+  the storage layer.
+- **After** the Procore export (design doc §4), as its acceptance test.
+
+### 6.3 Procedure
+
+1. **Pick an artifact.** Choose the latest `pg_dump` from
+   `r2://milehigh-data/backups/postgres/prod/…`. Record its timestamp and size.
+2. **Record source truth.** Capture prod's key-table row counts (§5.3 query
+   against prod) at the artifact's timestamp for comparison.
+3. **Wipe + restore sandbox** from the artifact:
+   ```bash
+   aws s3 cp "s3://milehigh-data/backups/postgres/prod/<path>.dump" /tmp/drill.dump --endpoint-url "$R2_ENDPOINT"
+   pg_restore --list /tmp/drill.dump > /dev/null            # integrity gate
+   psql "$SANDBOX_DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+   pg_restore --no-owner --no-acl -d "$SANDBOX_DATABASE_URL" /tmp/drill.dump
+   ```
+4. **Migrations.** Run any migrations newer than the dump, in documented order.
+5. **Validate data** (§5.3) — sandbox counts must match the source truth from
+   step 2 (allowing for writes between the dump time and the reading).
+6. **Referential-integrity / dangling-blob check** — for a sample of releases and
+   submittals with attachments, confirm the referenced blob key exists in R2
+   `assets/` (or on the restored disk). Log any dangling references.
+7. **App smoke test** — point a sandbox app instance at the restored DB; log in,
+   open the Job Log, open a submittal, open a marked-up PDF and a photo.
+8. **Measure RTO** — record wall-clock from step 3 start to step 7 pass. Compare
+   against §0. If it exceeds the target, that's an action item, not a pass.
+9. **Clean up** — `rm -f /tmp/drill.dump`.
+10. **Log the result** in §7 (date, artifact, RTO, pass/fail, issues).
+
+### 6.4 Pass criteria
+
+- Dump passed `pg_restore --list` before restore.
+- Restore completed with no errors; migrations applied cleanly.
+- Row counts reconcile with source truth.
+- No unexpected dangling blob references.
+- App smoke test passes.
+- Measured RTO within §0 target (or a filed action item if not).
+
+### 6.5 Failure handling
+
+Any failed step halts the drill and opens a board item (bug tracker). A failed
+drill means the backup is **not** trustworthy — treat as P0 until the next drill
+passes.
+
+---
+
+## 7. Log of provisioning decisions & drills
+
+Fill in as steps are actually done (this is the durable record — a green drill
+here is the only proof the backup works).
+
+| Date | Item | Detail | By |
+|---|---|---|---|
+| _TBD_ | PITR enabled | plan / retention window | |
+| _TBD_ | Persistent disk mounted | mount path / size | |
+| _TBD_ | pg_dump→R2 cron live | schedule / retention | |
+| _TBD_ | First recovery drill | artifact / RTO / result | |

--- a/docs/backup-and-dr-runbook.md
+++ b/docs/backup-and-dr-runbook.md
@@ -12,9 +12,11 @@ S3-compatible bucket by swapping the endpoint.
 
 > ⚠️ **Partially provisioned — read §7 before trusting anything here.** Postgres
 > PITR (3-day), the `/var/data` disk, the `mhmw-data` bucket, its scoped token
-> and all six lifecycle rules are **live**. The two backup scripts are written,
-> tested, and verified end-to-end against sandbox. **Neither cron is scheduled
-> yet, and no recovery drill has been run** — until that drill passes, this is a
+> and all six lifecycle rules are **live**. The **database backup cron is live
+> and has run successfully against production** (2026-08-09, 5.3 MB).
+> **Still outstanding: the blob backup is not scheduled** — it cannot run as a
+> cron job at all, because Render disks are not visible to cron services (§3) —
+> **and no recovery drill has been run.** Until that drill passes, this is a
 > backup we believe in rather than one we have proven. Render-side steps are
 > configured in the dashboard, outside this repo.
 
@@ -145,8 +147,9 @@ produces a ladder with no cleanup code to maintain or to fail silently.
 | Blobs weekly | `backups/disk/prod/weekly/` | delete after 56 days |
 | *(whole bucket)* | — | **abort incomplete multipart uploads after 7 days** |
 
-At ~3.4 MB/dump the full 34-object database ladder is ~140 MB; the blob tarballs
-are effectively the entire storage bill, which stays under a dollar a month.
+At the measured production dump size of **5.3 MB**, the full 34-object database
+ladder is ~180 MB. The blob tarballs are effectively the entire storage bill,
+which stays under a dollar a month.
 
 **On the multipart rule:** the blob archive is large enough to upload in parts.
 A run that dies partway leaves completed parts that are *billed as storage but
@@ -400,13 +403,20 @@ here is the only proof the backup works).
 | 2026-08-09 | Lifecycle rules live | 5 delete rules + multipart abort — see §2.2 | Daniel |
 | 2026-08-09 | Storage-root bug fixed | `MATERIAL_ORDER_STORAGE_ROOT` / `LOOKAHEAD_PDF_STORAGE_ROOT` were resolving to ephemeral paths; env vars set + derivation added to `app/config.py` | Claude |
 | 2026-08-09 | `backup_postgres.py` verified | sandbox → R2 end-to-end, 40 MB DB → 3.4 MB dump, daily + weekly objects byte-identical | Claude |
-| _TBD_ | pg_dump→R2 cron live | **Check `pg_dump --version` in the cron environment is ≥ 17 first** — Render's runtime image version has bitten people; fall back to a Docker-based cron if it lags | |
+| 2026-08-09 | **pg_dump→R2 cron live** | Render Cron Job service, `python -m scripts.backup_postgres`, `0 7 * * *` (01:00 MDT / 00:00 MST). Build command `pip install -r requirements.txt` | Daniel |
+| 2026-08-09 | **First production backup ever run** | 5.3 MB dump, `daily/` + `weekly/` objects verified byte-identical in R2 (5,596,996 B each) | Daniel |
+| 2026-08-09 | pg_dump version risk **retired** | Render's Python runtime ships **pg_dump 18.4 (Debian 18.4-1.pgdg12+1)** against Postgres 17 — comfortably newer. **No Docker-based cron needed** | — |
 | _TBD_ | `backup_blobs.py` cron live | schedule / retention | |
 | _TBD_ | First recovery drill | artifact / RTO / result | |
 | _TBD_ | Token rotation | no TTL was set deliberately; rotate manually and record here | |
 
 **Open items, deliberately not closed:**
 
+- ⚠️ **The cron service points at `feature/backup-infrastructure`, not `main`.**
+  Deliberate — it let the first production run happen before merging an unproven
+  path onto `main`. **Switch the service's branch to `main` when this merges, and
+  do not delete the feature branch before you do**, or the backup silently stops
+  building. This is the single most likely way for this to break.
 - **Sandbox test objects** from the 2026-08-09 verification sit under
   `backups/postgres/sandbox/…`, which has **no lifecycle rule** (rules cover
   `prod/` only). They are ~7 MB and will live until deleted by hand.

--- a/docs/backup-and-dr-runbook.md
+++ b/docs/backup-and-dr-runbook.md
@@ -14,11 +14,12 @@ S3-compatible bucket by swapping the endpoint.
 > PITR (3-day), the `/var/data` disk, the `mhmw-data` bucket, its scoped token
 > and all six lifecycle rules are **live**. The **database backup cron is live
 > and has run successfully against production** (2026-08-09, 5.3 MB).
-> **Still outstanding: the blob backup is not scheduled** — it cannot run as a
-> cron job at all, because Render disks are not visible to cron services (§3) —
-> **and no recovery drill has been run.** Until that drill passes, this is a
-> backup we believe in rather than one we have proven. Render-side steps are
-> configured in the dashboard, outside this repo.
+> **The first recovery drill passed on 2026-08-09** — a real production artifact
+> was restored off-platform onto a laptop, schema-checked against the application
+> models, and booted. The database backup is therefore *proven*, not merely
+> believed. **Still outstanding: the blob backup is not scheduled** — it cannot
+> run as a cron job at all, because Render disks are not visible to cron services
+> (§3). Render-side steps are configured in the dashboard, outside this repo.
 
 ---
 
@@ -407,8 +408,35 @@ here is the only proof the backup works).
 | 2026-08-09 | **First production backup ever run** | 5.3 MB dump, `daily/` + `weekly/` objects verified byte-identical in R2 (5,596,996 B each) | Daniel |
 | 2026-08-09 | pg_dump version risk **retired** | Render's Python runtime ships **pg_dump 18.4 (Debian 18.4-1.pgdg12+1)** against Postgres 17 — comfortably newer. **No Docker-based cron needed** | — |
 | _TBD_ | `backup_blobs.py` cron live | schedule / retention | |
-| _TBD_ | First recovery drill | artifact / RTO / result | |
+| 2026-08-09 | **First recovery drill — PASSED** | Artifact `backups/postgres/prod/daily/2026/08/09/mhmw-prod-2026-08-09T1843Z.dump` (5.3 MB, 509 TOC entries, from PG 17.9). Restored to a **local** Postgres 17, off-platform. `pg_restore` **0.78s**. Row counts: releases 966 · submittals 1,888 · release_events 11,062 · submittal_events 6,393 · users 29. Schema check: **47/47 model tables present, 0 missing**. App booted against the restored DB; data loads | Daniel + Claude |
 | _TBD_ | Token rotation | no TTL was set deliberately; rotate manually and record here | |
+
+**What the first drill taught us (2026-08-09):**
+
+- **Restore locally, not into sandbox.** Layer 2 exists to survive Render being
+  gone; restoring into another Render database cannot test that claim. The drill
+  restored onto a laptop and proved the artifact is portable off-platform
+  entirely. Make this the standing procedure — it also leaves sandbox usable as
+  a test environment.
+- ⚠️ **Empty the outbox tables before booting a restored copy.** A restored
+  database is an *active* system: `create_app()` starts APScheduler with seven+
+  jobs plus the `outbox_retry_worker` daemon, and the restored
+  `trello_outbox` / `procore_outbox` rows would be delivered for real against
+  whatever credentials are in the environment. Run
+  `DELETE FROM trello_outbox; DELETE FROM procore_outbox;` on the scratch DB
+  first, and set `TRELLO_MOCK=1`.
+- **The measured 0.78s is the data path, not full recovery.** A real incident
+  also needs a new Postgres provisioned and `DATABASE_URL` repointed — call it
+  15–30 minutes. Still far inside the 2h RTO target, with the restore itself
+  nowhere near the bottleneck.
+- **Comparing the restored schema against `db.metadata` is the strongest single
+  check** — it catches a structurally valid dump that is missing tables the
+  application needs. It also surfaced 5 tables in production that no model
+  defines (`job_events`, `procore_webhook_events`, `stash_sessions`,
+  `stashed_job_changes`, `user_panel_layouts`) — schema drift in prod, not a
+  backup problem, but worth knowing.
+- **Destroy the scratch copy afterwards.** `dropdb mhmw_drill` and delete the
+  local dump; both hold every row of production.
 
 **Open items, deliberately not closed:**
 

--- a/docs/backup-and-dr-runbook.md
+++ b/docs/backup-and-dr-runbook.md
@@ -1,18 +1,22 @@
 # Backup & Disaster-Recovery Runbook
 
-Status: **proposed**. Companion design doc:
+Status: **partially in force** as of 2026-08-09 — see the provisioning log in §7
+for exactly what is live and what is not. Companion design doc:
 [`data-architecture.md`](./data-architecture.md).
 
 This is the operational half: exact procedures for backing up and restoring the
 database and file assets, recovery-objective targets, and a repeatable
 backup/recovery **test plan**. It assumes the object store from the design doc is
-**Cloudflare R2** (`r2://milehigh-data/`, S3-compatible) — substitute any
+**Cloudflare R2** (`r2://mhmw-data/`, S3-compatible) — substitute any
 S3-compatible bucket by swapping the endpoint.
 
-> ⚠️ **Nothing in here has been provisioned yet.** Render's managed backups,
-> persistent-disk mounts, and any scheduled job are configured in the Render
-> dashboard, which is outside this repo. Treat the "Render dashboard" steps as a
-> checklist for a human with dashboard access.
+> ⚠️ **Partially provisioned — read §7 before trusting anything here.** Postgres
+> PITR (3-day), the `/var/data` disk, the `mhmw-data` bucket, its scoped token
+> and all six lifecycle rules are **live**. The two backup scripts are written,
+> tested, and verified end-to-end against sandbox. **Neither cron is scheduled
+> yet, and no recovery drill has been run** — until that drill passes, this is a
+> backup we believe in rather than one we have proven. Render-side steps are
+> configured in the dashboard, outside this repo.
 
 ---
 
@@ -53,11 +57,15 @@ R2 their RPO equals the write (near-zero).
 **One-time, in the Render dashboard**, for the production Postgres instance (and
 sandbox if you want it protected):
 
-1. Ensure the instance is on a **paid plan** that includes point-in-time recovery
-   / automated backups (free-tier instances do not).
-2. Confirm the backup retention window shown in the dashboard meets §0 (e.g. 7
-   days PITR).
-3. Record, in this file under §7, the exact plan and retention window in force.
+**Confirmed in force as of 2026-08-09: PITR is enabled with a 3-day window** on
+production Postgres (v17, Oregon). No action needed to turn it on.
+
+**The 3-day window is the thing to understand about this layer.** It satisfies
+the RPO in §0 — recovery granularity is minutes — but it bounds *detection*, not
+loss: corruption introduced on a Friday and noticed the following Tuesday is
+past recovery. PITR also lives in the same Render account as the database, so an
+account or billing failure takes both. Those two gaps are precisely what Layer 2
+exists to cover, which is why Layer 2 is not optional despite Layer 1 being on.
 
 Recovery from this layer is a dashboard operation ("restore to a point in time"),
 which provisions a **new** database. See §5.1.
@@ -68,7 +76,27 @@ This is defense-in-depth: a self-contained logical dump that lives outside
 Render and can be restored anywhere. It reuses the exact dump flags already
 proven in `migrations/copy_prod_to_sandbox.sh` (`-Fc --no-owner --no-acl`).
 
-**Manual dump + upload** (what the scheduled job automates):
+**Implemented as `scripts/backup_postgres.py`** — this is the job, not a sketch:
+
+```bash
+python -m scripts.backup_postgres                 # production (default)
+python -m scripts.backup_postgres --env sandbox
+python -m scripts.backup_postgres --skip-upload   # dump + verify, no R2
+```
+
+It resolves the URL, dumps, gates on `pg_restore --list` before uploading
+anything, writes the tier keys below, and always removes the local dump in a
+`finally` — a dump holds every row in the database and must never linger. It
+exits non-zero on any failure so the Render cron surfaces a broken run.
+Credentials come from `R2_ENDPOINT` / `R2_ACCESS_KEY_ID` /
+`R2_SECRET_ACCESS_KEY`; `R2_BUCKET` defaults to `mhmw-data`.
+
+Verified end-to-end against sandbox on 2026-08-09: 40 MB database → 3.4 MB dump,
+both the `daily/` object and the server-side `weekly/` copy landing byte-identical
+under the right prefixes.
+
+**The equivalent by hand**, for reference during an incident when reaching for a
+script is not what you want:
 
 ```bash
 # Requires: pg_dump (v16+ to match Render PG), awscli or rclone configured for R2.
@@ -80,7 +108,7 @@ pg_dump --no-owner --no-acl -Fc "$PRODUCTION_DATABASE_URL" -f "$OUT"
 
 # Upload to R2 (S3-compatible endpoint). Example with awscli:
 aws s3 cp "$OUT" \
-  "s3://milehigh-data/backups/postgres/prod/$(date -u +%Y/%m/%d)/$(basename "$OUT")" \
+  "s3://mhmw-data/backups/postgres/prod/$(date -u +%Y/%m/%d)/$(basename "$OUT")" \
   --endpoint-url "$R2_ENDPOINT"
 
 rm -f "$OUT"          # never leave dumps (they contain all data) on the box
@@ -100,17 +128,42 @@ as `app/__init__.py`). **Never** print `$PRODUCTION_DATABASE_URL`.
   prod DB URL must be a CI secret; acceptable if the Render cron option is
   unavailable.
 
-**Retention (R2 lifecycle rules on the `backups/postgres/` prefix):**
+**Retention — enforced entirely by R2 lifecycle rules. Nothing in this repo ever
+deletes a remote object.**
 
-| Tier | Keep |
-|---|---|
-| Daily | 14 days |
-| Weekly (Sunday) | 8 weeks |
-| Monthly (1st) | 12 months |
-| Procore-exit / annual snapshot | indefinite, **object-lock** (immutable) |
+R2 expires by *prefix and age*, and that is the only axis — one prefix can hold
+one expiry. So the tier lives in the key path above the date, and a run writes
+the same artifact to each tier it belongs to as independent objects. That is what
+produces a ladder with no cleanup code to maintain or to fail silently.
 
-Enable **bucket versioning** and, for the monthly/annual tier, **object-lock** so
-a compromised credential cannot delete history.
+| Tier | Prefix | Rule (live as of 2026-08-09) |
+|---|---|---|
+| Daily | `backups/postgres/prod/daily/` | delete after 14 days |
+| Weekly (Sunday) | `backups/postgres/prod/weekly/` | delete after 56 days |
+| Monthly (1st) | `backups/postgres/prod/monthly/` | delete after 365 days |
+| Blobs daily | `backups/disk/prod/daily/` | delete after 14 days |
+| Blobs weekly | `backups/disk/prod/weekly/` | delete after 56 days |
+| *(whole bucket)* | — | **abort incomplete multipart uploads after 7 days** |
+
+At ~3.4 MB/dump the full 34-object database ladder is ~140 MB; the blob tarballs
+are effectively the entire storage bill, which stays under a dollar a month.
+
+**On the multipart rule:** the blob archive is large enough to upload in parts.
+A run that dies partway leaves completed parts that are *billed as storage but
+invisible in the bucket listing*, so they accumulate forever. This rule is pure
+hygiene and every S3-compatible bucket wants it.
+
+**Bucket versioning is deliberately NOT used.** It protects against a key being
+overwritten or deleted, and every backup object here has a unique timestamped key
+that is never rewritten — there is no overwrite to protect against, and the
+retention ladder *is* the history. (There is also no versioning toggle in the R2
+bucket UI.) Revisit only if this bucket later holds live blobs under K3, where
+the same key does get rewritten.
+
+**Object-lock** for a genuinely immutable tier has to be enabled at bucket
+creation, so the Procore-exit / annual snapshot lands as a **separate bucket**
+when that export happens — not as a lifecycle rule here. Until then, the blast
+radius control is that the API token is scoped to `mhmw-data` alone.
 
 ### 2.3 Verifying a dump without restoring
 
@@ -132,24 +185,48 @@ Blobs are the PDFs, photos, and material-order attachments written under
 via the storage swap-points, so they are *already* backed up (versioned, offsite).
 No separate blob backup job needed.
 
-**Until that migration lands**, if blobs live on a mounted Render persistent
-disk, back the disk up nightly:
+**Until that migration lands**, `scripts/backup_blobs.py` tars the disk nightly:
 
 ```bash
-# On a box with the disk mounted at /var/data:
-STAMP=$(date -u +%Y-%m-%dT%H%MZ)
-tar -C /var/data -cf - pdfs photos order-attachments \
-  | zstd -q -o "/tmp/blobs-${STAMP}.tar.zst"
-aws s3 cp "/tmp/blobs-${STAMP}.tar.zst" \
-  "s3://milehigh-data/backups/disk/prod/$(date -u +%Y/%m/%d)/blobs-${STAMP}.tar.zst" \
-  --endpoint-url "$R2_ENDPOINT"
-rm -f "/tmp/blobs-${STAMP}.tar.zst"
+python -m scripts.backup_blobs                  # /var/data (default)
+python -m scripts.backup_blobs --skip-upload    # archive + verify, no R2
 ```
 
-Retention: mirror the DB daily/weekly tiers (14 days / 8 weeks). Blobs are
-append-mostly and content-addressed (attachments are sha256-keyed), so an
-incremental `aws s3 sync` of the disk into `assets/` is a cheaper alternative to
-tarballs once volume grows.
+> ⚠️ **Tar the MOUNT, never an enumerated list of subdirectories.** The original
+> version of this section said `tar -C /var/data -cf - pdfs photos
+> order-attachments`, which is exactly how `lookahead/` got missed — enumerate
+> and you will forget the next one that gets added. One tar of `/var/data`
+> covers everything on the disk today and anything added later. The script does
+> this and refuses to upload an empty archive, because an empty disk almost
+> always means a broken mount rather than a genuinely empty one.
+
+The script uses Python's `tarfile` rather than shelling out to `tar`/`zstd`, so
+the job carries no external binary dependencies that could go missing on a Render
+cron image — the same failure class as the `pg_dump` version problem in §2.2.
+
+**Storage roots — verified 2026-08-09.** All four must resolve beneath the mount:
+
+| Root | Resolves to |
+|---|---|
+| `PDF_STORAGE_ROOT` | `/var/data/pdfs` (set on Render) |
+| `PHOTO_STORAGE_ROOT` | `/var/data/photos` (derived) |
+| `MATERIAL_ORDER_STORAGE_ROOT` | `/var/data/order_attachments` |
+| `LOOKAHEAD_PDF_STORAGE_ROOT` | `/var/data/lookahead` |
+
+The last two were **read by their features but never defined in `app/config.py`**,
+so `config.get()` returned `None` and both fell back to `<repo>/app/storage/…`
+inside the deployed code tree — wiped on every deploy, while their DB rows
+survived pointing at files that no longer existed. Fixed twice: the env vars were
+set on Render, and `app/config.py` now derives both from `PDF_STORAGE_ROOT` the
+way `PHOTO_STORAGE_ROOT` already was, so one mounted disk implies all its
+children and a forgotten env var cannot route data onto ephemeral storage.
+`tests/test_storage_roots.py` guards it.
+
+Retention mirrors the DB daily/weekly tiers (14 days / 8 weeks); blobs get no
+monthly tier, so `backup_blobs.py` drops it. Blobs are append-mostly and
+content-addressed (attachments are sha256-keyed), so an incremental
+`aws s3 sync` into `assets/` beats tarballs once volume grows — at 1 GB it does
+not yet.
 
 > **Consistency note:** DB rows are the index into the blobs. When you back up,
 > the dump and the blob copy should be close in time; on restore, a blob
@@ -168,7 +245,7 @@ tarballs once volume grows.
   Graph/Anthropic/Recall creds, `R2_ENDPOINT` + access keys, `*_STORAGE_ROOT`).
   Never commit values. Hold an encrypted vault export off-platform.
 - **Code mirror** — optional weekly `git clone --mirror` bundle to
-  `r2://milehigh-data/backups/code/`, or a mirror to a second git host.
+  `r2://mhmw-data/backups/code/`, or a mirror to a second git host.
 
 ---
 
@@ -193,7 +270,7 @@ Render-wide outage (restore into any Postgres).
 
 ```bash
 # 1. Fetch the chosen dump from R2
-aws s3 cp "s3://milehigh-data/backups/postgres/prod/2026/07/23/milehigh-prod-2026-07-23T0700Z.dump" \
+aws s3 cp "s3://mhmw-data/backups/postgres/prod/2026/07/23/milehigh-prod-2026-07-23T0700Z.dump" \
   /tmp/restore.dump --endpoint-url "$R2_ENDPOINT"
 
 # 2. Sanity-check it lists
@@ -234,7 +311,7 @@ drill in §6.
 ### 5.4 Restore blob assets
 
 ```bash
-aws s3 cp "s3://milehigh-data/backups/disk/prod/2026/07/23/blobs-....tar.zst" \
+aws s3 cp "s3://mhmw-data/backups/disk/prod/2026/07/23/blobs-....tar.zst" \
   /tmp/blobs.tar.zst --endpoint-url "$R2_ENDPOINT"
 zstd -dc /tmp/blobs.tar.zst | tar -C /var/data -xf -   # onto the mounted disk
 ```
@@ -269,12 +346,12 @@ suite itself never touches it. **Never run the drill against production.**
 ### 6.3 Procedure
 
 1. **Pick an artifact.** Choose the latest `pg_dump` from
-   `r2://milehigh-data/backups/postgres/prod/…`. Record its timestamp and size.
+   `r2://mhmw-data/backups/postgres/prod/…`. Record its timestamp and size.
 2. **Record source truth.** Capture prod's key-table row counts (§5.3 query
    against prod) at the artifact's timestamp for comparison.
 3. **Wipe + restore sandbox** from the artifact:
    ```bash
-   aws s3 cp "s3://milehigh-data/backups/postgres/prod/<path>.dump" /tmp/drill.dump --endpoint-url "$R2_ENDPOINT"
+   aws s3 cp "s3://mhmw-data/backups/postgres/prod/<path>.dump" /tmp/drill.dump --endpoint-url "$R2_ENDPOINT"
    pg_restore --list /tmp/drill.dump > /dev/null            # integrity gate
    psql "$SANDBOX_DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
    pg_restore --no-owner --no-acl -d "$SANDBOX_DATABASE_URL" /tmp/drill.dump
@@ -316,7 +393,24 @@ here is the only proof the backup works).
 
 | Date | Item | Detail | By |
 |---|---|---|---|
-| _TBD_ | PITR enabled | plan / retention window | |
-| _TBD_ | Persistent disk mounted | mount path / size | |
-| _TBD_ | pg_dump→R2 cron live | schedule / retention | |
+| pre-existing | PITR enabled | Postgres 17, Oregon. **3-day window** | Daniel |
+| pre-existing | Persistent disk mounted | `/var/data`, **1 GB**. Originally provisioned for `.xlsx` snapshots from the since-retired OneDrive polling sync, not for blobs | Daniel |
+| 2026-08-09 | R2 bucket created | `mhmw-data`, Automatic (Western NA — pairs with Render Oregon), Standard class | Daniel |
+| 2026-08-09 | R2 token created | Object Read & Write, **scoped to `mhmw-data`**, no TTL, no IP filter (a DR credential must work from anywhere during a disaster) | Daniel |
+| 2026-08-09 | Lifecycle rules live | 5 delete rules + multipart abort — see §2.2 | Daniel |
+| 2026-08-09 | Storage-root bug fixed | `MATERIAL_ORDER_STORAGE_ROOT` / `LOOKAHEAD_PDF_STORAGE_ROOT` were resolving to ephemeral paths; env vars set + derivation added to `app/config.py` | Claude |
+| 2026-08-09 | `backup_postgres.py` verified | sandbox → R2 end-to-end, 40 MB DB → 3.4 MB dump, daily + weekly objects byte-identical | Claude |
+| _TBD_ | pg_dump→R2 cron live | **Check `pg_dump --version` in the cron environment is ≥ 17 first** — Render's runtime image version has bitten people; fall back to a Docker-based cron if it lags | |
+| _TBD_ | `backup_blobs.py` cron live | schedule / retention | |
 | _TBD_ | First recovery drill | artifact / RTO / result | |
+| _TBD_ | Token rotation | no TTL was set deliberately; rotate manually and record here | |
+
+**Open items, deliberately not closed:**
+
+- **Sandbox test objects** from the 2026-08-09 verification sit under
+  `backups/postgres/sandbox/…`, which has **no lifecycle rule** (rules cover
+  `prod/` only). They are ~7 MB and will live until deleted by hand.
+- **`backup_blobs.py` is temporary by design** and should be deleted when K3
+  lands and the app writes blobs straight to object storage.
+- **The 1 GB disk is a low ceiling** for a system about to absorb Procore's
+  document history. That is a K3 capacity argument, not a backup one.

--- a/docs/data-architecture.md
+++ b/docs/data-architecture.md
@@ -1,0 +1,288 @@
+# Data Architecture
+
+Status: **proposed** (design + forward plan). Companion operational doc:
+[`backup-and-dr-runbook.md`](./backup-and-dr-runbook.md).
+
+This is the coherent, whole-system view of where MileHigh's data lives, who owns
+each piece, how it is protected, and where it is heading. It exists because the
+data story had grown by accretion — Postgres, ephemeral disk, three external
+systems of record, and a half-built data lake — with no single document tying
+them together and no backup/DR story at all.
+
+Read this for the *what and why*. Read the runbook for the *how to operate and
+recover*.
+
+---
+
+## 1. Current state (as of 2026-07)
+
+### 1.1 Compute / deploy
+
+- **Everything runs in one Render web service.** Flask (Gunicorn, `wsgi.py`) plus
+  the React build served as static files from `frontend/dist/`.
+- **No separate worker/cron service.** Background work runs *in-process*:
+  APScheduler jobs (`init_scheduler()` in `app/__init__.py`) and the
+  `outbox_retry_worker` daemon thread. Scheduler duplication across Gunicorn
+  workers is avoided with the `WERKZEUG_RUN_MAIN` / `IS_RENDER_SCHEDULER` guard.
+- **No infrastructure-as-code.** There is no `render.yaml`, `Procfile`, or
+  Dockerfile in the repo — the Render service, its env vars, and (if any) its
+  persistent disk are configured only in the Render dashboard. **This means the
+  Render config itself is a single point of failure that git does not protect.**
+  See §6.
+
+### 1.2 Data stores
+
+| Store | Engine / location | What it holds | Durability today |
+|---|---|---|---|
+| **Operational DB** | Render managed **PostgreSQL**, one per env (`*_DATABASE_URL`) | `releases`, `projects`, `submittals`, `*_events`, `*_outbox`, `users`, board, notifications, **lake bronze** | Render's own storage; **no offsite copy, no in-repo backup automation** |
+| **On-disk blobs** | Local container FS under `*_STORAGE_ROOT` | Marked-up PDFs, release/board photos, material-order email attachments | **Ephemeral unless a Render persistent disk is mounted** (`.gitignore` calls `app/storage/` "ephemeral on Render") |
+| **App log file** | `logs/app.log` (rotating, 10MB×5) | Structured JSON logs | Ephemeral; also on stdout |
+| **Repo data files** | `docs/jobsites.json`, `data/*.csv`, `snapshots/*.pkl` | Derived/config data | In git or regenerable |
+
+Postgres connection is per-environment and SSL-required; pooling is tuned for
+Render's ~5-min idle timeout (`app/db_config.py`). Tests are hard-forced to
+in-memory SQLite (`TESTING=1`) and can never touch a real DB.
+
+### 1.3 Systems of record
+
+Three external systems feed the app; the boundary of "who owns the truth" is the
+single most important thing to get right before designing backups.
+
+| Domain | System of record today | Direction of travel |
+|---|---|---|
+| **Job log / scheduling** | The app's own Postgres (`releases`, `projects`) | Already authoritative; Trello is now a *mirror* the app writes **to** |
+| **Installer board** | **Trello** (cards) | Being subsumed by the app DB via `TrelloOutbox` |
+| **Submittals / ball-in-court / FC PDF packs** | **Procore** | ⚠️ **Contract ends Oct 2026** — must be extracted before then (see §4) |
+| **Raw external comms (email)** | App DB **lake bronze** (`raw_source_records`) | The emerging durable record for the `bb@mhmw.com` mailbox |
+
+Practical implication: **Postgres is the crown jewel.** Trello and Procore data
+that has been ingested into the app DB is protected by protecting Postgres.
+Blobs on disk (PDFs/photos/attachments) are the *second* priority because they
+are referenced by DB rows but not reconstructable from them.
+
+### 1.4 The "Hive Mind" data lake
+
+A real but **bronze-only, dormant** lakehouse-lite lives at `app/lake/`
+(`RawSourceRecord`, `LakeIngestState`, `graph_subscriptions`; migration
+`migrations/add_lake_tables.py`). It is "lakehouse-lite **on Postgres**" — not
+S3, not an external warehouse. The design intends bronze → silver → gold layers
+for the Banana Boy traceback feature, but only **bronze** exists. Ingestion
+(M365 mail pull + Graph push) is code-complete and gated off
+(`BB_MAIL_INGEST_ENABLED`, default off), **blocked on client Azure admin
+consent** (`docs/bb-email-ingestion.md`). No silver/gold, no external object
+store, `boto3` is not yet a dependency.
+
+---
+
+## 2. Target architecture
+
+The guiding principle: **one canonical operational database, one object store,
+and a clear medallion lake — each with a protection story.** Nothing exotic; the
+value is in coherence and in closing the backup gap.
+
+```
+                    ┌────────────────────────────────────────────┐
+   External         │              Render web service            │
+   systems          │   Flask + APScheduler + outbox worker      │
+   ─────────        │                                            │
+   Trello  ───────▶ │  ingest / webhooks / outbox                │
+   Procore ───────▶ │        │                    ▲              │
+   M365    ───────▶ │        ▼                    │ serve        │
+                    │  ┌──────────────┐   ┌────────────────┐     │
+                    │  │  Postgres    │   │ Object store    │◀───┼── NEW
+                    │  │ (crown jewel)│   │ (blobs + lake)  │     │
+                    │  │  bronze lake │   │  = Cloudflare R2│     │
+                    │  └──────┬───────┘   └───────┬─────────┘     │
+                    └─────────┼───────────────────┼──────────────┘
+                              │                    │
+              ┌───────────────┴───┐      ┌─────────┴─────────┐
+              ▼                   ▼      ▼                   ▼
+       Render managed      Nightly pg_dump   Blob writes    Lake silver/gold
+       PITR backups   +    → R2 (offsite)    (PDF/photo/    (Parquet/tables,
+       (primary DR)        (portability DR)   attachment)    later)
+```
+
+### 2.1 Object store: Cloudflare R2 (recommended, one bucket namespace)
+
+You asked for the offsite backup target to be wherever the blob storage for
+email/photo/PDF lives. **Recommendation: Cloudflare R2** as a single S3-compatible
+store serving *both* roles, split by key prefix:
+
+```
+r2://milehigh-data/
+  backups/
+    postgres/prod/2026/07/23/milehigh-prod-2026-07-23T0700Z.dump
+    postgres/sandbox/...
+    disk/prod/2026/07/23/blobs-2026-07-23T0700Z.tar.zst   # optional, see runbook
+  assets/
+    pdfs/<release_id>/v<n>.pdf
+    photos/<release_id>/<photo_id>.<ext>
+    order-attachments/<sha256>.pdf
+```
+
+Why R2:
+
+- **S3-compatible API** → drops straight into the existing swap-points. Every
+  storage module already documents itself as "single swap point — replace these
+  functions to migrate to OneDrive/S3" (`app/brain/job_log/features/pdf_markup/storage.py`,
+  `.../photos/storage.py`, `app/brain/board/photos/storage.py`,
+  `app/brain/material_orders/attachment_store.py`). `boto3` against R2 is the
+  smallest possible change.
+- **Zero egress fees** — matters for both restores (you pull the whole dump back)
+  and for serving assets to the app.
+- **Cheap at rest**, versioning + lifecycle rules for retention, object-lock
+  available for ransomware-resistant immutable backups.
+
+Alternatives if you'd rather: **Backblaze B2** (equivalent, also S3-compatible,
+slightly cheaper storage); **AWS S3** (deepest ecosystem, Glacier tiering, but
+egress costs on restore). Microsoft OneDrive/M365 was considered (you already use
+Graph) but is a poor fit for programmatic backup/asset storage — no S3 API, weak
+lifecycle/immutability — so it's not recommended for this role.
+
+### 2.2 Blob migration: disk → R2 (removes the ephemerality risk entirely)
+
+Today PDFs/photos/attachments live on the container FS and are **lost on recycle
+unless a Render persistent disk is mounted**. Two ways to make them durable, in
+priority order:
+
+1. **Short term (do now): mount a Render persistent disk** and point
+   `PDF_STORAGE_ROOT` (e.g. `/var/data/pdfs`; `PHOTO_STORAGE_ROOT` derives the
+   sibling `photos`) and `MATERIAL_ORDER_STORAGE_ROOT` at it. This stops data
+   loss immediately with zero code change. The disk then needs its own backup
+   (runbook §3).
+2. **Target: move blobs to R2** via the existing swap-points. Once assets live in
+   R2, they are already offsite and versioned, and the "persistent disk backup"
+   problem disappears — the disk stops holding anything you can't rebuild. This
+   is the preferred end state; the persistent disk becomes a cache at most.
+
+Either way, **the DB row is the index and the blob is the payload** — a restore
+must bring both back to a consistent point (runbook §5.3).
+
+### 2.3 The lake: finish the medallion, keep it on Postgres for now
+
+- **Bronze** (`raw_source_records`) stays as-is: immutable, append-only, one row
+  per raw external record. It is backed up as part of Postgres — no special
+  handling.
+- **Silver** (normalized, deduped, typed entities) and **gold** (serving
+  views/marts for Banana Boy traceback and analytics) are still backlog. Build
+  them as Postgres tables/materialized views first; only graduate to
+  Parquet-in-R2 if/when volume or analytical workload justifies it. Do not stand
+  up an external warehouse speculatively.
+- **Attachments** referenced by bronze rows should land in `assets/` in R2
+  (§2.1), not on ephemeral disk — this is the `docs/bb-email-ingestion.md`
+  "stash attachments to R2/S3" note, now with a concrete home.
+
+### 2.4 What stays exactly as it is
+
+- Per-env Postgres selection and pooling (`app/db_config.py`) — correct, leave it.
+- The idempotent standalone migration convention (`migrations/README.md`) — the
+  backup story does **not** introduce Alembic.
+- In-process scheduler/outbox model — fine at current scale.
+
+---
+
+## 3. Backup & disaster-recovery strategy (summary)
+
+Full procedures, commands, and schedules live in the
+[runbook](./backup-and-dr-runbook.md). The strategy in one paragraph:
+
+**Two independent layers for the database.** (1) *Primary:* Render managed
+Postgres **point-in-time recovery** — enable it (requires a paid Postgres plan),
+it gives near-zero-RPO recovery inside Render with no code to maintain. (2)
+*Defense-in-depth & portability:* a scheduled **`pg_dump -Fc` to R2**, retained
+on a tiered schedule, so a full logical copy of the data lives **outside Render's
+blast radius** and can be restored anywhere (this is also the Procore-style
+"get our data out" insurance). **Blobs** are protected by moving them off
+ephemeral disk (§2.2) — persistent disk plus, ideally, R2 as the store of record.
+
+Proposed objectives (confirm in the runbook):
+
+| | Target | Floor (must never exceed) |
+|---|---|---|
+| **RPO** (max data loss) | ~5 min via PITR | 24 h via nightly dump |
+| **RTO** (time to restore) | < 2 h | < 1 business day |
+
+---
+
+## 4. Procore data exit (Oct 2026 forcing function)
+
+`docs/ops-planning.md` flags this as an **unowned, no-plan, hard-deadline** risk:
+the Procore contract ends **October 2026** and the submittal/ball-in-court/FC-PDF
+data must be pulled out before access lapses. It belongs in the data architecture
+because it is fundamentally a *data-custody migration*, and the target
+architecture above is exactly where that data should land.
+
+Plan of record (needs an owner and a date):
+
+1. **Inventory** what Procore holds that the app does *not* already mirror into
+   `submittals` / `submittal_events`. Much may already be in Postgres; confirm.
+2. **Export** the rest via the Procore API (and any document/PDF assets) into:
+   Postgres rows for structured data, `assets/` in R2 for documents.
+3. **Snapshot** — take one authoritative `pg_dump` + R2 asset sync *after*
+   extraction completes and store it with `object-lock` retention, so there is an
+   immutable "as of contract end" copy.
+4. **Verify** with the same restore drill used for DR (runbook §6).
+
+This should be scheduled to *complete* well before Oct 2026, not started then.
+Owner: **TBD — needs assignment.**
+
+---
+
+## 5. Testing backup & recovery
+
+A backup you have never restored is a hypothesis, not a backup. The concrete,
+repeatable drill lives in the runbook (§6): restore the latest prod dump into the
+**sandbox** environment (the safe, existing target — `SANDBOX_DATABASE_URL`),
+run the app against it, and verify row counts and referential integrity against
+prod. This reuses the exact mechanism already proven by
+`migrations/copy_prod_to_sandbox.sh`, but sourced from a *backup artifact* rather
+than a live prod dump — which is what makes it a recovery test rather than a
+clone. Cadence: **quarterly**, and once immediately after this plan lands.
+
+---
+
+## 6. Code & config: do we need backups outside GitHub?
+
+**Source code: no dedicated backup needed.** GitHub is durable and every clone is
+a complete history; the practical risks are *account/org loss* and *provider
+outage*, not data loss. A cheap mitigation covers both without treating it as a
+pillar:
+
+- Enable a **scheduled read-only mirror** of the repo to a second location (a
+  second git host, or a periodic `git clone --mirror` bundle pushed to
+  `r2://milehigh-data/backups/code/`). Low effort, closes the org-loss gap.
+
+**The real gap is everything that is *not* in git:**
+
+- **Render dashboard configuration** — the service definition, build/start
+  commands, persistent disk mounts, and cron settings exist only in Render.
+  *Mitigation:* adopt **`render.yaml` (Blueprint) in the repo** so the
+  infrastructure is version-controlled and reproducible. This is the highest-value
+  "backup" item after the database.
+- **Secrets / environment variables** — `*_DATABASE_URL`, Procore/Trello/Graph/
+  Anthropic/Recall credentials live only in Render env. They are correctly *not*
+  in git. *Mitigation:* keep a maintained, access-controlled secrets inventory
+  (a `docs/` checklist of *which* vars must exist per env — names only, never
+  values) plus an encrypted vault export held by the owner, so a rebuild-from-
+  scratch is possible.
+
+So: don't back up code beyond a low-cost mirror; **do** version the Render
+config and document the secret inventory — those are the things whose loss would
+actually stop a rebuild.
+
+---
+
+## 7. Prioritized roadmap
+
+| # | Item | Why | Effort |
+|---|---|---|---|
+| 1 | Enable Render managed Postgres **PITR** (paid plan) | Primary DR, near-zero RPO, no code | Dashboard only |
+| 2 | **Mount a persistent disk**, point `*_STORAGE_ROOT` at it | Stops blob loss on recycle *today* | Dashboard + env vars |
+| 3 | Scheduled **`pg_dump → R2`** + retention + restore drill | Offsite portability; Procore-exit insurance | New cron + runbook |
+| 4 | Commit **`render.yaml`** + secrets inventory doc | Config is currently un-backed-up | Small |
+| 5 | Migrate blobs **disk → R2** via existing swap-points | Durable, offsite, versioned assets | Medium |
+| 6 | **Procore export** into Postgres + R2, immutable snapshot | Hard Oct-2026 deadline | Medium/large, unowned |
+| 7 | Lake **silver/gold** on Postgres | Unblocks Banana Boy traceback | Backlog |
+
+Items 1–4 are the backup/DR foundation and should land first. 5–7 are the
+architecture build-out.

--- a/docs/data-architecture.md
+++ b/docs/data-architecture.md
@@ -109,7 +109,7 @@ email/photo/PDF lives. **Recommendation: Cloudflare R2** as a single S3-compatib
 store serving *both* roles, split by key prefix:
 
 ```
-r2://milehigh-data/
+r2://mhmw-data/
   backups/
     postgres/prod/2026/07/23/milehigh-prod-2026-07-23T0700Z.dump
     postgres/sandbox/...
@@ -250,7 +250,7 @@ pillar:
 
 - Enable a **scheduled read-only mirror** of the repo to a second location (a
   second git host, or a periodic `git clone --mirror` bundle pushed to
-  `r2://milehigh-data/backups/code/`). Low effort, closes the org-loss gap.
+  `r2://mhmw-data/backups/code/`). Low effort, closes the org-loss gap.
 
 **The real gap is everything that is *not* in git:**
 

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -40,20 +40,32 @@ Source findings: `~/Desktop/Transcripts/MHMW/processed/`. Meeting rollup:
 
 **Effort:** S = under a day · M = 2–4 days · L = 1–2 weeks · XL = 3+ weeks.
 
-> ### 🔴 Read this first
+> ### 🟠 Read this first — **substantially corrected 2026-08-09**
 >
-> **There is no backup of production.** Confirmed 2026-07-22 — neither the
-> Postgres database nor the disk holding every PDF and photo. This is **K4**,
-> it is scheduled for **this week**, and it outranks every feature below it.
-> Nothing in this catalog is worth building if the data it operates on cannot
-> be recovered.
+> **The "there is no backup of production" claim that headed this catalog since
+> 2026-07-22 was wrong.** Render-managed **PITR has been enabled all along**,
+> with a 3-day window. The database was never as exposed as this document said,
+> and K4's Tier 0 framing rested on that error for over two weeks.
 >
-> **Status 2026-07-26 — still true.** A runbook and data-architecture plan exist
-> on `claude/render-backup-data-architecture-vlizsr` (unmerged, 610 lines of
-> docs). **Nothing has been enabled**; nothing backup-related has reached main.
-> The week it was scheduled for has ended with the exposure unchanged — and this
-> batch just added `tm_tickets`, `tm_ticket_attachments`, and `subcontractors`
-> to the set of tables with no backup behind them.
+> **What was actually true:** the 3-day window is short (corruption noticed after
+> a weekend is past recovery), PITR lives in the same Render account as the
+> database (a correlated failure), and **the binary disk had no protection at
+> all** — that part was correct.
+>
+> **Status 2026-08-09.** An independent offsite layer now exists:
+> `scripts/backup_postgres.py` and `scripts/backup_blobs.py` write tiered,
+> lifecycle-expired backups to Cloudflare R2 (`mhmw-data`), verified end-to-end
+> against sandbox. **Neither cron is scheduled yet and no recovery drill has
+> run**, so this is not finished — see `docs/backup-and-dr-runbook.md` §7 for the
+> exact live/not-live split.
+>
+> **The audit also found a live data-loss bug**, unrelated to backups but found
+> by looking: `MATERIAL_ORDER_STORAGE_ROOT` and `LOOKAHEAD_PDF_STORAGE_ROOT` were
+> read by their features but never defined in config, so supplier-order
+> attachments and ingested lookahead PDFs were written into the deployed code
+> tree and **destroyed on every deploy** while their DB rows survived pointing at
+> nothing. Fixed. Marked-up PDFs and photos were always on the mounted disk and
+> were never affected.
 
 ---
 
@@ -1761,8 +1773,9 @@ written is an operation.
 
 #### Backups — split out as K4
 
-Backups were originally bundled here. **They are now K4 and are CRITICAL.**
-Confirmed 2026-07-22: **there is no backup.**
+Backups were originally bundled here. **They are now K4.** Status as of
+2026-08-09: largely closed, and the 2026-07-22 "there is no backup" premise was
+wrong about Postgres — PITR was enabled all along.
 
 One connection matters for sequencing: **object storage solves the binary-backup
 problem structurally.** Versioning and replication are built into every object
@@ -1774,22 +1787,32 @@ writing a disk-backup script with a short shelf life.
 
 ---
 
-### K4. Backups — **🔴 CRITICAL. This week.**
+### K4. Backups — **🟠 Largely closed 2026-08-09. Crons + drill remain.**
 
-> **Confirmed by Daniel 2026-07-22: there is no backup.** Elevated above every
-> other item in this catalog. Nothing else here matters if the data is not
-> recoverable.
+> **The 2026-07-22 "there is no backup" finding was half wrong**, and it drove
+> this item's Tier 0 rank for over two weeks. Managed Postgres PITR had been
+> enabled the entire time. The binary disk half was correct.
 
 **This is not a feature and should not be queued behind features.** Every item
 in this document assumes the data it operates on continues to exist.
 
-#### What is unprotected
+#### State as of 2026-08-09
 
 | Asset | State |
 |---|---|
-| **Production Postgres** | No backup. Every release, submittal, event stream, and audit trail |
-| **Binary storage disk** | No backup. Every marked-up PDF, release photo, board photo |
-| **The combination** | Worse than either alone — a restored DB with no files gives you `storage_key` rows pointing at nothing, which *looks* like a successful restore |
+| **Production Postgres** | ✅ Managed PITR, **3-day window** (was always on) **+** nightly `pg_dump` → R2, tiered and lifecycle-expired. `scripts/backup_postgres.py`, verified end-to-end against sandbox |
+| **Binary storage disk** | 🟠 `/var/data` (1 GB). `scripts/backup_blobs.py` tars the whole mount → R2. Written and tested, **never yet run against the real disk** |
+| **The combination** | The failure mode this table used to warn about — `storage_key` rows pointing at nothing — **was already happening in production**, independent of any restore: two storage roots resolved to ephemeral paths and were wiped every deploy. Found and fixed 2026-08-09 |
+
+#### What is still open
+
+- **Neither cron is scheduled.** Nothing runs automatically.
+- **No production backup has ever run.** Sandbox only.
+- **No recovery drill.** Runbook §6 defines it. Until it passes, the backup is
+  believed rather than proven — and an untested backup has a long history of
+  turning out never to have been valid.
+- **3-day PITR bounds detection, not just loss.** Corruption noticed after a
+  weekend is past that window; layer 2 is what covers it.
 
 #### Why this is worse than it looks
 
@@ -1918,7 +1941,7 @@ the transcript alone.
 
 | Item | Effort | Note |
 |---|---|---|
-| **K4 Backups** | S–M | **Still no backup as of 2026-07-26.** A runbook exists on an unmerged branch; nothing is enabled. The week it was scheduled for has passed and the exposure is unchanged — **and it now covers T&M tickets, field photos, and subcontractor accounts too.** Not a feature — the precondition for every other item being worth building |
+| **K4 Backups** | S–M | 🟠 **Mostly done 2026-08-09, not finished.** The "no backup" premise was wrong — Postgres PITR (3-day) was always on. Offsite layer 2 now built and verified to R2: `backup_postgres.py`, `backup_blobs.py`, lifecycle retention, runbook corrected. **Remaining: schedule both crons, run the recovery drill.** Until the drill passes this is unproven. Also fixed a live data-loss bug in two storage roots found during the work |
 
 ---
 
@@ -2048,12 +2071,19 @@ deferred.** If one Procore submittal advances GC→DRR→FC and our sync freezes
 DWL DRR filtering, `start_install`, Rel assignment. Resolvable with a read-only
 SQL check. See B3.
 
-**There is no backup — see K4.** Confirmed 2026-07-22, **still true 2026-07-26.**
-Prod Postgres and the binary storage disk are both unprotected. A runbook and
-data-architecture plan were written to
-`claude/render-backup-data-architecture-vlizsr` and never merged or executed.
-This outranked everything else in the catalog for a week in which four other
-items shipped.
+**The backup picture was misdiagnosed — see K4.** The 2026-07-22 finding of "no
+backup" was **wrong about Postgres**: managed PITR (3-day window) had been
+enabled the whole time. It was **right about the binary disk**, which had no
+protection. Corrected 2026-08-09, when an offsite layer to R2 was built,
+verified against sandbox, and the runbook merged. Crons and the recovery drill
+remain outstanding.
+
+**The lesson generalizes past backups.** Nobody could say what was protected
+without checking the dashboard, and nobody had. The same session found an hourly
+OneDrive→Excel poller documented in CLAUDE.md that does not exist, a persistent
+disk still mounted for that dead pipeline, and two storage roots silently writing
+to ephemeral paths. **The gap is between what is documented and what is true**,
+and a data lake built over that gap inherits it at scale.
 
 **Carmen's mailbox moved and the code review cannot prove the outside moved with
 it.** `carmen_ai@mhmw.com` replaced `bb@mhmw.com` in `Config.CARMEN_MAILBOX` and

--- a/docs/procore-decommission-plan.md
+++ b/docs/procore-decommission-plan.md
@@ -258,7 +258,7 @@ which changes the risk profile of two items the catalog already flagged.
 
 | # | Item | Why now |
 |---|---|---|
-| 0.1 | **K4 — backups** | Catalog Tier 0, unresolved since 2026-07-22, a runbook sitting unmerged on `claude/render-backup-data-architecture-vlizsr`. **When Procore goes away, an unrecoverable Postgres and an unbacked-up disk stop being a risk and become the plan.** This is the argument that should finally move it |
+| 0.1 | **K4 — backups** | 🟠 **Largely closed 2026-08-09.** The premise was wrong — Postgres PITR (3-day) had been on since before 7/22, so Postgres was never unrecoverable; the binary disk genuinely was unprotected and now has a tiered offsite backup to R2, verified against sandbox. **Still open: two crons and a recovery drill.** The October argument holds for that remainder — when the Brain becomes the system of record for submittals and drawings, an *unproven* backup is the exposure |
 | 0.2 | **K3 — object storage decision + cost numbers** | Bill asked for numbers on the record: *"I'll start preparing some numbers for that, so there's some awareness"* [L662–666]. Every binary currently sits on one Render disk. Procore's document history does not fit that shape |
 | 0.3 | **Archival policy** | Agreed in the meeting: closed projects get metadata + a text record, and the drawing files get dropped [L666–683]. Write it down; it bounds 0.2's cost estimate |
 
@@ -440,7 +440,7 @@ Each of these is cut with a citation, so nobody has to re-litigate it from memor
 | **B3 Soft-link sub/DRR/FC** | **Dissolved as a feature.** §1.2 — owning the record makes the link a primary key. The correctness question it raised is answered by `docs/submittal-id-coherence-audit.md`: three separate Procore records, and the new model removes the class of problem |
 | **B1 Procore export** | Still Bill's. **The inventory sub-task should come back to Daniel** (§4) |
 | **B4 Customer-Procore access** | **De-risked.** Invited-user access survives October [L811–818]. Still worth the rep question; no longer a blocker |
-| **K4 Backups** | Unchanged in rank (Tier 0), **strengthened in argument** (§0.1) |
+| **K4 Backups** | **Largely closed 2026-08-09** (§0.1). The Tier 0 premise was wrong — PITR was always on. Offsite layer built and verified; two crons and a recovery drill remain |
 | **K3 Object storage** | **Promoted from unranked to a precondition.** Bill asked for the numbers on the record |
 | **K2 → D1 → D2** | Was "the whole critical path" as of 2026-07-26. **It is not any more.** The project page (D1) is now a *dependency* of the submittal work rather than a peer — the submittal section and aging view live on it |
 | **A2 Change orders** | Still blocked on Bill. Unchanged |
@@ -493,9 +493,10 @@ slack, against an eight-week window that also contains Slice 0, live bug fixes, 
 
 **That is tight but not unreasonable**, on three conditions:
 
-1. **Slice 0 happens this week**, not opportunistically. Backups in particular have now been Tier 0 for
-   two weeks with nothing enabled — and the October plan is what converts that from a risk into a
-   certainty.
+1. **Slice 0 happens this week**, not opportunistically. Backups moved on 8/9, and the finding was that
+   the Tier 0 premise had been wrong for two weeks — PITR was enabled the whole time. What is left is
+   small (two crons, one recovery drill) but it is the part that makes the backup *proven* rather than
+   *believed*, and the October plan is what makes that distinction matter.
 2. **The §4 inventory runs early**, in Slice 1. It is the only thing here that can produce a surprise
    large enough to change the plan, and it costs a day.
 3. **Slice 5 is allowed to slip.** It is the natural release valve — genuinely valuable, and genuinely

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,7 +71,7 @@ Every open item in one place. Detail lives in the workstream sections below.
 
 | ID | Item | Effort | Depends on | Status |
 |---|---|---|---|---|
-| **K4** | Backups — Postgres + binary disk | S–M | — | 🔴 **Not started.** Tier 0 since 7/22; runbook unmerged |
+| **K4** | Backups — Postgres + binary disk | S–M | — | 🟠 **Mostly done 8/9.** Premise was wrong (PITR always on, 3-day). Offsite R2 layer built + verified; runbook merged. **Left: 2 crons + recovery drill** |
 | **K3** | Object storage migration + cost numbers for Bill | L | — | Not started. Size generously. **Blocks P7, C3, P11** — every submittal binary lands wherever this decides |
 | **N4** | Two-calendar business-day fix + 26-call-site audit | M | — | Not started. Gates E1–E3 |
 | **MIG** | Run the outstanding migration backlog per environment | S–M | — | Standing item. Several shipped features carry unrun migrations (A1 alone shipped five); the 8/6 bug wave added `releases_unique_job_release_name.py` (the BUG-3 fix — verify run state per env); Workstream 1 adds more. Scripts handed over per the usual split |
@@ -204,7 +204,7 @@ Not features. Everything below sits on these.
 
 | ID | Item | Effort | Note |
 |---|---|---|---|
-| **K4** | **Backups** | S–M | 🔴 Tier 0 since 2026-07-22, still nothing enabled. A runbook sits unmerged on `claude/render-backup-data-architecture-vlizsr`. **October is what converts this from a risk into a certainty** — the Brain becomes the system of record for submittals and drawings, and neither Postgres nor the binary disk is recoverable today |
+| **K4** | **Backups** | S–M | 🟠 **Substantially done 2026-08-09.** The Tier 0 premise was **wrong**: Postgres PITR (3-day window) had been enabled since before 7/22 — the database was never unrecoverable. The binary disk genuinely had nothing, and now has an offsite tiered backup to R2 (`mhmw-data`), verified end-to-end against sandbox, with the runbook merged and corrected. **Outstanding: schedule both crons, run the recovery drill** — until the drill passes this is believed, not proven. The work also surfaced a live data-loss bug (two storage roots writing to ephemeral paths, now fixed) |
 | **K3** | **Object storage + cost numbers** | L | Every binary is on one Render disk. Bill asked for numbers on the record [L662–666]. Procore's document history does not fit that shape. Archival policy agreed in the meeting: closed projects keep metadata + a text record, drawing files get dropped [L666–683]. **Size generously** — the retention posture decided 2026-08-06 is *"handle as much as possible and slide irrelevant data out as those things become more clear,"* so prune later rather than filter on the way in |
 | **N4** | **Two-calendar business-day fix** | M | See below |
 
@@ -809,7 +809,7 @@ to show did not fit the window and is retired.
 
 | When | What |
 |---|---|
-| **This week** | K4 backups · K3 decision + storage numbers for Bill · **P11 delta inventory** · MIG backlog *(done 8/6: the bug pile · drafter permissions · N6)* |
+| **This week** | K4 backups **crons + recovery drill** *(build done 8/9)* · K3 decision + storage numbers for Bill *(R2 provisioned 8/9 — storage cost is now a known sub-$1/mo figure; the open part is the blob migration, not the vendor)* · **P11 delta inventory** · MIG backlog *(done 8/6: the bug pile · drafter permissions · N6)* |
 | **Weeks 1–3** | P1 extend `Submittals` · P0 origination · P2 workflow engine + tests — **blocked start on Bill's template export** · N4 |
 | **Weeks 3–4** | C3 **narrow** (revision viewer) · **P11 document pull begins** — paced by rate limits, runs in the background from here |
 | **Weeks 4–5** | P7 returned ingestion · D1 **minimal** (submittal tab) |
@@ -837,8 +837,11 @@ by deciding rather than deferring. That is real progress. It is not four weeks o
 progress.
 
 Two conditions still carry the plan. **Workstream 0 happens this week** rather
-than opportunistically; backups have been Tier 0 for over two weeks with nothing
-enabled, and October is what converts that exposure from a risk into a certainty.
+than opportunistically. Backups moved on 8/9 — and the finding was that the Tier
+0 premise had been wrong for two weeks, since Postgres PITR was on the whole
+time. What remains there is small (two crons and a recovery drill) but is the
+part that converts a believed backup into a proven one, and October is what makes
+that distinction matter.
 And **Workstream 2 is allowed to slip** — it is the release valve, and nothing in
 it stops us leaving Procore.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,7 +71,7 @@ Every open item in one place. Detail lives in the workstream sections below.
 
 | ID | Item | Effort | Depends on | Status |
 |---|---|---|---|---|
-| **K4** | Backups — Postgres + binary disk | S–M | — | 🟠 **Mostly done 8/9.** Premise was wrong (PITR always on, 3-day). Offsite R2 layer built + verified; runbook merged. **Left: 2 crons + recovery drill** |
+| **K4** | Backups — Postgres + binary disk | S–M | — | 🟢 **Postgres DONE 8/9** — cron live, first prod backup run, **recovery drill passed** (restored off-platform, schema-verified, app booted). 🟠 **Blobs deferred** — Procore still carries PDFs/photos; folding into the data-lake work |
 | **K3** | Object storage migration + cost numbers for Bill | L | — | Not started. Size generously. **Blocks P7, C3, P11** — every submittal binary lands wherever this decides |
 | **N4** | Two-calendar business-day fix + 26-call-site audit | M | — | Not started. Gates E1–E3 |
 | **MIG** | Run the outstanding migration backlog per environment | S–M | — | Standing item. Several shipped features carry unrun migrations (A1 alone shipped five); the 8/6 bug wave added `releases_unique_job_release_name.py` (the BUG-3 fix — verify run state per env); Workstream 1 adds more. Scripts handed over per the usual split |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ APScheduler==3.11.0
 alembic==1.16.1
 blinker==1.9.0
 black==24.10.0
+boto3==1.35.49
 certifi==2024.7.4
 charset-normalizer==3.3.2
 click==8.1.7

--- a/scripts/_db_urls.py
+++ b/scripts/_db_urls.py
@@ -1,0 +1,45 @@
+"""Resolve Postgres connection URLs for operational scripts from the environment.
+
+Credentials must never be hardcoded in this repo (it is public). Each URL comes from
+an env var, matching the names app/db_config.py already uses:
+
+    PRODUCTION_DATABASE_URL  (falls back to DATABASE_URL)
+    SANDBOX_DATABASE_URL
+
+Set them in .env or export them before running a script. A missing var exits with a
+clear message rather than silently connecting somewhere unexpected.
+"""
+import os
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _require(name: str, *fallbacks: str) -> str:
+    for var in (name, *fallbacks):
+        value = (os.environ.get(var) or "").strip()
+        if value:
+            return value
+    names = " or ".join((name, *fallbacks))
+    sys.exit(
+        f"error: {names} is not set.\n"
+        f"Add it to .env or export it before running this script."
+    )
+
+
+def prod_url() -> str:
+    """Production Postgres URL. Exits if unset."""
+    return _require("PRODUCTION_DATABASE_URL", "DATABASE_URL")
+
+
+def sandbox_url() -> str:
+    """Sandbox Postgres URL. Exits if unset."""
+    return _require("SANDBOX_DATABASE_URL")
+
+
+def mask(url: str) -> str:
+    """host/db only — never print credentials."""
+    tail = url.split("@")[-1] if "@" in url else url
+    return tail.split("/")[-1] if "/" in tail else tail

--- a/scripts/_r2.py
+++ b/scripts/_r2.py
@@ -1,0 +1,127 @@
+"""Cloudflare R2 (S3-compatible) client helper for backup scripts.
+
+Credentials come from the environment only — never from this repo (it is public):
+
+    R2_ENDPOINT           https://<account-id>.r2.cloudflarestorage.com
+    R2_BUCKET             mhmw-data
+    R2_ACCESS_KEY_ID      from the bucket-scoped R2 API token
+    R2_SECRET_ACCESS_KEY  from the same token (shown once at creation)
+
+In production these are set on the Render Cron Job service. Locally, export them
+or add them to .env when you need to exercise a real upload.
+
+Swapping providers means changing R2_ENDPOINT — every call here is plain S3.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# R2 hard-codes this; S3 would use a real region. Signing needs *a* value.
+_REGION = "auto"
+
+# The standing backup bucket. R2_BUCKET overrides it.
+DEFAULT_BUCKET = "mhmw-data"
+
+
+def _require(name: str) -> str:
+    value = (os.environ.get(name) or "").strip()
+    if not value:
+        sys.exit(
+            f"error: {name} is not set.\n"
+            f"Backup uploads need R2_ENDPOINT, R2_BUCKET, R2_ACCESS_KEY_ID and "
+            f"R2_SECRET_ACCESS_KEY. Set them in the environment, or pass "
+            f"--skip-upload to dump and verify locally without uploading."
+        )
+    return value
+
+
+def tiers_for(now: datetime) -> list[str]:
+    """Which retention tiers a run belongs to.
+
+    Always daily; Sundays are also weekly; the 1st is also monthly. A run writes
+    the same artifact to each tier as an independent object, so each ages on its
+    own lifecycle clock — that is what produces a backup ladder with no cleanup
+    code. Daily is always first; callers upload that one and server-side copy
+    the rest.
+    """
+    tiers = ["daily"]
+    if now.weekday() == 6:  # Monday=0 ... Sunday=6
+        tiers.append("weekly")
+    if now.day == 1:
+        tiers.append("monthly")
+    return tiers
+
+
+def backup_key(
+    category: str, env_segment: str, tier: str, now: datetime, filename: str
+) -> str:
+    """Object key for a backup artifact.
+
+    The first three segments must match the R2 lifecycle rule prefixes exactly
+    (backups/postgres/prod/daily/, backups/disk/prod/daily/, ...) or retention
+    silently will not apply and objects accumulate forever.
+    """
+    return f"backups/{category}/{env_segment}/{tier}/{now:%Y/%m/%d}/{filename}"
+
+
+def bucket() -> str:
+    """Target bucket name.
+
+    Defaults to the standing backup bucket so a deploy cannot silently lose it.
+    Environments share the bucket on purpose — they are namespaced by the key
+    prefix (backups/postgres/prod/... vs .../sandbox/...), not by bucket.
+    """
+    return (os.environ.get("R2_BUCKET") or "").strip() or DEFAULT_BUCKET
+
+
+def client():
+    """boto3 S3 client pointed at R2. Exits with a clear message if unusable."""
+    try:
+        import boto3
+    except ImportError:
+        sys.exit(
+            "error: boto3 is not installed.\n"
+            "Run: pip install -r requirements.txt"
+        )
+
+    return boto3.client(
+        "s3",
+        endpoint_url=_require("R2_ENDPOINT"),
+        aws_access_key_id=_require("R2_ACCESS_KEY_ID"),
+        aws_secret_access_key=_require("R2_SECRET_ACCESS_KEY"),
+        region_name=_REGION,
+    )
+
+
+def upload(local_path: str, key: str, *, s3=None) -> None:
+    """Upload a file to <bucket>/<key>. boto3 splits large files automatically.
+
+    Prints the bucket and key — never the endpoint or credentials.
+    """
+    s3 = s3 or client()
+    name = bucket()
+    size_mb = os.path.getsize(local_path) / (1024 * 1024)
+    print(f"  uploading {size_mb:.1f} MB -> s3://{name}/{key}")
+    s3.upload_file(local_path, name, key)
+
+
+def copy(src_key: str, dst_key: str, *, s3=None) -> None:
+    """Server-side copy within the bucket — no re-upload of the payload.
+
+    Used to write a second retention tier (weekly/monthly) from an object that
+    is already in R2, so a large blob tarball is only transferred once.
+    """
+    s3 = s3 or client()
+    name = bucket()
+    print(f"  copying   -> s3://{name}/{dst_key}")
+    s3.copy_object(
+        Bucket=name,
+        Key=dst_key,
+        CopySource={"Bucket": name, "Key": src_key},
+    )

--- a/scripts/_r2.py
+++ b/scripts/_r2.py
@@ -99,6 +99,23 @@ def client():
     )
 
 
+def latest_object(prefix: str, *, s3=None):
+    """Most recently modified object under `prefix`, or None if there are none.
+
+    Used to compare a new artifact against the previous one — a dump that
+    suddenly collapses in size is the signature of a silent partial failure
+    (e.g. reduced privileges), which otherwise exits zero and looks healthy.
+    """
+    s3 = s3 or client()
+    newest = None
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket(), Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if newest is None or obj["LastModified"] > newest["LastModified"]:
+                newest = obj
+    return newest
+
+
 def upload(local_path: str, key: str, *, s3=None) -> None:
     """Upload a file to <bucket>/<key>. boto3 splits large files automatically.
 

--- a/scripts/backup_blobs.py
+++ b/scripts/backup_blobs.py
@@ -1,0 +1,163 @@
+"""Blob-asset backup to Cloudflare R2 — the mounted disk, tarred nightly.
+
+Postgres PITR does not cover a mounted filesystem, so the binaries need their
+own job: marked-up PDFs, release/board/T&M photos, supplier-order attachments
+and ingested lookahead PDFs all live on the Render persistent disk under
+/var/data.
+
+TEMPORARY BY DESIGN. The end state is the app writing blobs straight to object
+storage (K3), at which point they are already offsite and versioned and this
+script should be deleted. Until that lands, a nightly tarball is the cheap thing
+that keeps the binaries recoverable.
+
+Tars the MOUNT, not an enumerated list of subdirectories. The runbook originally
+listed `pdfs photos order-attachments`, which is exactly how app/storage/lookahead
+got missed — enumerate and you will forget the next one. One tar of the mount
+covers everything on the disk today and anything added later.
+
+Uses Python's tarfile rather than shelling out to tar/zstd so the job has no
+external binary dependencies to go missing on a Render cron image.
+
+Usage
+-----
+    python -m scripts.backup_blobs                        # /var/data (default)
+    python -m scripts.backup_blobs --root /var/data
+    python -m scripts.backup_blobs --skip-upload          # archive locally only
+
+Exits non-zero on any failure so the Render cron surfaces a broken run.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+
+try:  # allow both `python -m scripts.backup_blobs` and direct execution
+    from scripts import _r2
+except ImportError:  # pragma: no cover - path fixup for direct execution
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts import _r2
+
+# The Render persistent disk mount. Every *_STORAGE_ROOT resolves beneath it
+# once PDF_STORAGE_ROOT is set (see app/config.py).
+DEFAULT_ROOT = "/var/data"
+
+
+def archive(root: str, out_path: str) -> tuple[int, int]:
+    """tar.gz the whole mount. Returns (file_count, uncompressed_bytes)."""
+    files = 0
+    raw_bytes = 0
+    print(f"  archiving {root} ...")
+    with tarfile.open(out_path, "w:gz") as tar:
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for name in filenames:
+                full = os.path.join(dirpath, name)
+                if not os.path.isfile(full) or os.path.islink(full):
+                    continue
+                try:
+                    raw_bytes += os.path.getsize(full)
+                    tar.add(full, arcname=os.path.relpath(full, root))
+                    files += 1
+                except OSError as exc:  # unreadable/vanished mid-walk
+                    print(f"  warning: skipped {os.path.relpath(full, root)}: {exc}")
+    return files, raw_bytes
+
+
+def verify(archive_path: str, expected_files: int) -> None:
+    """An archive that will not list is worthless — gate before uploading."""
+    print("  verifying archive is readable...")
+    try:
+        with tarfile.open(archive_path, "r:gz") as tar:
+            found = sum(1 for m in tar.getmembers() if m.isfile())
+    except (tarfile.TarError, OSError) as exc:
+        sys.exit(f"error: CORRUPT ARCHIVE — cannot read it back. Not uploading.\n{exc}")
+    if found != expected_files:
+        sys.exit(
+            f"error: archive holds {found} files but {expected_files} were added. "
+            f"Not uploading."
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root", default=DEFAULT_ROOT, help=f"disk mount to back up (default: {DEFAULT_ROOT})"
+    )
+    parser.add_argument(
+        "--env",
+        choices=("prod", "sandbox"),
+        default="prod",
+        help="key namespace (default: prod)",
+    )
+    parser.add_argument(
+        "--skip-upload",
+        action="store_true",
+        help="archive and verify locally without touching R2 (implies --keep-local)",
+    )
+    parser.add_argument(
+        "--keep-local", action="store_true", help="do not delete the local archive"
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.root):
+        sys.exit(
+            f"error: {args.root} does not exist or is not a directory.\n"
+            f"On Render this is the persistent disk mount; locally pass --root."
+        )
+
+    now = datetime.now(timezone.utc)
+    stamp = f"{now:%Y-%m-%dT%H%MZ}"
+    filename = f"blobs-{stamp}.tar.gz"
+
+    print(f"backup_blobs: {args.root} -> {args.env} @ {stamp}")
+
+    workdir = tempfile.mkdtemp(prefix="mhmw-blobs-")
+    out_path = os.path.join(workdir, filename)
+    keep = args.keep_local or args.skip_upload
+
+    try:
+        files, raw_bytes = archive(args.root, out_path)
+        if files == 0:
+            # An empty disk is far more likely to mean a broken mount or a wrong
+            # --root than a genuinely empty one. Do not upload a useless archive.
+            sys.exit(
+                f"error: no files found under {args.root}. Refusing to upload an "
+                f"empty archive — check the mount path."
+            )
+
+        size_mb = os.path.getsize(out_path) / (1024 * 1024)
+        raw_mb = raw_bytes / (1024 * 1024)
+        print(f"  archived {files:,} files, {raw_mb:.1f} MB -> {size_mb:.1f} MB compressed")
+        verify(out_path, files)
+
+        tiers = [t for t in _r2.tiers_for(now) if t != "monthly"]  # blobs: no monthly tier
+        print(f"  tiers: {', '.join(tiers)}")
+
+        if args.skip_upload:
+            print("  --skip-upload set; would have written:")
+            for tier in tiers:
+                print(f"    s3://<bucket>/{_r2.backup_key('disk', args.env, tier, now, filename)}")
+            print(f"  local archive kept at {out_path}")
+            return 0
+
+        s3 = _r2.client()
+        primary = _r2.backup_key("disk", args.env, tiers[0], now, filename)
+        _r2.upload(out_path, primary, s3=s3)
+        for tier in tiers[1:]:
+            _r2.copy(primary, _r2.backup_key("disk", args.env, tier, now, filename), s3=s3)
+
+        print("backup_blobs: OK")
+        return 0
+    finally:
+        if keep:
+            print(f"  (local archive retained: {out_path})")
+        else:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -68,6 +68,23 @@ def require_tool(name: str) -> None:
         )
 
 
+def tool_version(name: str) -> str:
+    """Best-effort `<tool> --version`, for the run log.
+
+    Worth a line in every run: Render's cron image ships whatever pg_dump it
+    ships, and a client older than the server fails the dump outright. Logging it
+    means the first Trigger Run answers "is this image compatible?" without a
+    shell, and every later run leaves a record.
+    """
+    try:
+        result = subprocess.run(
+            [name, "--version"], capture_output=True, text=True, timeout=10
+        )
+        return (result.stdout or result.stderr).strip() or "unknown"
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
 def dump(url: str, out_path: str) -> None:
     """pg_dump in custom format — same flags as migrations/copy_prod_to_sandbox.sh."""
     print("  running pg_dump...")
@@ -128,6 +145,7 @@ def main() -> int:
     filename = f"mhmw-{env_segment}-{stamp}.dump"
 
     print(f"backup_postgres: {args.env} ({mask(url)}) @ {stamp}")
+    print(f"  client: {tool_version('pg_dump')}")
 
     workdir = tempfile.mkdtemp(prefix="mhmw-backup-")
     out_path = os.path.join(workdir, filename)

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -1,0 +1,174 @@
+"""Logical Postgres backup to Cloudflare R2 — layer 2 of the backup design.
+
+Render's managed PITR is layer 1 (3-day window, same account as the database).
+This is the independent, portable copy: a self-contained `pg_dump -Fc` that can
+be restored into any Postgres, anywhere, including during a Render-wide outage.
+See docs/backup-and-dr-runbook.md.
+
+Retention is enforced by R2 lifecycle rules, not by this script — nothing here
+ever deletes a remote object. The tier lives in the key prefix so each tier ages
+on its own clock:
+
+    backups/postgres/prod/daily/2026/08/09/mhmw-prod-2026-08-09T1700Z.dump
+    backups/postgres/prod/weekly/...      (also written on Sundays)
+    backups/postgres/prod/monthly/...     (also written on the 1st)
+
+A Sunday run writes the same dump to daily/ and weekly/ as two independent
+objects, which is what produces a real backup ladder without any cleanup code.
+
+Usage
+-----
+    python -m scripts.backup_postgres                      # production (default)
+    python -m scripts.backup_postgres --env sandbox
+    python -m scripts.backup_postgres --skip-upload        # dump + verify only
+    python -m scripts.backup_postgres --database-url postgresql://...
+
+Exits non-zero on any failure so the Render cron surfaces a broken run.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+try:  # allow both `python -m scripts.backup_postgres` and direct execution
+    from scripts import _r2
+    from scripts._db_urls import mask, prod_url, sandbox_url
+except ImportError:  # pragma: no cover - path fixup for direct execution
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts import _r2
+    from scripts._db_urls import mask, prod_url, sandbox_url
+
+# Path segment per environment. Must match the R2 lifecycle rule prefixes
+# exactly (backups/postgres/prod/daily/ etc.) or retention silently won't apply.
+ENV_SEGMENT = {"production": "prod", "sandbox": "sandbox"}
+
+
+def resolve_url(env: str, override: str | None) -> str:
+    if override:
+        return override
+    return prod_url() if env == "production" else sandbox_url()
+
+
+def key_for(env_segment: str, tier: str, now: datetime, filename: str) -> str:
+    return _r2.backup_key("postgres", env_segment, tier, now, filename)
+
+
+def require_tool(name: str) -> None:
+    if shutil.which(name) is None:
+        sys.exit(
+            f"error: {name} not found on PATH.\n"
+            f"Install the Postgres client tools (macOS: brew install libpq, then "
+            f"add its bin to PATH). The major version must be >= the server's — "
+            f"newer is fine, older is refused."
+        )
+
+
+def dump(url: str, out_path: str) -> None:
+    """pg_dump in custom format — same flags as migrations/copy_prod_to_sandbox.sh."""
+    print("  running pg_dump...")
+    result = subprocess.run(
+        ["pg_dump", "--no-owner", "--no-acl", "-Fc", url, "-f", out_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        if "server version" in stderr and "pg_dump version" in stderr:
+            sys.exit(
+                f"error: pg_dump version mismatch.\n{stderr}\n\n"
+                f"Install a pg_dump whose major version is >= the server's."
+            )
+        sys.exit(f"error: pg_dump failed.\n{stderr}")
+
+
+def verify(dump_path: str) -> None:
+    """A dump that will not list is worthless — gate before uploading it."""
+    print("  verifying dump is readable...")
+    result = subprocess.run(
+        ["pg_restore", "--list", dump_path], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        sys.exit(
+            "error: CORRUPT DUMP — pg_restore --list failed. Not uploading.\n"
+            f"{(result.stderr or '').strip()}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--env",
+        choices=sorted(ENV_SEGMENT),
+        default="production",
+        help="which database to back up (default: production)",
+    )
+    parser.add_argument("--database-url", help="explicit URL, overrides --env")
+    parser.add_argument(
+        "--skip-upload",
+        action="store_true",
+        help="dump and verify locally without touching R2 (implies --keep-local)",
+    )
+    parser.add_argument(
+        "--keep-local", action="store_true", help="do not delete the local dump"
+    )
+    args = parser.parse_args()
+
+    require_tool("pg_dump")
+    require_tool("pg_restore")
+
+    now = datetime.now(timezone.utc)
+    env_segment = ENV_SEGMENT[args.env]
+    url = resolve_url(args.env, args.database_url)
+    stamp = f"{now:%Y-%m-%dT%H%MZ}"
+    filename = f"mhmw-{env_segment}-{stamp}.dump"
+
+    print(f"backup_postgres: {args.env} ({mask(url)}) @ {stamp}")
+
+    workdir = tempfile.mkdtemp(prefix="mhmw-backup-")
+    out_path = os.path.join(workdir, filename)
+    keep = args.keep_local or args.skip_upload
+
+    try:
+        dump(url, out_path)
+        size_mb = os.path.getsize(out_path) / (1024 * 1024)
+        print(f"  dump written: {size_mb:.1f} MB")
+        verify(out_path)
+
+        tiers = _r2.tiers_for(now)
+        print(f"  tiers: {', '.join(tiers)}")
+
+        if args.skip_upload:
+            print("  --skip-upload set; would have written:")
+            for tier in tiers:
+                print(f"    s3://<bucket>/{key_for(env_segment, tier, now, filename)}")
+            print(f"  local dump kept at {out_path}")
+            return 0
+
+        s3 = _r2.client()
+        primary = key_for(env_segment, tiers[0], now, filename)
+        _r2.upload(out_path, primary, s3=s3)
+        # Extra tiers are server-side copies — the payload only crosses the wire once.
+        for tier in tiers[1:]:
+            _r2.copy(primary, key_for(env_segment, tier, now, filename), s3=s3)
+
+        print("backup_postgres: OK")
+        return 0
+    finally:
+        if keep:
+            print(f"  (local dump retained: {out_path})")
+        else:
+            # A dump contains every row in the database. Never leave it on disk.
+            try:
+                os.unlink(out_path)
+            except FileNotFoundError:
+                pass
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backup_postgres.py
+++ b/scripts/backup_postgres.py
@@ -116,6 +116,47 @@ def verify(dump_path: str) -> None:
         )
 
 
+# A dump this much smaller than the previous one is treated as a failure rather
+# than a backup. Generous on purpose: it is a corruption tripwire, not a trend
+# monitor, and a false positive here blocks a backup.
+SHRINK_THRESHOLD = 0.5
+
+
+def check_not_shrunk(s3, env_segment: str, size: int, *, allow_shrink: bool) -> None:
+    """Refuse to upload a dump that collapsed in size versus the previous one.
+
+    `pg_dump` can exit zero having captured far less than it should — reduced
+    privileges being the usual cause. The result is a valid archive with a
+    readable table of contents that is missing most of the database, which every
+    other check here would pass. Size is the only signal that catches it.
+    """
+    previous = _r2.latest_object(f"backups/postgres/{env_segment}/daily/", s3=s3)
+    if previous is None:
+        print("  size check: no previous backup to compare against (first run)")
+        return
+
+    ratio = size / previous["Size"] if previous["Size"] else 1.0
+    summary = (
+        f"{size / 1024 / 1024:.1f} MB vs previous "
+        f"{previous['Size'] / 1024 / 1024:.1f} MB ({ratio:.0%})"
+    )
+    if ratio >= SHRINK_THRESHOLD:
+        print(f"  size check: {summary}")
+        return
+
+    if allow_shrink:
+        print(f"  size check: {summary} — SHRANK, allowed by --allow-shrink")
+        return
+
+    sys.exit(
+        f"error: dump shrank to {ratio:.0%} of the previous one ({summary}).\n"
+        f"That is the signature of a partial dump, not a smaller database.\n"
+        f"Previous: {previous['Key']}\n"
+        f"If the database genuinely shrank (a purge, a dropped table), re-run "
+        f"with --allow-shrink."
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
@@ -132,6 +173,11 @@ def main() -> int:
     )
     parser.add_argument(
         "--keep-local", action="store_true", help="do not delete the local dump"
+    )
+    parser.add_argument(
+        "--allow-shrink",
+        action="store_true",
+        help="upload even if the dump is much smaller than the previous one",
     )
     args = parser.parse_args()
 
@@ -168,6 +214,9 @@ def main() -> int:
             return 0
 
         s3 = _r2.client()
+        check_not_shrunk(
+            s3, env_segment, os.path.getsize(out_path), allow_shrink=args.allow_shrink
+        )
         primary = key_for(env_segment, tiers[0], now, filename)
         _r2.upload(out_path, primary, s3=s3)
         # Extra tiers are server-side copies — the payload only crosses the wire once.

--- a/tests/test_backup_keys.py
+++ b/tests/test_backup_keys.py
@@ -1,0 +1,84 @@
+"""Pure unit tests for backup tier selection and R2 key layout.
+
+No Flask, no DB, no network. These guard the two things that would silently
+break retention: the tier a run belongs to, and the key prefix that the R2
+lifecycle rules match on. A typo in either means objects never expire (cost) or
+expire on the wrong clock (data loss).
+"""
+from datetime import datetime, timezone
+
+from scripts._r2 import backup_key, tiers_for
+from scripts.backup_postgres import ENV_SEGMENT, key_for
+
+
+def _utc(iso: str) -> datetime:
+    return datetime.fromisoformat(iso).replace(tzinfo=timezone.utc)
+
+
+class TestTiers:
+    def test_weekday_is_daily_only(self):
+        assert tiers_for(_utc("2026-08-10")) == ["daily"]  # Monday
+
+    def test_sunday_adds_weekly(self):
+        assert tiers_for(_utc("2026-08-09")) == ["daily", "weekly"]  # Sunday
+
+    def test_first_of_month_adds_monthly(self):
+        assert tiers_for(_utc("2026-09-01")) == ["daily", "monthly"]  # Tuesday
+
+    def test_first_of_month_on_a_sunday_hits_all_three(self):
+        assert tiers_for(_utc("2026-11-01")) == ["daily", "weekly", "monthly"]
+
+    def test_daily_is_always_first(self):
+        # The primary upload is tiers[0]; extra tiers are server-side copies of it.
+        for day in ("2026-08-09", "2026-08-10", "2026-09-01", "2026-11-01"):
+            assert tiers_for(_utc(day))[0] == "daily"
+
+
+class TestKeys:
+    def test_key_matches_lifecycle_rule_prefix(self):
+        key = key_for("prod", "daily", _utc("2026-08-09"), "mhmw-prod-x.dump")
+        assert key.startswith("backups/postgres/prod/daily/")
+        assert key == "backups/postgres/prod/daily/2026/08/09/mhmw-prod-x.dump"
+
+    def test_month_and_day_are_zero_padded(self):
+        # Unpadded segments would still match the prefix rule, but sort wrong in
+        # the bucket listing, which is what a human browses during an incident.
+        key = key_for("prod", "monthly", _utc("2026-09-01"), "f.dump")
+        assert "/2026/09/01/" in key
+
+    def test_each_tier_gets_a_distinct_key(self):
+        now = _utc("2026-11-01")
+        keys = {key_for("prod", t, now, "f.dump") for t in tiers_for(now)}
+        assert len(keys) == 3
+
+    def test_production_maps_to_the_prod_segment(self):
+        # The lifecycle rules are written against 'prod', not 'production'.
+        assert ENV_SEGMENT["production"] == "prod"
+        assert key_for(ENV_SEGMENT["production"], "daily", _utc("2026-08-09"), "f").startswith(
+            "backups/postgres/prod/"
+        )
+
+    def test_sandbox_keys_are_not_covered_by_prod_rules(self):
+        key = key_for(ENV_SEGMENT["sandbox"], "daily", _utc("2026-08-09"), "f")
+        assert not key.startswith("backups/postgres/prod/")
+
+
+class TestBlobKeys:
+    """Blob archives use the same scheme under a different category."""
+
+    def test_matches_the_disk_lifecycle_prefix(self):
+        key = backup_key("disk", "prod", "daily", _utc("2026-08-09"), "blobs-x.tar.gz")
+        assert key == "backups/disk/prod/daily/2026/08/09/blobs-x.tar.gz"
+
+    def test_blobs_have_no_monthly_rule_so_drop_that_tier(self):
+        # Only five delete rules exist; backups/disk/prod/monthly/ is not one of
+        # them, so a monthly blob object would never expire.
+        now = _utc("2026-11-01")  # a Sunday and the 1st — all three tiers
+        blob_tiers = [t for t in tiers_for(now) if t != "monthly"]
+        assert blob_tiers == ["daily", "weekly"]
+
+    def test_postgres_and_disk_categories_do_not_collide(self):
+        now = _utc("2026-08-09")
+        assert backup_key("disk", "prod", "daily", now, "f") != backup_key(
+            "postgres", "prod", "daily", now, "f"
+        )

--- a/tests/test_backup_keys.py
+++ b/tests/test_backup_keys.py
@@ -7,6 +7,8 @@ expire on the wrong clock (data loss).
 """
 from datetime import datetime, timezone
 
+import pytest
+
 from scripts._r2 import backup_key, tiers_for
 from scripts.backup_postgres import ENV_SEGMENT, key_for
 
@@ -61,6 +63,52 @@ class TestKeys:
     def test_sandbox_keys_are_not_covered_by_prod_rules(self):
         key = key_for(ENV_SEGMENT["sandbox"], "daily", _utc("2026-08-09"), "f")
         assert not key.startswith("backups/postgres/prod/")
+
+
+class TestShrinkGuard:
+    """A dump can exit zero having captured far less than it should.
+
+    Reduced privileges are the usual cause: valid archive, readable table of
+    contents, most of the database missing. Every other check passes it. Size
+    versus the previous artifact is the only signal that catches it.
+    """
+
+    def _guard(self, monkeypatch, previous_size, new_size, allow_shrink=False):
+        from scripts import _r2, backup_postgres
+
+        monkeypatch.setattr(
+            _r2,
+            "latest_object",
+            lambda prefix, s3=None: (
+                None
+                if previous_size is None
+                else {"Size": previous_size, "Key": "prev.dump"}
+            ),
+        )
+        backup_postgres.check_not_shrunk(
+            None, "prod", new_size, allow_shrink=allow_shrink
+        )
+
+    def test_first_run_has_nothing_to_compare(self, monkeypatch):
+        self._guard(monkeypatch, None, 5_000_000)  # must not raise
+
+    def test_same_size_passes(self, monkeypatch):
+        self._guard(monkeypatch, 5_000_000, 5_000_000)
+
+    def test_modest_shrink_passes(self, monkeypatch):
+        # Real databases fluctuate; the guard is a tripwire, not a trend monitor.
+        self._guard(monkeypatch, 5_000_000, 3_000_000)  # 60%
+
+    def test_growth_passes(self, monkeypatch):
+        self._guard(monkeypatch, 5_000_000, 9_000_000)
+
+    def test_collapse_blocks_the_upload(self, monkeypatch):
+        with pytest.raises(SystemExit):
+            self._guard(monkeypatch, 5_000_000, 1_000_000)  # 20%
+
+    def test_collapse_can_be_overridden(self, monkeypatch):
+        # A genuine purge or dropped table is a legitimate reason to shrink.
+        self._guard(monkeypatch, 5_000_000, 1_000_000, allow_shrink=True)
 
 
 class TestBlobKeys:

--- a/tests/test_storage_roots.py
+++ b/tests/test_storage_roots.py
@@ -1,0 +1,94 @@
+"""Storage roots must all resolve onto the mounted disk when one is configured.
+
+Regression guard for a live bug found 2026-08-09: MATERIAL_ORDER_STORAGE_ROOT and
+LOOKAHEAD_PDF_STORAGE_ROOT were read by their features but never defined in
+Config, so config.get() returned None and both fell back to <repo>/app/storage/,
+inside the deployed code tree. On Render that directory is wiped every deploy, so
+supplier-order attachments and ingested lookahead PDFs were being destroyed while
+their DB rows survived pointing at missing files.
+
+Config is evaluated at import, so these reload the module under a patched env.
+"""
+import importlib
+
+import pytest
+
+import app.config
+
+DISK = "/var/data/pdfs"
+
+
+@pytest.fixture(autouse=True)
+def _restore_config():
+    """Config is module-level state — put it back for everything downstream."""
+    yield
+    importlib.reload(app.config)
+
+
+def _config_with(monkeypatch, **env):
+    for key in (
+        "PDF_STORAGE_ROOT",
+        "PHOTO_STORAGE_ROOT",
+        "MATERIAL_ORDER_STORAGE_ROOT",
+        "LOOKAHEAD_PDF_STORAGE_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    importlib.reload(app.config)
+    return app.config.Config
+
+
+class TestDerivedFromMountedDisk:
+    def test_every_root_lands_on_the_disk(self, monkeypatch):
+        cfg = _config_with(monkeypatch, PDF_STORAGE_ROOT=DISK)
+        assert cfg.PDF_STORAGE_ROOT == "/var/data/pdfs"
+        assert cfg.PHOTO_STORAGE_ROOT == "/var/data/photos"
+        assert cfg.MATERIAL_ORDER_STORAGE_ROOT == "/var/data/order_attachments"
+        assert cfg.LOOKAHEAD_PDF_STORAGE_ROOT == "/var/data/lookahead"
+
+    def test_no_root_escapes_the_mount(self, monkeypatch):
+        # The actual invariant: nothing may resolve outside the mounted disk.
+        cfg = _config_with(monkeypatch, PDF_STORAGE_ROOT=DISK)
+        roots = [
+            cfg.PDF_STORAGE_ROOT,
+            cfg.PHOTO_STORAGE_ROOT,
+            cfg.MATERIAL_ORDER_STORAGE_ROOT,
+            cfg.LOOKAHEAD_PDF_STORAGE_ROOT,
+        ]
+        assert all(r.startswith("/var/data/") for r in roots)
+
+    def test_derived_paths_match_the_render_env_vars(self, monkeypatch):
+        # These exact values are set on the Render service. If the derivation
+        # ever disagrees, prod and local would write to different directories.
+        cfg = _config_with(monkeypatch, PDF_STORAGE_ROOT=DISK)
+        assert cfg.MATERIAL_ORDER_STORAGE_ROOT == "/var/data/order_attachments"
+        assert cfg.LOOKAHEAD_PDF_STORAGE_ROOT == "/var/data/lookahead"
+
+    def test_trailing_slash_on_the_pdf_root_is_tolerated(self, monkeypatch):
+        cfg = _config_with(monkeypatch, PDF_STORAGE_ROOT="/var/data/pdfs/")
+        assert cfg.MATERIAL_ORDER_STORAGE_ROOT == "/var/data/order_attachments"
+        assert cfg.LOOKAHEAD_PDF_STORAGE_ROOT == "/var/data/lookahead"
+
+
+class TestExplicitOverrides:
+    def test_explicit_values_win_over_derivation(self, monkeypatch):
+        cfg = _config_with(
+            monkeypatch,
+            PDF_STORAGE_ROOT=DISK,
+            MATERIAL_ORDER_STORAGE_ROOT="/mnt/other/orders",
+            LOOKAHEAD_PDF_STORAGE_ROOT="/mnt/other/look",
+        )
+        assert cfg.MATERIAL_ORDER_STORAGE_ROOT == "/mnt/other/orders"
+        assert cfg.LOOKAHEAD_PDF_STORAGE_ROOT == "/mnt/other/look"
+
+
+class TestLocalDev:
+    def test_without_a_disk_everything_stays_unset(self, monkeypatch):
+        # No disk configured: the feature modules apply their own
+        # <repo>/app/storage/... fallback. Nothing should be invented here.
+        cfg = _config_with(monkeypatch)
+        assert cfg.PDF_STORAGE_ROOT is None
+        assert cfg.PHOTO_STORAGE_ROOT is None
+        assert cfg.MATERIAL_ORDER_STORAGE_ROOT is None
+        assert cfg.LOOKAHEAD_PDF_STORAGE_ROOT is None


### PR DESCRIPTION
Closes the Postgres half of **K4**, and corrects the premise it rested on.

## The premise was wrong

The *"there is no backup of production"* claim that has headed `docs/feature-catalog.md` since 2026-07-22 — and drove K4's Tier 0 rank for over two weeks — was **wrong about Postgres**. Render-managed PITR (3-day window) had been enabled the entire time. It was right about the binary disk.

The real gaps were narrower but genuine: a 3-day window bounds *detection* (corruption noticed after a weekend is past recovery), PITR lives in the same Render account as the database, and the disk had nothing at all.

## What this adds

| File | Purpose |
|---|---|
| `scripts/_r2.py` | R2 client, upload, server-side copy, tier/key layout |
| `scripts/backup_postgres.py` | dump → integrity gate → size guard → tiered upload |
| `scripts/backup_blobs.py` | tars the disk mount → tiered upload (**temporary**, see below) |

**Retention is pure configuration.** No cleanup code exists anywhere. R2 expires by prefix and age only, so the tier lives in the key path and a run writes the same artifact to each tier it belongs to as independent objects. That produces a ladder with nothing to maintain and nothing that can fail silently.

**Three gates before anything uploads:** `pg_restore --list` must succeed; the dump must not have collapsed to under 50% of the previous one (the signature of a silent partial dump, which passes every other check); and a `finally` always removes the local dump, which holds every row in the database.

## Proven, not assumed

- **First production backup ever run** — 5.3 MB, daily + weekly objects verified byte-identical in R2
- **Recovery drill passed** — a real production artifact pulled from R2 and restored **onto a laptop, off the Render platform entirely**. That is the claim layer 2 exists to make, and restoring into another Render database could not have tested it
- **47 of 47** tables the application models require restored, none missing; app booted against the restored DB
- `pg_restore` in 0.78s; 509 TOC entries; all row counts present
- **pg_dump version risk retired** — Render's runtime ships 18.4 against Postgres 17, so no Docker cron is needed

## Fixes a live data-loss bug

Found by looking, unrelated to backups. `MATERIAL_ORDER_STORAGE_ROOT` and `LOOKAHEAD_PDF_STORAGE_ROOT` were read by their features but never defined in `Config`, so `config.get()` returned `None` and both fell back to `<repo>/app/storage/` inside the deployed code tree — **wiped on every deploy**, while their DB rows survived pointing at files that no longer existed. Supplier-order attachments and ingested lookahead PDFs were affected; marked-up PDFs and photos were always on the mounted disk and never were.

Fixed twice: env vars set on Render, and both roots now derive from `PDF_STORAGE_ROOT` the way `PHOTO_STORAGE_ROOT` already did, so one mounted disk implies all its children.

## Not done, deliberately

**Blob backups are not scheduled.** They cannot run as a Render cron job at all — disks are not visible to cron services — so they would have to live inside the web service. Deferred by decision: Procore still carries PDFs and photos, and the disk migration belongs in the data-lake work rather than as a backup chore. `backup_blobs.py` is written and tested but is **throwaway** once blobs move to object storage.

## ⚠️ On merge

**Switch the cron service's branch from `feature/backup-infrastructure` to `main` before deleting this branch.** The cron was pointed at the feature branch deliberately so the first production run could happen before an unproven path reached `main`. Delete the branch first and the backup stops building silently — the single most likely way for this to break.

## Tests

1194 passing. New coverage for tier selection, key layout (the prefixes the lifecycle rules match on), the shrink guard, and the storage-root regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)