### PR TITLE
Redesign release hub modal (N7 activity, details, change log, attachments)

### DIFF
--- a/app/brain/pdf_review/routes.py
+++ b/app/brain/pdf_review/routes.py
@@ -1,19 +1,19 @@
-"""REST endpoints for Carmen Miranda PDF review (admin-only).
+"""REST endpoints for Carmen Miranda PDF review.
 
 Registered on brain_bp under /brain:
   POST /releases/<release_id>/drawing/versions/<vid>/carmen-review  — enqueue a review (202)
   GET  /releases/<release_id>/drawing/versions/<vid>/carmen-review  — latest review status + findings
 
-Admin-only, matching the "admin-only Carmen Miranda" decision. The POST returns immediately
-(202) with a `pending` row; the review runs on a background thread (worker.py). The
-frontend panel polls the GET until status is `complete` or `error`.
+Per-version GET/POST are open to admin OR drafter (AI review loop in the release hub).
+The POST returns immediately (202) with a `pending` row; the review runs on a background
+thread (worker.py). The frontend panel polls the GET until status is `complete` or `error`.
 """
 import io
 
 from flask import jsonify, current_app, send_file
 
 from app.brain import brain_bp
-from app.auth.utils import admin_required, login_required, get_current_user
+from app.auth.utils import admin_required, drafter_or_admin_required, login_required, get_current_user
 from flask import request
 
 from app.models import (
@@ -46,7 +46,7 @@ def _load_version(release_id, version_id):
     '/releases/<int:release_id>/drawing/versions/<int:version_id>/carmen-review',
     methods=['POST'],
 )
-@admin_required
+@drafter_or_admin_required
 def request_bb_review(release_id, version_id):
     version = _load_version(release_id, version_id)
     if not version:
@@ -82,7 +82,7 @@ def request_bb_review(release_id, version_id):
     '/releases/<int:release_id>/drawing/versions/<int:version_id>/carmen-review',
     methods=['GET'],
 )
-@admin_required
+@drafter_or_admin_required
 def get_bb_review(release_id, version_id):
     version = _load_version(release_id, version_id)
     if not version:

--- a/frontend/src/components/BBReviewPanel.jsx
+++ b/frontend/src/components/BBReviewPanel.jsx
@@ -1,34 +1,55 @@
 /**
- * BBReviewPanel — Carmen Miranda code-compliance review for one PDF drawing version.
+ * BBReviewPanel — Carmen code-compliance review for one PDF drawing version.
  *
- * Admin-only (gate via the `enabled` prop; the backend also enforces @admin_required).
- * Self-contained: loads the latest review on mount, lets an admin kick off a new one,
- * polls while it's `pending`, and renders the findings (severity chip, verdict,
- * computation, and the sheet citations Carmen used).
+ * Gated via `enabled` (admin or drafter). Loads the latest review, can enqueue
+ * a new one, polls while pending, and renders findings + accept/reject feedback.
+ * Optional onCite jumps the hub PDF viewer to a finding's page.
  */
 import React, { useEffect, useRef, useState } from 'react';
 
 import { jobsApi } from '../services/jobsApi';
-import { Finding, FeedbackControls } from './bbReview/shared';
-import { actionableCount } from './bbReview/urgency';
+import { FeedbackControls } from './bbReview/shared';
+import { actionableCount, URGENCY_STYLES, urgencyOf } from './bbReview/urgency';
 
 const POLL_MS = 5000;
 
-export function BBReviewPanel({ releaseId, versionId, enabled }) {
-    const [open, setOpen] = useState(false);
+export function BBReviewPanel({
+    releaseId,
+    versionId,
+    enabled,
+    /** When true, load review as soon as enabled (for badge + default expand). */
+    autoLoad = false,
+    /** (page:number, ruleId?:string) => void — only called when finding has a page. */
+    onCite = null,
+    /** (count:number) => void — actionable findings for the hub badge. */
+    onFlagsChange = null,
+    defaultOpen = false,
+}) {
+    const [open, setOpen] = useState(defaultOpen);
     const [review, setReview] = useState(undefined);   // undefined=unloaded, null=none
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState(null);
     const pollRef = useRef(null);
+    const flagsReported = useRef(null);
 
     const clearPoll = () => {
         if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    };
+
+    const reportFlags = (r) => {
+        if (!onFlagsChange) return;
+        const findings = r?.status === 'complete' ? (r.findings || []) : [];
+        const n = actionableCount(findings);
+        if (flagsReported.current === n) return;
+        flagsReported.current = n;
+        onFlagsChange(n);
     };
 
     const load = async () => {
         try {
             const r = await jobsApi.getBBReview(releaseId, versionId);
             setReview(r);
+            reportFlags(r);
             if (r && r.status === 'pending') startPoll();
             else clearPoll();
         } catch (err) {
@@ -42,17 +63,19 @@ export function BBReviewPanel({ releaseId, versionId, enabled }) {
             try {
                 const r = await jobsApi.getBBReview(releaseId, versionId);
                 setReview(r);
+                reportFlags(r);
                 if (!r || r.status !== 'pending') clearPoll();
             } catch { /* keep polling; transient */ }
         }, POLL_MS);
     };
 
-    // Load once when the panel is first expanded.
+    // Load when expanded, or autoLoad when enabled.
     useEffect(() => {
-        if (open && review === undefined) load();
+        if (!enabled) return undefined;
+        if ((open || autoLoad) && review === undefined) load();
         return clearPoll;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [open]);
+    }, [open, autoLoad, enabled, releaseId, versionId]);
 
     useEffect(() => clearPoll, []);
 
@@ -62,7 +85,9 @@ export function BBReviewPanel({ releaseId, versionId, enabled }) {
         try {
             const r = await jobsApi.requestBBReview(releaseId, versionId);
             setReview(r);
+            reportFlags(r);
             startPoll();
+            setOpen(true);
         } catch (err) {
             setError(err?.message || 'Failed to start review');
         } finally {
@@ -73,79 +98,124 @@ export function BBReviewPanel({ releaseId, versionId, enabled }) {
     if (!enabled) return null;
 
     const findings = review?.findings || [];
-    // Count everything the PM must act on (violations + needs-verification), not just violations.
     const flags = actionableCount(findings);
     const isPending = review?.status === 'pending';
     const canRun = !isPending && !busy;
 
     return (
-        <div className="mt-2 pt-2 border-t border-gray-100 dark:border-slate-700">
+        <div className="mt-2 pt-2 border-t border-hairline">
             <button
                 type="button"
                 onClick={() => setOpen((o) => !o)}
-                className="text-xs font-medium text-yellow-700 dark:text-yellow-400 hover:text-yellow-800 dark:hover:text-yellow-300 flex items-center gap-1"
+                className="text-xs font-medium flex items-center gap-1 bg-transparent border-0 cursor-pointer"
+                style={{ color: 'var(--st-amber-fg)' }}
             >
                 <span>{open ? '▾' : '▸'}</span>
-                <span>🍌 Carmen review</span>
+                <span>Findings</span>
                 {review?.status === 'complete' && (
-                    <span className={flags ? 'text-red-600 dark:text-red-400 font-semibold' : 'text-green-600 dark:text-green-400'}>
-                        {flags ? `${flags} flag${flags > 1 ? 's' : ''}` : 'clear'}
+                    <span
+                        className="font-semibold"
+                        style={{ color: flags ? 'var(--fl-red-bg)' : 'var(--st-green-fg)' }}
+                    >
+                        {flags ? `${flags} to confirm` : 'clear'}
                     </span>
                 )}
-                {isPending && <span className="text-gray-400 dark:text-slate-500 italic">running…</span>}
+                {isPending && <span className="text-ink-3 italic">running…</span>}
             </button>
 
             {open && (
                 <div className="mt-2 space-y-2">
-                    {review === undefined && <p className="text-xs text-gray-400 dark:text-slate-500 italic">Loading…</p>}
+                    {review === undefined && <p className="text-xs text-ink-3 italic">Loading…</p>}
 
                     {review === null && (
-                        <p className="text-xs text-gray-500 dark:text-slate-400">
-                            Submit this set to Carmen for a code-compliance check.
+                        <p className="text-xs text-ink-3">
+                            No review yet — run Carmen for a code-compliance check.
                         </p>
                     )}
 
                     {isPending && (
-                        <p className="text-xs text-gray-500 dark:text-slate-400 italic">
-                            Carmen is reviewing the full set — this takes a couple of minutes.
+                        <p className="text-xs text-ink-3 italic">
+                            Carmen is reviewing — this can take a couple of minutes.
                         </p>
                     )}
 
                     {review?.status === 'error' && (
-                        <p className="text-xs text-red-600 dark:text-red-400">Review failed: {review.error || 'unknown error'}</p>
+                        <p className="text-xs" style={{ color: 'var(--fl-red-bg)' }}>
+                            Review failed: {review.error || 'unknown error'}
+                        </p>
                     )}
 
                     {review?.status === 'complete' && findings.length === 0 && (
-                        <p className="text-xs text-green-700 dark:text-green-300">No issues found against Carmen's known failure modes.</p>
+                        <p className="text-xs" style={{ color: 'var(--st-green-fg)' }}>
+                            No issues found.
+                        </p>
                     )}
 
-                    {review?.status === 'complete' && findings.map((f, i) => (
-                        <div key={i}>
-                            <Finding f={f} />
-                            {/* Accept/deny/notes training loop, keyed by raw finding index. */}
-                            <FeedbackControls
-                                releaseId={releaseId}
-                                reviewId={review.id}
-                                findingIndex={i}
-                                finding={f}
-                                initial={review.feedback?.[i]}
-                            />
-                        </div>
-                    ))}
+                    {review?.status === 'complete' && findings.map((f, i) => {
+                        const bucket = urgencyOf(f);
+                        const style = URGENCY_STYLES[bucket] || URGENCY_STYLES.low;
+                        const canJump = f?.page != null && typeof onCite === 'function';
+                        return (
+                            <div
+                                key={i}
+                                className={`rounded-md border border-hairline border-l-4 ${style.stripe} bg-surface p-2.5 text-sm`}
+                            >
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <span className={`text-[11px] font-semibold px-1.5 py-0.5 rounded ${style.chip}`}>
+                                        {style.label}
+                                    </span>
+                                    {f?.location && (
+                                        <span className="text-xs text-ink-3">{f.location}</span>
+                                    )}
+                                    {f?.rule_id && (
+                                        <span className="text-xs font-mono text-ink-3 ml-auto">{f.rule_id}</span>
+                                    )}
+                                </div>
+                                {f?.issue && <p className="text-ink mt-1">{f.issue}</p>}
+                                {f?.computation && (
+                                    <p
+                                        className="text-xs font-mono text-ink-2 mt-1 whitespace-pre-wrap break-words bg-surface-2 rounded"
+                                        style={{ padding: '6px 8px' }}
+                                    >
+                                        {f.computation}
+                                    </p>
+                                )}
+                                {canJump && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onCite(f.page, f.rule_id || null)}
+                                        className="mt-1.5 text-xs font-medium bg-transparent border-0 cursor-pointer"
+                                        style={{ color: '#b45309' }}
+                                    >
+                                        p{f.page} · jump ↵
+                                    </button>
+                                )}
+                                {/* Hide jump when no page — per product decision. */}
+                                <FeedbackControls
+                                    releaseId={releaseId}
+                                    reviewId={review.id}
+                                    findingIndex={i}
+                                    finding={f}
+                                    initial={review.feedback?.[i]}
+                                />
+                            </div>
+                        );
+                    })}
 
-                    {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+                    {error && <p className="text-xs" style={{ color: 'var(--fl-red-bg)' }}>{error}</p>}
 
                     <div className="flex items-center gap-2 pt-1">
                         <button
                             type="button"
                             onClick={runReview}
                             disabled={!canRun}
-                            className="px-3 py-1.5 text-xs bg-yellow-500 text-white rounded-md font-semibold disabled:opacity-50"
+                            className="px-3 py-1.5 text-xs font-semibold text-white rounded-md disabled:opacity-50 border-0 cursor-pointer"
+                            style={{ background: 'var(--st-amber-fg)' }}
                         >
-                            {review ? 'Re-run Carmen review' : 'Submit to Carmen for review'}
+                            {review ? 'Re-run review' : 'Run Carmen review'}
                         </button>
                         {review?.status === 'complete' && review.model && (
-                            <span className="text-[11px] text-gray-400 dark:text-slate-500">
+                            <span className="text-[11px] text-ink-3">
                                 {review.model}
                                 {review.output_tokens ? ` · ${review.output_tokens} tok` : ''}
                             </span>

--- a/frontend/src/components/EventsList.hub.test.jsx
+++ b/frontend/src/components/EventsList.hub.test.jsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import axios from 'axios';
+import EventsList, { fieldLabelForAction, fromToOf } from './EventsList.jsx';
+
+vi.mock('axios', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+    },
+}));
+
+const EVENTS = [
+    {
+        id: 1,
+        type: 'job',
+        action: 'update_stage',
+        user_name: 'David Servold',
+        source: 'Brain',
+        created_at: '2026-04-16T07:00:00',
+        job: 340,
+        release: '481',
+        payload: { from: 'Paint complete', to: 'Shipping completed' },
+        current_value: 'Shipping completed',
+    },
+    {
+        id: 2,
+        type: 'job',
+        action: 'update_fab_order',
+        user_name: 'David Servold',
+        source: 'Brain',
+        created_at: '2026-04-16T07:00:30',
+        job: 340,
+        release: '481',
+        payload: { from: 3, to: 1 },
+        current_value: 1,
+    },
+    {
+        id: 3,
+        type: 'job',
+        action: 'update_notes',
+        user_name: 'Bill ONeill',
+        source: 'Brain',
+        created_at: '2026-04-30T06:53:00',
+        job: 340,
+        release: '481',
+        payload: { from: '', to: 'Need to paint and ship clevis rods.' },
+        current_value: 'Need to paint and ship clevis rods.',
+    },
+];
+
+describe('fieldLabelForAction / fromToOf', () => {
+    it('maps raw actions to plain labels', () => {
+        expect(fieldLabelForAction('update_fab_order')).toBe('Fab Order');
+        expect(fieldLabelForAction('update_stage')).toBe('Stage');
+        expect(fieldLabelForAction('update_notes')).toBe('Notes');
+        expect(fieldLabelForAction('update_ship_date')).toBe('Ship Date');
+        expect(fieldLabelForAction('update_something_else')).toBe('Something Else');
+    });
+
+    it('extracts from/to from job payloads', () => {
+        expect(fromToOf(EVENTS[0])).toEqual({ from: 'Paint complete', to: 'Shipping completed' });
+    });
+});
+
+describe('EventsList variant=hub', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        axios.get.mockResolvedValue({ data: { events: EVENTS } });
+    });
+
+    it('renders summary, day groups, field labels, and no Identifier column', async () => {
+        render(
+            <EventsList
+                variant="hub"
+                jobFilter="340"
+                releaseFilter="481"
+            />
+        );
+
+        expect(await screen.findByText('3 changes')).toBeInTheDocument();
+        expect(screen.getByText('Newest first')).toBeInTheDocument();
+        expect(screen.getByText('Stage')).toBeInTheDocument();
+        expect(screen.getByText('Fab Order')).toBeInTheDocument();
+        expect(screen.getByText('Notes')).toBeInTheDocument();
+
+        expect(screen.getByText('Paint complete')).toBeInTheDocument();
+        expect(screen.getByText('Shipping completed')).toBeInTheDocument();
+
+        expect(screen.queryByText('Identifier')).not.toBeInTheDocument();
+        expect(screen.queryByText('update_stage')).not.toBeInTheDocument();
+        expect(screen.queryByText('update_fab_order')).not.toBeInTheDocument();
+
+        expect(screen.getAllByText('Brain').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByRole('button', { name: /Undo/i }).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not use hub layout for default variant', async () => {
+        render(
+            <EventsList
+                jobFilter="340"
+                releaseFilter="481"
+            />
+        );
+
+        expect(await screen.findByText('Identifier')).toBeInTheDocument();
+        expect(screen.getByText('update_stage')).toBeInTheDocument();
+    });
+
+    it('expands payload on toggle', async () => {
+        render(
+            <EventsList
+                variant="hub"
+                jobFilter="340"
+                releaseFilter="481"
+            />
+        );
+
+        expect(await screen.findByText('3 changes')).toBeInTheDocument();
+
+        const toggles = screen.getAllByText(/payload/);
+        fireEvent.click(toggles[0]);
+        await waitFor(() => {
+            expect(screen.getByText(/"from"/)).toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/components/EventsList.jsx
+++ b/frontend/src/components/EventsList.jsx
@@ -1,21 +1,28 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: Reusable events table with fetch, payload expansion, and undo confirmation. Powers both the Events page and the EventsModal embedded in detail modals.
+ * purpose: Reusable events viewer — full table for Events page / EventsModal; hub
+ *   Change Log layout (day groups, plain-language diffs, no Identifier) for ReleaseHubModal.
  * exports:
- *   EventsList: Self-contained events viewer that takes filter props and handles its own data fetching, rendering, and undo flow
- * imports_from: [react, axios, react-dom, ../utils/api]
- * imported_by: [frontend/src/pages/Events.jsx, frontend/src/components/EventsModal.jsx]
+ *   EventsList: Self-contained events viewer (fetch, expand, undo)
+ *   fieldLabelForAction: map raw action → human field label (tests)
+ *   fromToOf: extract from/to from event payload (tests)
+ * imports_from: [react, axios, react-dom, ../utils/api, ../utils/stageTint]
+ * imported_by: [frontend/src/pages/Events.jsx, frontend/src/components/EventsModal.jsx,
+ *   frontend/src/components/ReleaseHubModal.jsx]
  * invariants:
  *   - Refetches whenever any filter prop changes
- *   - Undo POST hits /brain/events/{id}/undo for job events and /brain/submittal-events/{id}/undo for submittal events
- *   - Toast and undo-confirmation render via portal so they sit above any wrapping modal
+ *   - Undo POST hits /brain/events/{id}/undo for job events and /brain/submittal-events/{id}/undo
+ *   - Toast and undo-confirmation render via portal above wrapping modals
+ *   - variant="default" keeps the Events page table; variant="hub" is release-modal only
+ * updated_by_agent: 2026-08-08T00:00:00Z
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import axios from 'axios';
 
 import { API_BASE_URL } from '../utils/api';
+import { stageTint } from '../utils/stageTint';
 
 const UNDO_WHITELIST = new Set([
     'update_stage',
@@ -30,6 +37,32 @@ const UNDO_ACTION_LABEL = {
     update_fab_order: 'Fab Order',
     update_start_install: 'Start Install',
 };
+
+/** Plain field labels for hub Change Log — never render raw action names. */
+const ACTION_FIELD_LABEL = {
+    ...UNDO_ACTION_LABEL,
+    update_ship_date: 'Ship Date',
+    clear_hard_date: 'Start Install',
+    update_invoiced: 'Invoiced',
+    update_job_comp: 'Install Prog',
+    update_released: 'Released',
+    update_comp_eta: 'Comp. ETA',
+    update_paint_color: 'Paint Color',
+    update_installer: 'Installer',
+    update_num_guys: 'Crew',
+    update_install_hrs: 'Install Hrs',
+    update_fab_hrs: 'Fab Hrs',
+    update_pm: 'PM',
+    update_by: 'By',
+};
+
+export function fieldLabelForAction(action) {
+    if (!action) return 'Change';
+    if (ACTION_FIELD_LABEL[action]) return ACTION_FIELD_LABEL[action];
+    // update_foo_bar → Foo Bar
+    const stripped = String(action).replace(/^update_/, '').replace(/_/g, ' ');
+    return stripped.replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 const DWL_UNDO_FIELDS = new Set([
     'order_number',
@@ -129,9 +162,83 @@ const formatPayloadValue = (action, value) => {
     return String(value);
 };
 
-// Build the list of cascaded reverts shown below the primary undo line. Job events
-// surface them via `linked_children`; DWL step events embed the swapped neighbor's
-// change in `payload.swapped_with` rather than emitting a separate child event.
+export function fromToOf(event) {
+    const payload = event?.payload || {};
+    if (event?.type === 'submittal') {
+        const field = dwlPayloadField(event);
+        if (field) {
+            const inner = payload[field] || {};
+            return { from: inner.old, to: inner.new };
+        }
+    }
+    const from = payload.from ?? payload.old ?? payload.old_value ?? null;
+    const to = payload.to ?? payload.new ?? payload.new_value ?? null;
+    return { from, to };
+}
+
+/** Pretty display for a from/to chip (dates without UTC off-by-one). */
+function displayValue(value) {
+    if (value === null || value === undefined || value === '') return '—';
+    const s = String(value);
+    if (/^asap$/i.test(s.trim())) return 'ASAP';
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+    if (m) {
+        const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+        if (!isNaN(d)) {
+            return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+    }
+    return s;
+}
+
+function dayBucket(iso) {
+    if (!iso) return { key: 'unknown', label: 'UNKNOWN DATE' };
+    const d = new Date(iso);
+    if (isNaN(d)) return { key: 'unknown', label: 'UNKNOWN DATE' };
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const dow = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase();
+    const mon = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase();
+    const day = d.getDate();
+    return { key, label: `${dow} · ${mon} ${day}` };
+}
+
+function formatTimeOnly(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (isNaN(d)) return '—';
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
+function formatRangeLabel(events) {
+    if (!events.length) return '';
+    const times = events
+        .map((e) => new Date(e.created_at).getTime())
+        .filter((t) => Number.isFinite(t));
+    if (!times.length) return '';
+    const min = new Date(Math.min(...times));
+    const max = new Date(Math.max(...times));
+    const fmt = (d) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const a = fmt(min);
+    const b = fmt(max);
+    return a === b ? a : `${a} – ${b}`;
+}
+
+function groupEventsByDay(events) {
+    const groups = [];
+    const indexByKey = new Map();
+    for (const event of events || []) {
+        const { key, label } = dayBucket(event.created_at);
+        let g = indexByKey.get(key);
+        if (!g) {
+            g = { key, label, events: [] };
+            indexByKey.set(key, g);
+            groups.push(g);
+        }
+        g.events.push(event);
+    }
+    return groups;
+}
+
 function buildLinkedRevertItems(undoTarget) {
     const items = [];
     if (undoTarget.linked_children && undoTarget.linked_children.length > 0) {
@@ -161,6 +268,282 @@ const UNDO_DISCLAIMER = {
     job: 'Undo reverts this row only. Cascaded changes outside this row (scheduling for other releases, other rows in the same stash session) are not rolled back.',
 };
 
+function DiffChip({ value, variant = 'old', stageName = null }) {
+    const blank = value === null || value === undefined || value === '';
+    const text = blank ? '—' : displayValue(value);
+    let bg = 'var(--head-bg)';
+    let fg = 'var(--text-2)';
+    if (variant === 'new') {
+        if (stageName) {
+            const t = stageTint(stageName);
+            bg = t.bg;
+            fg = t.fg;
+        } else {
+            bg = 'var(--st-green-bg)';
+            fg = 'var(--st-green-fg)';
+        }
+    }
+    return (
+        <span
+            className="inline-block font-mono font-semibold"
+            style={{
+                fontSize: 11,
+                padding: '2px 7px',
+                borderRadius: 5,
+                background: bg,
+                color: fg,
+                maxWidth: variant === 'old' ? 150 : 250,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                verticalAlign: 'middle',
+            }}
+            title={text}
+        >
+            {text}
+        </span>
+    );
+}
+
+function HubSourceChip({ source }) {
+    const s = (source || '').toString();
+    let bg = 'var(--head-bg)';
+    let fg = 'var(--text-2)';
+    if (s === 'Brain') {
+        bg = 'var(--st-amber-bg)';
+        fg = 'var(--st-amber-fg)';
+    } else if (s === 'Trello') {
+        bg = 'var(--st-blue-bg)';
+        fg = 'var(--st-blue-fg)';
+    } else if (s === 'Procore') {
+        bg = 'var(--st-purple-bg)';
+        fg = 'var(--st-purple-fg)';
+    }
+    return (
+        <span
+            className="inline-block font-semibold"
+            style={{
+                fontSize: 11,
+                padding: '2px 7px',
+                borderRadius: 5,
+                background: bg,
+                color: fg,
+            }}
+        >
+            {s || '—'}
+        </span>
+    );
+}
+
+function HubDayDivider({ label }) {
+    return (
+        <div className="flex items-center" style={{ gap: 8, margin: '14px 0 6px' }}>
+            <span
+                className="font-bold uppercase shrink-0"
+                style={{ fontSize: 10, letterSpacing: '.04em', color: 'var(--text-3)' }}
+            >
+                {label}
+            </span>
+            <div className="flex-1 min-w-0" style={{ height: 1, background: 'var(--border)' }} />
+        </div>
+    );
+}
+
+function HubChangeRow({
+    event,
+    expanded,
+    onTogglePayload,
+    onUndo,
+}) {
+    const { from, to } = fromToOf(event);
+    const field = event.type === 'submittal'
+        ? (DWL_FIELD_LABEL[dwlPayloadField(event)] || fieldLabelForAction(event.action))
+        : fieldLabelForAction(event.action);
+    const isStage = event.action === 'update_stage';
+    const isNotes = event.action === 'update_notes'
+        || (event.type === 'submittal' && dwlPayloadField(event) === 'notes');
+    const longNotes = isNotes && (
+        String(from || '').length > 80 || String(to || '').length > 80
+    );
+    const { canUndo, reason } = getUndoEligibility(event);
+    const uniqueKey = `${event.type}-${event.id}`;
+
+    return (
+        <div
+            className="border-b border-hairline"
+            style={{ padding: '8px 0' }}
+            onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(30,90,200,.05)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+        >
+            <div
+                className="grid items-center gap-2"
+                style={{
+                    gridTemplateColumns: '66px 118px minmax(0,1fr) 64px 64px',
+                }}
+            >
+                <span className="font-mono text-ink-3" style={{ fontSize: 11.5 }}>
+                    {formatTimeOnly(event.created_at)}
+                </span>
+                <span className="text-ink truncate font-medium" style={{ fontSize: 12.5 }} title={event.user_name || ''}>
+                    {event.user_name || '—'}
+                </span>
+                <div className="min-w-0">
+                    <div className="flex items-center flex-wrap" style={{ gap: 6 }}>
+                        <span className="text-ink-2 shrink-0" style={{ fontSize: 12 }}>{field}</span>
+                        {!longNotes && (
+                            <>
+                                <DiffChip value={from} variant="old" />
+                                <span className="text-ink-3" style={{ fontSize: 12 }}>→</span>
+                                <DiffChip
+                                    value={to}
+                                    variant="new"
+                                    stageName={isStage ? String(to || '') : null}
+                                />
+                            </>
+                        )}
+                        {longNotes && (
+                            <button
+                                type="button"
+                                onClick={() => onTogglePayload(uniqueKey)}
+                                className="font-mono text-brand bg-transparent border-0 cursor-pointer"
+                                style={{ fontSize: 11 }}
+                            >
+                                payload {expanded ? '▴' : '▾'}
+                            </button>
+                        )}
+                        {isUndoEvent(event) && (
+                            <span
+                                className="font-semibold uppercase"
+                                style={{
+                                    fontSize: 9.5,
+                                    padding: '1px 5px',
+                                    borderRadius: 4,
+                                    background: 'var(--st-amber-bg)',
+                                    color: 'var(--st-amber-fg)',
+                                }}
+                            >
+                                undo
+                            </span>
+                        )}
+                    </div>
+                    {longNotes && !expanded && (
+                        <div className="text-ink-2 truncate" style={{ fontSize: 12, marginTop: 3 }} title={displayValue(to)}>
+                            {displayValue(to)}
+                        </div>
+                    )}
+                </div>
+                <div className="flex justify-center">
+                    <HubSourceChip source={event.source} />
+                </div>
+                <div className="flex justify-end">
+                    <button
+                        type="button"
+                        onClick={() => canUndo && onUndo(event)}
+                        disabled={!canUndo}
+                        title={canUndo ? 'Revert this change' : reason}
+                        className="font-semibold border cursor-pointer disabled:cursor-not-allowed"
+                        style={{
+                            fontSize: 11,
+                            padding: '3px 7px',
+                            borderRadius: 6,
+                            background: canUndo ? 'var(--surface)' : 'var(--surface-2)',
+                            color: canUndo ? 'var(--accent)' : 'var(--text-3)',
+                            borderColor: canUndo ? 'var(--border-strong)' : 'var(--border)',
+                            opacity: canUndo ? 1 : 0.55,
+                        }}
+                    >
+                        ↺ Undo
+                    </button>
+                </div>
+            </div>
+            {expanded && (
+                <pre
+                    className="font-mono border border-hairline bg-surface-2 text-ink overflow-x-auto"
+                    style={{
+                        marginTop: 8,
+                        marginLeft: 66 + 8 + 118 + 8,
+                        padding: 10,
+                        borderRadius: 8,
+                        fontSize: 11,
+                        lineHeight: 1.4,
+                        maxHeight: 200,
+                    }}
+                >
+                    {formatPayload(event.payload)}
+                </pre>
+            )}
+            {/* Short notes: optional expand for raw payload */}
+            {!longNotes && (
+                <div style={{ marginLeft: 66 + 8 + 118 + 8, marginTop: 2 }}>
+                    <button
+                        type="button"
+                        onClick={() => onTogglePayload(uniqueKey)}
+                        className="font-mono text-ink-3 bg-transparent border-0 cursor-pointer hover:text-brand"
+                        style={{ fontSize: 10.5, padding: 0 }}
+                    >
+                        {expanded ? 'hide payload ▴' : 'payload ▾'}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function HubChangeLog({
+    events,
+    expandedPayload,
+    togglePayload,
+    setUndoTarget,
+}) {
+    const groups = useMemo(() => groupEventsByDay(events), [events]);
+    const range = formatRangeLabel(events);
+    const count = events.length;
+
+    if (count === 0) {
+        return (
+            <div className="text-center" style={{ padding: '48px 16px' }}>
+                <p className="text-ink-3" style={{ fontSize: 13 }}>No changes on this release yet.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className="flex items-baseline justify-between flex-wrap" style={{ gap: 8, marginBottom: 4 }}>
+                <span className="text-ink-2" style={{ fontSize: 13 }}>
+                    <span className="font-semibold text-ink">
+                        {count} change{count === 1 ? '' : 's'}
+                    </span>
+                    {range ? (
+                        <span className="text-ink-3">
+                            {' · '}{range}
+                        </span>
+                    ) : null}
+                </span>
+                <span className="text-ink-3" style={{ fontSize: 10.5 }}>Newest first</span>
+            </div>
+
+            {groups.map((group) => (
+                <div key={group.key}>
+                    <HubDayDivider label={group.label} />
+                    {group.events.map((event) => {
+                        const uniqueKey = `${event.type}-${event.id}`;
+                        return (
+                            <HubChangeRow
+                                key={uniqueKey}
+                                event={event}
+                                expanded={!!expandedPayload[uniqueKey]}
+                                onTogglePayload={togglePayload}
+                                onUndo={setUndoTarget}
+                            />
+                        );
+                    })}
+                </div>
+            ))}
+        </div>
+    );
+}
+
 export function EventsList({
     submittalId = '',
     jobFilter = '',
@@ -169,7 +552,12 @@ export function EventsList({
     selectedSource = '',
     selectedUser = '',
     limit = 50,
+    // 'default' = Events page / EventsModal. 'hub' = Release hub Change Log tab.
+    variant = 'default',
 }) {
+    const isHub = variant === 'hub';
+    const effectiveLimit = isHub && limit === 50 ? 100 : limit;
+
     const [events, setEvents] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -181,13 +569,13 @@ export function EventsList({
     useEffect(() => {
         fetchEvents();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedDate, limit, selectedSource, submittalId, jobFilter, releaseFilter, selectedUser]);
+    }, [selectedDate, effectiveLimit, selectedSource, submittalId, jobFilter, releaseFilter, selectedUser]);
 
     const fetchEvents = async () => {
         setLoading(true);
         setError(null);
         try {
-            const params = { limit };
+            const params = { limit: effectiveLimit };
             if (selectedDate) {
                 params.start = selectedDate;
                 params.end = selectedDate;
@@ -255,150 +643,8 @@ export function EventsList({
         }
     };
 
-    if (loading) {
-        return (
-            <div className="text-center py-12">
-                <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-accent-500 mb-4"></div>
-                <p className="text-gray-600 dark:text-slate-400 font-medium">Loading events...</p>
-            </div>
-        );
-    }
-
-    if (error) {
-        return (
-            <div className="bg-red-50 dark:bg-red-900/30 border-l-4 border-red-500 text-red-700 dark:text-red-200 px-6 py-4 rounded-lg shadow-sm">
-                <div className="flex items-center">
-                    <span className="text-xl mr-3">⚠️</span>
-                    <div>
-                        <p className="font-semibold">Error loading events</p>
-                        <p className="text-sm mt-1">{error}</p>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-
-    return (
+    const undoPortal = (
         <>
-            <div className="flex-1 min-h-0 flex flex-col overflow-hidden gap-1.5">
-                {/* Lattice CSS: tokens.css .job-log-table-frame / .job-log-table (separate
-                    borders + --grid lines, per CURRENT_STYLING_PIN §3). */}
-                <div className="job-log-table-frame flex-1 min-h-0 flex flex-col">
-                    <div className="job-log-table-scroll overflow-auto flex-1 min-h-0">
-                        <table className="job-log-table">
-                            <thead className="sticky top-0 z-10">
-                                <tr>
-                                    <th style={{ width: '13%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Date</th>
-                                    <th style={{ width: '10%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Source</th>
-                                    <th style={{ width: '9%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">User</th>
-                                    <th style={{ width: '9%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Identifier</th>
-                                    <th style={{ width: '15%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Action</th>
-                                    <th style={{ width: '36%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Payload</th>
-                                    <th style={{ width: '8%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Undo</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {events.length === 0 ? (
-                                    <tr>
-                                        <td colSpan="7" className="px-6 py-12 text-center bg-surface">
-                                            <div className="text-gray-400 dark:text-slate-500 text-4xl mb-3">📭</div>
-                                            <p className="text-gray-500 dark:text-slate-400 font-medium">No events found</p>
-                                        </td>
-                                    </tr>
-                                ) : (
-                                    events.map((event, index) => {
-                                        const uniqueKey = `${event.type}-${event.id}`;
-                                        // White / blue-100 zebra bands, same tokens as the Job Log.
-                                        const bandClass = index % 2 === 0 ? 'jl-band-a' : 'jl-band-b';
-                                        return (
-                                            <tr
-                                                key={uniqueKey}
-                                                className={`jl-row ${bandClass}`}
-                                            >
-                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-mono text-center text-ink-2">
-                                                    {formatDateTime(event.created_at)}
-                                                </td>
-                                                <td className="px-2 py-1.5 whitespace-nowrap text-center">
-                                                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-jl-2 font-semibold ${getSourceColor(event.source)}`}>
-                                                        {event.source}
-                                                    </span>
-                                                    {isUndoEvent(event) && (
-                                                        <span
-                                                            className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-700"
-                                                            title="Undo event"
-                                                        >
-                                                            ↶ undo
-                                                        </span>
-                                                    )}
-                                                </td>
-                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl text-center text-ink-2">
-                                                    {event.user_name || '—'}
-                                                </td>
-                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-mono text-center text-ink">
-                                                    {event.type === 'job'
-                                                        ? `${event.job}-${event.release || 'N/A'}`
-                                                        : event.submittal_id || 'N/A'
-                                                    }
-                                                </td>
-                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-medium text-center text-ink">
-                                                    {event.action}
-                                                </td>
-                                                <td className="px-2 py-1.5 text-jl">
-                                                    {expandedPayload[uniqueKey] ? (
-                                                        <div className="space-y-1.5">
-                                                            <pre className="bg-surface-2 p-2 rounded text-jl-2 font-mono overflow-x-auto max-w-md border border-hairline text-ink">
-                                                                {formatPayload(event.payload)}
-                                                            </pre>
-                                                            <button
-                                                                onClick={() => togglePayload(uniqueKey)}
-                                                                className="text-jl-2 text-brand hover:underline font-medium"
-                                                            >
-                                                                ▲ Collapse
-                                                            </button>
-                                                        </div>
-                                                    ) : (
-                                                        <button
-                                                            onClick={() => togglePayload(uniqueKey)}
-                                                            className="text-jl-2 text-brand hover:underline font-medium"
-                                                        >
-                                                            ▼ View Payload
-                                                        </button>
-                                                    )}
-                                                </td>
-                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl text-center">
-                                                    {(() => {
-                                                        const { canUndo, reason } = getUndoEligibility(event);
-                                                        return (
-                                                            <button
-                                                                onClick={() => canUndo && setUndoTarget(event)}
-                                                                disabled={!canUndo}
-                                                                title={canUndo ? 'Revert this change' : reason}
-                                                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-jl-2 font-semibold border transition-colors ${
-                                                                    canUndo
-                                                                        ? 'bg-white dark:bg-slate-700 text-accent-700 dark:text-accent-300 border-accent-300 dark:border-accent-700 hover:bg-accent-50 dark:hover:bg-slate-600 cursor-pointer'
-                                                                        : 'bg-gray-50 dark:bg-slate-800 text-gray-400 dark:text-slate-500 border-gray-200 dark:border-slate-700 cursor-not-allowed'
-                                                                }`}
-                                                            >
-                                                                ↶ Undo
-                                                            </button>
-                                                        );
-                                                    })()}
-                                                </td>
-                                            </tr>
-                                        );
-                                    })
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div className="flex items-center gap-2 text-xs font-semibold text-gray-700 dark:text-slate-200 flex-shrink-0">
-                    <span>
-                        Total: <span className="text-gray-900 dark:text-slate-100 font-bold">{events.length}</span> events
-                    </span>
-                </div>
-            </div>
-
             {undoTarget && createPortal(
                 <div
                     className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40"
@@ -512,6 +758,166 @@ export function EventsList({
                 </div>,
                 document.body
             )}
+        </>
+    );
+
+    if (loading) {
+        return (
+            <div className="text-center py-12">
+                <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-accent-500 mb-4"></div>
+                <p className={isHub ? 'text-ink-3 font-medium' : 'text-gray-600 dark:text-slate-400 font-medium'}>
+                    Loading {isHub ? 'changes' : 'events'}…
+                </p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="bg-red-50 dark:bg-red-900/30 border-l-4 border-red-500 text-red-700 dark:text-red-200 px-6 py-4 rounded-lg shadow-sm">
+                <div className="flex items-center">
+                    <span className="text-xl mr-3">⚠️</span>
+                    <div>
+                        <p className="font-semibold">Error loading events</p>
+                        <p className="text-sm mt-1">{error}</p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (isHub) {
+        return (
+            <>
+                <HubChangeLog
+                    events={events}
+                    expandedPayload={expandedPayload}
+                    togglePayload={togglePayload}
+                    setUndoTarget={setUndoTarget}
+                />
+                {undoPortal}
+            </>
+        );
+    }
+
+    return (
+        <>
+            <div className="flex-1 min-h-0 flex flex-col overflow-hidden gap-1.5">
+                <div className="job-log-table-frame flex-1 min-h-0 flex flex-col">
+                    <div className="job-log-table-scroll overflow-auto flex-1 min-h-0">
+                        <table className="job-log-table">
+                            <thead className="sticky top-0 z-10">
+                                <tr>
+                                    <th style={{ width: '13%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Date</th>
+                                    <th style={{ width: '10%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Source</th>
+                                    <th style={{ width: '9%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">User</th>
+                                    <th style={{ width: '9%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Identifier</th>
+                                    <th style={{ width: '15%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Action</th>
+                                    <th style={{ width: '36%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Payload</th>
+                                    <th style={{ width: '8%' }} className="px-2 py-1.5 text-center text-jl-head font-bold text-ink bg-head-bg leading-tight">Undo</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {events.length === 0 ? (
+                                    <tr>
+                                        <td colSpan="7" className="px-6 py-12 text-center bg-surface">
+                                            <div className="text-gray-400 dark:text-slate-500 text-4xl mb-3">📭</div>
+                                            <p className="text-gray-500 dark:text-slate-400 font-medium">No events found</p>
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    events.map((event, index) => {
+                                        const uniqueKey = `${event.type}-${event.id}`;
+                                        const bandClass = index % 2 === 0 ? 'jl-band-a' : 'jl-band-b';
+                                        return (
+                                            <tr
+                                                key={uniqueKey}
+                                                className={`jl-row ${bandClass}`}
+                                            >
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-mono text-center text-ink-2">
+                                                    {formatDateTime(event.created_at)}
+                                                </td>
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-center">
+                                                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-jl-2 font-semibold ${getSourceColor(event.source)}`}>
+                                                        {event.source}
+                                                    </span>
+                                                    {isUndoEvent(event) && (
+                                                        <span
+                                                            className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-700"
+                                                            title="Undo event"
+                                                        >
+                                                            ↶ undo
+                                                        </span>
+                                                    )}
+                                                </td>
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl text-center text-ink-2">
+                                                    {event.user_name || '—'}
+                                                </td>
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-mono text-center text-ink">
+                                                    {event.type === 'job'
+                                                        ? `${event.job}-${event.release || 'N/A'}`
+                                                        : event.submittal_id || 'N/A'
+                                                    }
+                                                </td>
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl font-medium text-center text-ink">
+                                                    {event.action}
+                                                </td>
+                                                <td className="px-2 py-1.5 text-jl">
+                                                    {expandedPayload[uniqueKey] ? (
+                                                        <div className="space-y-1.5">
+                                                            <pre className="bg-surface-2 p-2 rounded text-jl-2 font-mono overflow-x-auto max-w-md border border-hairline text-ink">
+                                                                {formatPayload(event.payload)}
+                                                            </pre>
+                                                            <button
+                                                                onClick={() => togglePayload(uniqueKey)}
+                                                                className="text-jl-2 text-brand hover:underline font-medium"
+                                                            >
+                                                                ▲ Collapse
+                                                            </button>
+                                                        </div>
+                                                    ) : (
+                                                        <button
+                                                            onClick={() => togglePayload(uniqueKey)}
+                                                            className="text-jl-2 text-brand hover:underline font-medium"
+                                                        >
+                                                            ▼ View Payload
+                                                        </button>
+                                                    )}
+                                                </td>
+                                                <td className="px-2 py-1.5 whitespace-nowrap text-jl text-center">
+                                                    {(() => {
+                                                        const { canUndo, reason } = getUndoEligibility(event);
+                                                        return (
+                                                            <button
+                                                                onClick={() => canUndo && setUndoTarget(event)}
+                                                                disabled={!canUndo}
+                                                                title={canUndo ? 'Revert this change' : reason}
+                                                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-jl-2 font-semibold border transition-colors ${
+                                                                    canUndo
+                                                                        ? 'bg-white dark:bg-slate-700 text-accent-700 dark:text-accent-300 border-accent-300 dark:border-accent-700 hover:bg-accent-50 dark:hover:bg-slate-600 cursor-pointer'
+                                                                        : 'bg-gray-50 dark:bg-slate-800 text-gray-400 dark:text-slate-500 border-gray-200 dark:border-slate-700 cursor-not-allowed'
+                                                                }`}
+                                                            >
+                                                                ↶ Undo
+                                                            </button>
+                                                        );
+                                                    })()}
+                                                </td>
+                                            </tr>
+                                        );
+                                    })
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2 text-xs font-semibold text-gray-700 dark:text-slate-200 flex-shrink-0">
+                    <span>
+                        Total: <span className="text-gray-900 dark:text-slate-100 font-bold">{events.length}</span> events
+                    </span>
+                </div>
+            </div>
+            {undoPortal}
         </>
     );
 }

--- a/frontend/src/components/JobDetailsBody.formatInstallProg.test.jsx
+++ b/frontend/src/components/JobDetailsBody.formatInstallProg.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { formatInstallProg } from './JobDetailsBody.jsx';
+
+describe('formatInstallProg', () => {
+    it('appends % to whole numbers', () => {
+        expect(formatInstallProg(75)).toBe('75%');
+        expect(formatInstallProg('75')).toBe('75%');
+        expect(formatInstallProg('0')).toBe('0%');
+        expect(formatInstallProg('100')).toBe('100%');
+    });
+
+    it('keeps X as X', () => {
+        expect(formatInstallProg('X')).toBe('X');
+        expect(formatInstallProg('x')).toBe('X');
+    });
+
+    it('treats blank and O as empty', () => {
+        expect(formatInstallProg(null)).toBeNull();
+        expect(formatInstallProg('')).toBeNull();
+        expect(formatInstallProg('O')).toBeNull();
+        expect(formatInstallProg('o')).toBeNull();
+    });
+
+    it('does not invent % for decimals or junk', () => {
+        expect(formatInstallProg('0.75')).toBe('0.75');
+        expect(formatInstallProg('75.5')).toBe('75.5');
+        expect(formatInstallProg('half')).toBe('half');
+    });
+});

--- a/frontend/src/components/JobDetailsBody.jsx
+++ b/frontend/src/components/JobDetailsBody.jsx
@@ -71,14 +71,17 @@ export function formatInstallProg(raw) {
     return s;
 }
 
-/** Uppercase section rule. */
-function SectionLabel({ children }) {
+/** Uppercase section rule. Optional `action` sits on the right of the same line. */
+function SectionLabel({ children, action = null }) {
     return (
         <div
-            className="text-jl-label font-bold uppercase text-ink-3 border-b border-hairline-strong"
+            className="flex items-center justify-between gap-2 border-b border-hairline-strong"
             style={{ paddingBottom: 6 }}
         >
-            {children}
+            <span className="text-jl-label font-bold uppercase text-ink-3 min-w-0">
+                {children}
+            </span>
+            {action}
         </div>
     );
 }
@@ -175,6 +178,7 @@ function FlowCell({ label, value, flag = null, accent = false }) {
 export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged = null }) {
     const [materialOrders, setMaterialOrders] = useState([]);
     const [ordersLoading, setOrdersLoading] = useState(false);
+    const [markAllBusy, setMarkAllBusy] = useState(false);
     const materialsRef = useRef(null);
 
     const jobId = job ? (job['Job #'] || job.job) : null;
@@ -209,6 +213,36 @@ export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged
             if (onOrdersChanged) onOrdersChanged();
         } catch {
             // Leave the row unchanged (e.g. insufficient permissions).
+        }
+    };
+
+    // Itemized orders only (not galvanizing/stock shipping_status rows).
+    const pendingReceivable = materialOrders.filter(
+        (o) => !o.shipping_status && o.status !== 'received'
+    );
+
+    const handleMarkAllReceived = async () => {
+        if (!pendingReceivable.length || markAllBusy) return;
+        setMarkAllBusy(true);
+        try {
+            const results = await Promise.all(
+                pendingReceivable.map((o) =>
+                    jobsApi.markMaterialOrderReceived(o.id, true)
+                        .then((data) => ({ id: o.id, order: data?.order || { ...o, status: 'received' } }))
+                        .catch(() => null)
+                )
+            );
+            const byId = new Map(
+                results.filter(Boolean).map((r) => [r.id, r.order])
+            );
+            if (byId.size > 0) {
+                setMaterialOrders((prev) =>
+                    prev.map((o) => (byId.has(o.id) ? byId.get(o.id) : o))
+                );
+                if (onOrdersChanged) onOrdersChanged();
+            }
+        } finally {
+            setMarkAllBusy(false);
         }
     };
 
@@ -373,7 +407,21 @@ export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged
                 </div>
 
                 <div className="min-w-0">
-                    <SectionLabel>Materials ordered</SectionLabel>
+                    <SectionLabel
+                        action={pendingReceivable.length > 0 ? (
+                            <button
+                                type="button"
+                                onClick={handleMarkAllReceived}
+                                disabled={markAllBusy}
+                                className="text-brand font-semibold bg-transparent border-0 cursor-pointer disabled:opacity-50 shrink-0"
+                                style={{ fontSize: 11.5 }}
+                            >
+                                {markAllBusy ? 'Marking…' : 'Mark all received'}
+                            </button>
+                        ) : null}
+                    >
+                        Materials ordered
+                    </SectionLabel>
                     {materialsBlock}
                 </div>
             </div>

--- a/frontend/src/components/JobDetailsBody.jsx
+++ b/frontend/src/components/JobDetailsBody.jsx
@@ -1,22 +1,20 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: The Details pane of the release hub — a two-column dossier (Schedule/Assignment,
- *   Production/Materials) plus banana-code stage flow (N7). Date/stage activity lives on the
- *   right rail, intermingled with notes.
+ * purpose: Details pane of the release hub — date-flow hero, 3-col metadata
+ *   (Assignment / Production / Materials), banana-code stage progress at bottom.
  * exports:
- *   JobDetailsBody: The detail sections, with no dialog chrome, for a host modal to place
+ *   JobDetailsBody: Detail sections only (no dialog chrome) for a host modal
+ *   formatInstallProg: Job Comp → display string (whole number + %, X, or —)
  * imports_from: [react, ../services/jobsApi, ../constants/columnHeaders, ../utils/stageTint,
  *   ./StageIconRow]
  * imported_by: [frontend/src/components/ReleaseHubModal.jsx]
  * invariants:
- *   - Owns its own data fetch, so it loads when mounted rather than on an isOpen flag
- *   - Reads display keys ('Ship Date') with a raw-key fallback ('ship_date') so Job Log and
- *     Timeline rows both render — the two surfaces serialize releases slightly differently
- *   - External links (Events/Procore/Trello) live in the host's header, and the notes thread
- *     in the host's right rail; neither belongs here
- *   - UI only / functionality frozen: no new write paths from this pane
- * updated_by_agent: 2026-08-06T00:00:00Z
+ *   - Owns its own material-orders fetch when mounted
+ *   - Reads display keys ('Ship Date') with raw-key fallback ('ship_date')
+ *   - External links live in the host header; Activity rail is host-owned
+ *   - UI only: no new write paths except existing mark-received on orders
+ * updated_by_agent: 2026-08-08T00:00:00Z
  */
 import React, { useState, useEffect, useRef } from 'react';
 
@@ -28,8 +26,6 @@ import { StageIconRow } from './StageIconRow';
 /** Slightly larger than the table column so the icons read at modal scale. */
 const MODAL_BANANA_ICON_SIZE = 36;
 
-// Label a field exactly as the Job Log table headers it, so the modal and the
-// table speak the same language ('Job Comp' reads "Install Prog" in both).
 const labelFor = (key) => HEADER_OVERRIDES[key] || key;
 
 // Date-only ("2026-06-15") formatter that avoids the UTC-midnight off-by-one
@@ -59,12 +55,28 @@ const formatTimeAgo = (dateString) => {
     }
 };
 
-/** Uppercase section rule. `stacked` adds the top gap for a second section in the same column. */
-function SectionLabel({ children, stacked = false }) {
+/**
+ * Install Prog (Job Comp) display:
+ *   blank / O → null (caller renders —)
+ *   X → "X"
+ *   whole number → "75%" (no decimal handling)
+ */
+export function formatInstallProg(raw) {
+    if (raw == null || raw === false) return null;
+    const s = String(raw).trim();
+    if (!s || s.toUpperCase() === 'O') return null;
+    if (s.toUpperCase() === 'X') return 'X';
+    // Whole digits only — reject decimals / junk.
+    if (/^\d+$/.test(s)) return `${s}%`;
+    return s;
+}
+
+/** Uppercase section rule. */
+function SectionLabel({ children }) {
     return (
         <div
             className="text-jl-label font-bold uppercase text-ink-3 border-b border-hairline-strong"
-            style={{ paddingTop: stacked ? 20 : 0, paddingBottom: 6 }}
+            style={{ paddingBottom: 6 }}
         >
             {children}
         </div>
@@ -72,8 +84,7 @@ function SectionLabel({ children, stacked = false }) {
 }
 
 /**
- * One label/value line. An empty value renders an em dash rather than collapsing
- * the row — a blank Invoiced is information, and dropping the line hides it.
+ * One label/value line. Empty value → em dash (blank Invoiced is still information).
  */
 function Field({ label, value, mono = true, flag = null }) {
     const blank = value == null || value === '' || value === false;
@@ -103,6 +114,61 @@ function MiniFlag({ kind }) {
         >
             {kind}
         </span>
+    );
+}
+
+function FlowArrow() {
+    return (
+        <span
+            aria-hidden
+            className="shrink-0"
+            style={{
+                color: 'var(--border-strong)',
+                fontSize: 17,
+                padding: '0 4px',
+                lineHeight: 1,
+                alignSelf: 'center',
+            }}
+        >
+            →
+        </span>
+    );
+}
+
+/**
+ * One cell in the date-flow hero: uppercase label + mono value (+ optional flag).
+ */
+function FlowCell({ label, value, flag = null, accent = false }) {
+    const blank = value == null || value === '' || value === false;
+    return (
+        <div className="min-w-0" style={{ flex: '1 1 0' }}>
+            <div
+                className="font-bold uppercase flex items-center flex-wrap"
+                style={{
+                    fontSize: 10,
+                    letterSpacing: '.04em',
+                    color: 'var(--text-3)',
+                    gap: 6,
+                    marginBottom: 4,
+                }}
+            >
+                <span>{label}</span>
+                {flag}
+            </div>
+            <div
+                className="font-mono font-semibold truncate"
+                style={{
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: blank
+                        ? '#9aa3b2'
+                        : (accent ? 'var(--accent)' : 'var(--text)'),
+                }}
+                title={blank ? undefined : String(value)}
+            >
+                {blank ? '—' : value}
+            </div>
+        </div>
     );
 }
 
@@ -140,8 +206,6 @@ export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged
             setMaterialOrders((prev) =>
                 prev.map((o) => (o.id === order.id ? (data?.order || o) : o))
             );
-            // Let the Job Log refresh its Mats column right away rather than
-            // waiting for the next poll.
             if (onOrdersChanged) onOrdersChanged();
         } catch {
             // Leave the row unchanged (e.g. insufficient permissions).
@@ -167,28 +231,118 @@ export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged
         && job.start_install_formulaTF === false
         && Boolean(pick('Start install', 'start_install'));
     const startInstall = formatDate(pick('Start install', 'start_install'));
+    const startInstallDisplay = isAsap ? 'ASAP' : startInstall;
+    const startFlag = isAsap
+        ? <MiniFlag kind="ASAP" />
+        : (isHardDate ? <MiniFlag kind="HARD" /> : null);
 
     const stage = pick('Stage', 'stage');
     const tint = stageTint(stage);
+    const installProg = formatInstallProg(pick('Job Comp', 'job_comp'));
+
+    const materialsBlock = (
+        <div ref={materialsRef}>
+            {ordersLoading ? (
+                <p className="text-jl text-ink-3 italic" style={{ padding: '8px 2px' }}>Loading…</p>
+            ) : materialOrders.length === 0 ? (
+                <p className="text-jl text-ink-3 italic" style={{ padding: '8px 2px' }}>None ordered.</p>
+            ) : (
+                materialOrders.map((o) => {
+                    const isStatusOrder = Boolean(o.shipping_status);
+                    const received = o.status === 'received';
+                    const complete = o.shipping_status === 'complete';
+                    const badgeLabel = isStatusOrder
+                        ? (complete ? 'Complete' : 'Planning')
+                        : (received ? 'Received' : 'Ordered');
+                    const done = isStatusOrder ? complete : received;
+                    const pill = done
+                        ? { bg: 'var(--st-green-bg)', fg: 'var(--st-green-fg)' }
+                        : { bg: 'var(--st-amber-bg)', fg: 'var(--st-amber-fg)' };
+                    const meta = [o.supplier, o.po_number ? `PO ${o.po_number}` : null]
+                        .filter(Boolean).join(' · ');
+                    return (
+                        <div key={o.id} className="border-b border-hairline" style={{ padding: '8px 2px' }}>
+                            <div className="flex items-center justify-between gap-3">
+                                <span className="text-jl text-ink-2 min-w-0 truncate">
+                                    {o.quantity != null ? `(${o.quantity}) ` : ''}{o.description}
+                                </span>
+                                <span className="flex items-center gap-2 shrink-0">
+                                    {!isStatusOrder && (
+                                        <button
+                                            onClick={() => handleToggleReceived(o)}
+                                            className="text-jl-2 text-brand hover:underline"
+                                        >
+                                            {received ? 'Mark ordered' : 'Mark received'}
+                                        </button>
+                                    )}
+                                    <span
+                                        className="inline-block font-semibold"
+                                        style={{ padding: '2px 8px', borderRadius: 5, fontSize: 11.5, background: pill.bg, color: pill.fg }}
+                                    >
+                                        {badgeLabel}
+                                    </span>
+                                </span>
+                            </div>
+                            {(meta || o.ordered_by || o.ordered_at) && (
+                                <p className="text-jl-2 text-ink-3 mt-0.5">
+                                    {[meta, o.ordered_by ? `Ordered by ${o.ordered_by}` : null,
+                                        o.ordered_at ? formatDate(o.ordered_at) : null]
+                                        .filter(Boolean).join(' · ')}
+                                </p>
+                            )}
+                        </div>
+                    );
+                })
+            )}
+        </div>
+    );
 
     return (
         <div>
-            <div className="grid grid-cols-1 lg:grid-cols-2" style={{ gap: '0 28px' }}>
-                <div className="min-w-0">
-                    <SectionLabel>Schedule</SectionLabel>
-                    <Field label={labelFor('Released')} value={formatDate(pick('Released', 'released'))} />
-                    <Field label={labelFor('Ship Date')} value={formatDate(pick('Ship Date', 'ship_date'))} />
-                    <Field
-                        label={labelFor('Start install')}
-                        value={isAsap ? 'ASAP' : startInstall}
-                        flag={isAsap ? <MiniFlag kind="ASAP" /> : (isHardDate ? <MiniFlag kind="HARD" /> : null)}
+            {/* ── Date flow hero ─────────────────────────────────────────── */}
+            <div
+                className="border border-hairline bg-surface-2"
+                style={{ borderRadius: 10, padding: '16px 20px', marginBottom: 22 }}
+            >
+                <div className="flex items-stretch min-w-0" style={{ gap: 0 }}>
+                    <FlowCell label="Released" value={formatDate(pick('Released', 'released'))} />
+                    <FlowArrow />
+                    <FlowCell label="Ship Date" value={formatDate(pick('Ship Date', 'ship_date'))} />
+                    <FlowArrow />
+                    <FlowCell
+                        label="Start Install"
+                        value={startInstallDisplay}
+                        flag={startFlag}
                     />
-                    <Field
-                        label={labelFor('Comp. ETA')}
+                    <FlowArrow />
+                    <FlowCell
+                        label="Comp. ETA"
                         value={formatDate(pick('Comp. ETA', 'comp_eta') || job.comp_eta_effective)}
                     />
+                    <div
+                        aria-hidden
+                        className="shrink-0 self-stretch"
+                        style={{
+                            width: 1,
+                            background: 'var(--border)',
+                            margin: '0 16px',
+                        }}
+                    />
+                    <FlowCell label="Install Prog" value={installProg} accent />
+                </div>
+            </div>
 
-                    <SectionLabel stacked>Assignment</SectionLabel>
+            {/* ── Metadata: Assignment · Production · Materials ──────────── */}
+            <div
+                className="grid"
+                style={{
+                    gridTemplateColumns: '1fr 1fr 1fr',
+                    columnGap: 30,
+                    rowGap: 20,
+                }}
+            >
+                <div className="min-w-0">
+                    <SectionLabel>Assignment</SectionLabel>
                     <Field label={labelFor('PM')} value={pick('PM', 'pm')} mono={false} />
                     <Field label={labelFor('BY')} value={pick('BY', 'by')} mono={false} />
                     <Field label="Installer" value={job.installer} mono={false} />
@@ -214,72 +368,17 @@ export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged
                     <Field label="Stage Group" value={pick('Stage Group', 'stage_group')} mono={false} />
                     <Field label={labelFor('Fab Order')} value={pick('Fab Order', 'fab_order')} />
                     <Field label={labelFor('Fab Hrs')} value={pick('Fab Hrs', 'fab_hrs')} />
-                    <Field label={labelFor('Job Comp')} value={pick('Job Comp', 'job_comp')} />
+                    <Field label={labelFor('Job Comp')} value={installProg} />
                     <Field label={labelFor('Invoiced')} value={pick('Invoiced', 'invoiced')} />
+                </div>
 
-                    <div ref={materialsRef}>
-                        <SectionLabel stacked>Materials ordered</SectionLabel>
-                        {ordersLoading ? (
-                            <p className="text-jl text-ink-3 italic" style={{ padding: '8px 2px' }}>Loading…</p>
-                        ) : materialOrders.length === 0 ? (
-                            <p className="text-jl text-ink-3 italic" style={{ padding: '8px 2px' }}>None ordered.</p>
-                        ) : (
-                            materialOrders.map((o) => {
-                                // Status orders (galvanizing / stock) track a planning→complete
-                                // shipping lifecycle, not the itemized ordered/received toggle.
-                                const isStatusOrder = Boolean(o.shipping_status);
-                                const received = o.status === 'received';
-                                const complete = o.shipping_status === 'complete';
-                                const badgeLabel = isStatusOrder
-                                    ? (complete ? 'Complete' : 'Planning')
-                                    : (received ? 'Received' : 'Ordered');
-                                // Status pills reuse the stage tints (handoff §4).
-                                const done = isStatusOrder ? complete : received;
-                                const pill = done
-                                    ? { bg: 'var(--st-green-bg)', fg: 'var(--st-green-fg)' }
-                                    : { bg: 'var(--st-amber-bg)', fg: 'var(--st-amber-fg)' };
-                                const meta = [o.supplier, o.po_number ? `PO ${o.po_number}` : null]
-                                    .filter(Boolean).join(' · ');
-                                return (
-                                    <div key={o.id} className="border-b border-hairline" style={{ padding: '8px 2px' }}>
-                                        <div className="flex items-center justify-between gap-3">
-                                            <span className="text-jl text-ink-2 min-w-0 truncate">
-                                                {o.quantity != null ? `(${o.quantity}) ` : ''}{o.description}
-                                            </span>
-                                            <span className="flex items-center gap-2 shrink-0">
-                                                {!isStatusOrder && (
-                                                    <button
-                                                        onClick={() => handleToggleReceived(o)}
-                                                        className="text-jl-2 text-brand hover:underline"
-                                                    >
-                                                        {received ? 'Mark ordered' : 'Mark received'}
-                                                    </button>
-                                                )}
-                                                <span
-                                                    className="inline-block font-semibold"
-                                                    style={{ padding: '2px 8px', borderRadius: 5, fontSize: 11.5, background: pill.bg, color: pill.fg }}
-                                                >
-                                                    {badgeLabel}
-                                                </span>
-                                            </span>
-                                        </div>
-                                        {(meta || o.ordered_by || o.ordered_at) && (
-                                            <p className="text-jl-2 text-ink-3 mt-0.5">
-                                                {[meta, o.ordered_by ? `Ordered by ${o.ordered_by}` : null,
-                                                    o.ordered_at ? formatDate(o.ordered_at) : null]
-                                                    .filter(Boolean).join(' · ')}
-                                            </p>
-                                        )}
-                                    </div>
-                                );
-                            })
-                        )}
-                    </div>
+                <div className="min-w-0">
+                    <SectionLabel>Materials ordered</SectionLabel>
+                    {materialsBlock}
                 </div>
             </div>
 
-            {/* N7: same bottom placement as the old progress bar; visual is the live
-                Banana Code icon row already used on Job Log / Archive. */}
+            {/* ── Stage progress (banana code) ───────────────────────────── */}
             <div style={{ marginTop: 22 }}>
                 <SectionLabel>Stage progress</SectionLabel>
                 <div className="flex flex-col items-center" style={{ marginTop: 14, gap: 10 }}>

--- a/frontend/src/components/JobDetailsBody.jsx
+++ b/frontend/src/components/JobDetailsBody.jsx
@@ -1,10 +1,13 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: The Details pane of the release hub — a two-column dossier (Schedule/Assignment, Production/Materials) plus the stage progress ladder, per the Aug 2026 redesign handoff §4.
+ * purpose: The Details pane of the release hub — a two-column dossier (Schedule/Assignment,
+ *   Production/Materials) plus banana-code stage flow (N7). Date/stage activity lives on the
+ *   right rail, intermingled with notes.
  * exports:
  *   JobDetailsBody: The detail sections, with no dialog chrome, for a host modal to place
- * imports_from: [react, ../services/jobsApi, ../constants/columnHeaders, ../utils/stageTint]
+ * imports_from: [react, ../services/jobsApi, ../constants/columnHeaders, ../utils/stageTint,
+ *   ./StageIconRow]
  * imported_by: [frontend/src/components/ReleaseHubModal.jsx]
  * invariants:
  *   - Owns its own data fetch, so it loads when mounted rather than on an isOpen flag
@@ -12,13 +15,18 @@
  *     Timeline rows both render — the two surfaces serialize releases slightly differently
  *   - External links (Events/Procore/Trello) live in the host's header, and the notes thread
  *     in the host's right rail; neither belongs here
+ *   - UI only / functionality frozen: no new write paths from this pane
  * updated_by_agent: 2026-08-06T00:00:00Z
  */
 import React, { useState, useEffect, useRef } from 'react';
 
 import { jobsApi } from '../services/jobsApi';
 import { HEADER_OVERRIDES } from '../constants/columnHeaders';
-import { stageTint, STAGE_LADDER, stageLadderIndex } from '../utils/stageTint';
+import { stageTint } from '../utils/stageTint';
+import { StageIconRow } from './StageIconRow';
+
+/** Slightly larger than the table column so the icons read at modal scale. */
+const MODAL_BANANA_ICON_SIZE = 36;
 
 // Label a field exactly as the Job Log table headers it, so the modal and the
 // table speak the same language ('Job Comp' reads "Install Prog" in both).
@@ -161,7 +169,6 @@ export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged
     const startInstall = formatDate(pick('Start install', 'start_install'));
 
     const stage = pick('Stage', 'stage');
-    const currentStageIdx = stageLadderIndex(stage);
     const tint = stageTint(stage);
 
     return (
@@ -271,39 +278,17 @@ export function JobDetailsBody({ job, scrollToMaterials = false, onOrdersChanged
                 </div>
             </div>
 
+            {/* N7: same bottom placement as the old progress bar; visual is the live
+                Banana Code icon row already used on Job Log / Archive. */}
             <div style={{ marginTop: 22 }}>
                 <SectionLabel>Stage progress</SectionLabel>
-                {/* One bar segment per stage: past = accent, current = the stage's
-                    own tint, future = grid grey. The handoff labels every segment,
-                    but it drew a 7-stage ladder — the real one is 17, and 17 labels
-                    at this width truncate to "Relea… Materi… Cut St…", which reads
-                    as noise. Only the ends and the current stage are named; the
-                    rest carry their name as a tooltip. */}
-                <div className="flex items-stretch" style={{ gap: 4, marginTop: 12 }}>
-                    {STAGE_LADDER.map((s, i) => {
-                        const isCurrent = i === currentStageIdx;
-                        const isPast = currentStageIdx >= 0 && i < currentStageIdx;
-                        const bar = isCurrent ? tint.fg : (isPast ? 'var(--accent)' : 'var(--grid)');
-                        return (
-                            <div key={s} className="flex-1 min-w-0" title={s}>
-                                <div style={{ height: 5, borderRadius: 3, background: bar }} />
-                            </div>
-                        );
-                    })}
-                </div>
-                <div className="flex items-baseline justify-between gap-3" style={{ marginTop: 8 }}>
-                    <span className="text-jl-2 text-ink-3">{STAGE_LADDER[0]}</span>
-                    {currentStageIdx >= 0 ? (
-                        <span className="text-jl font-bold text-ink">
-                            {stage}
-                            <span className="text-ink-3 font-medium">
-                                {` · step ${currentStageIdx + 1} of ${STAGE_LADDER.length}`}
-                            </span>
-                        </span>
+                <div className="flex flex-col items-center" style={{ marginTop: 14, gap: 10 }}>
+                    <StageIconRow stage={stage} iconSize={MODAL_BANANA_ICON_SIZE} />
+                    {stage ? (
+                        <span className="text-jl font-bold text-ink">{stage}</span>
                     ) : (
-                        <span className="text-jl-2 text-ink-3 italic">Stage not on the ladder</span>
+                        <span className="text-jl-2 text-ink-3 italic">No stage set</span>
                     )}
-                    <span className="text-jl-2 text-ink-3">{STAGE_LADDER[STAGE_LADDER.length - 1]}</span>
                 </div>
             </div>
 

--- a/frontend/src/components/JobLogCardGrid.jsx
+++ b/frontend/src/components/JobLogCardGrid.jsx
@@ -83,7 +83,7 @@ export default function JobLogCardGrid({
                             key={row.id}
                             job={row}
                             onOpen={(job) => openHub(job, 'details')}
-                            onOpenDrawings={(job) => openHub(job, 'drawings')}
+                            onOpenDrawings={(job) => openHub(job, 'attachments')}
                             onUpdate={onUpdate}
                             stageToGroup={stageToGroup}
                             stageGroupColors={stageGroupColors}

--- a/frontend/src/components/JobsTableRow.jsx
+++ b/frontend/src/components/JobsTableRow.jsx
@@ -1537,6 +1537,10 @@ export function JobsTableRow({ row, columns, formatCellValue, formatDate, rowInd
                 initialTab={hubTab}
                 scrollToMaterials={modalScrollToMaterials}
                 onOrdersChanged={refreshMaterialSummary}
+                onNotesChanged={(notes) => {
+                    setLocalNotes(notes);
+                    setNotesInputValue(notes ?? '');
+                }}
                 onOpenVersion={(vid, mode) => {
                     setIsModalOpen(false);
                     setPdfMarkupVersionId(vid);

--- a/frontend/src/components/PdfReadViewer.jsx
+++ b/frontend/src/components/PdfReadViewer.jsx
@@ -1,0 +1,288 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: Thin read-only PDF page viewer for the release hub Attachments tab.
+ *   Single-page canvas + page nav + Fit/Width zoom. Cite bar when a finding jumps.
+ * exports:
+ *   PdfReadViewer: props { fileUrl, fileName, citePage, citeRuleId, onClearCite }
+ * imports_from: [react, pdfjs-dist]
+ * imported_by: [frontend/src/components/PdfVersionHistoryModal.jsx]
+ * invariants:
+ *   - Read-only — no annotation tools (markup stays in PdfMarkupModal)
+ *   - citePage (1-based) scrolls/jumps to that page when set
+ *   - No page / missing URL → empty drop state
+ * updated_by_agent: 2026-08-08T00:00:00Z
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import * as pdfjsLib from 'pdfjs-dist';
+import workerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
+
+if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
+    pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl;
+}
+
+const FIT = { width: 'width', fit: 'fit' };
+
+export function PdfReadViewer({
+    fileUrl = null,
+    fileName = '',
+    citePage = null,
+    citeRuleId = null,
+    onClearCite = null,
+}) {
+    const canvasRef = useRef(null);
+    const wellRef = useRef(null);
+    const pdfRef = useRef(null);
+    const [numPages, setNumPages] = useState(0);
+    const [page, setPage] = useState(1);
+    const [mode, setMode] = useState(FIT.width);
+    const [scaleBoost, setScaleBoost] = useState(1);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    // Load document when URL changes.
+    useEffect(() => {
+        let cancelled = false;
+        pdfRef.current = null;
+        setNumPages(0);
+        setPage(1);
+        setError(null);
+        if (!fileUrl) {
+            setLoading(false);
+            return undefined;
+        }
+        setLoading(true);
+        (async () => {
+            try {
+                const resp = await fetch(fileUrl, { credentials: 'include' });
+                if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+                const data = await resp.arrayBuffer();
+                if (cancelled) return;
+                const task = pdfjsLib.getDocument({ data });
+                const pdf = await task.promise;
+                if (cancelled) return;
+                pdfRef.current = pdf;
+                setNumPages(pdf.numPages || 0);
+                setPage(1);
+            } catch (err) {
+                if (!cancelled) setError(err?.message || 'Failed to load PDF');
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [fileUrl]);
+
+    // Jump when a finding cites a page.
+    useEffect(() => {
+        if (citePage == null || !numPages) return;
+        const p = Math.max(1, Math.min(numPages, Number(citePage) || 1));
+        setPage(p);
+    }, [citePage, numPages]);
+
+    const renderPage = useCallback(async () => {
+        const pdf = pdfRef.current;
+        const canvas = canvasRef.current;
+        const well = wellRef.current;
+        if (!pdf || !canvas || !well || page < 1) return;
+        try {
+            const pg = await pdf.getPage(page);
+            const base = pg.getViewport({ scale: 1 });
+            const availW = Math.max(200, well.clientWidth - 32);
+            const availH = Math.max(200, well.clientHeight - 32);
+            let scale = availW / base.width;
+            if (mode === FIT.fit) {
+                scale = Math.min(availW / base.width, availH / base.height);
+            }
+            scale = Math.max(0.25, Math.min(4, scale * scaleBoost));
+            const viewport = pg.getViewport({ scale });
+            const ctx = canvas.getContext('2d');
+            canvas.width = viewport.width;
+            canvas.height = viewport.height;
+            await pg.render({ canvasContext: ctx, viewport }).promise;
+        } catch {
+            // Transient during rapid page/zoom changes.
+        }
+    }, [page, mode, scaleBoost]);
+
+    useEffect(() => {
+        renderPage();
+    }, [renderPage, numPages, fileUrl]);
+
+    // Re-render on container resize.
+    useEffect(() => {
+        const el = wellRef.current;
+        if (!el || typeof ResizeObserver === 'undefined') return undefined;
+        const ro = new ResizeObserver(() => { renderPage(); });
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, [renderPage]);
+
+    const go = (delta) => {
+        setPage((p) => Math.max(1, Math.min(numPages, p + delta)));
+        onClearCite?.();
+    };
+
+    if (!fileUrl) {
+        return (
+            <div className="flex-1 min-h-0 flex flex-col" style={{ background: '#232b3e' }}>
+                <div className="flex-1 grid place-items-center text-center" style={{ color: '#9aa3b2' }}>
+                    <div>
+                        <div style={{ fontSize: 28, marginBottom: 8 }}>📄</div>
+                        <p style={{ fontSize: 13 }}>Select a drawing to preview</p>
+                        <p style={{ fontSize: 12, marginTop: 4, opacity: 0.75 }}>
+                            or drop a PDF from the left rail
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex-1 min-h-0 flex flex-col" style={{ background: '#232b3e' }}>
+            {/* Toolbar */}
+            <div
+                className="shrink-0 flex items-center border-b border-hairline bg-surface"
+                style={{ gap: 10, padding: '8px 12px', minHeight: 40 }}
+            >
+                <span className="font-mono text-ink truncate" style={{ fontSize: 12.5, maxWidth: 280 }} title={fileName}>
+                    {fileName || 'drawing.pdf'}
+                </span>
+                <span className="font-mono text-ink-3" style={{ fontSize: 11.5 }}>
+                    p {page} / {numPages || '—'}
+                </span>
+                <div className="flex-1" />
+                <button
+                    type="button"
+                    onClick={() => { setScaleBoost((s) => Math.max(0.5, +(s - 0.15).toFixed(2))); onClearCite?.(); }}
+                    className="font-semibold border border-hairline-strong bg-surface text-ink-2"
+                    style={{ width: 28, height: 26, borderRadius: 6, fontSize: 14 }}
+                    aria-label="Zoom out"
+                >
+                    −
+                </button>
+                <button
+                    type="button"
+                    onClick={() => { setScaleBoost((s) => Math.min(3, +(s + 0.15).toFixed(2))); onClearCite?.(); }}
+                    className="font-semibold border border-hairline-strong bg-surface text-ink-2"
+                    style={{ width: 28, height: 26, borderRadius: 6, fontSize: 14 }}
+                    aria-label="Zoom in"
+                >
+                    +
+                </button>
+                <button
+                    type="button"
+                    onClick={() => { setMode(FIT.fit); setScaleBoost(1); }}
+                    className="font-semibold border"
+                    style={{
+                        height: 26, padding: '0 10px', borderRadius: 6, fontSize: 11.5,
+                        background: mode === FIT.fit ? 'var(--accent-soft)' : 'var(--surface)',
+                        color: mode === FIT.fit ? 'var(--accent)' : 'var(--text-2)',
+                        borderColor: mode === FIT.fit ? 'var(--accent)' : 'var(--border-strong)',
+                    }}
+                >
+                    Fit
+                </button>
+                <button
+                    type="button"
+                    onClick={() => { setMode(FIT.width); setScaleBoost(1); }}
+                    className="font-semibold border"
+                    style={{
+                        height: 26, padding: '0 10px', borderRadius: 6, fontSize: 11.5,
+                        background: mode === FIT.width ? 'var(--accent-soft)' : 'var(--surface)',
+                        color: mode === FIT.width ? 'var(--accent)' : 'var(--text-2)',
+                        borderColor: mode === FIT.width ? 'var(--accent)' : 'var(--border-strong)',
+                    }}
+                >
+                    Width
+                </button>
+                <div className="flex items-center" style={{ gap: 4, marginLeft: 4 }}>
+                    <button
+                        type="button"
+                        disabled={page <= 1}
+                        onClick={() => go(-1)}
+                        className="font-semibold border border-hairline-strong bg-surface text-ink-2 disabled:opacity-40"
+                        style={{ height: 26, padding: '0 8px', borderRadius: 6, fontSize: 11.5 }}
+                    >
+                        Prev
+                    </button>
+                    <button
+                        type="button"
+                        disabled={page >= numPages}
+                        onClick={() => go(1)}
+                        className="font-semibold border border-hairline-strong bg-surface text-ink-2 disabled:opacity-40"
+                        style={{ height: 26, padding: '0 8px', borderRadius: 6, fontSize: 11.5 }}
+                    >
+                        Next
+                    </button>
+                </div>
+            </div>
+
+            {/* Citation bar */}
+            {citePage != null && (
+                <div
+                    className="shrink-0 flex items-center"
+                    style={{
+                        gap: 8,
+                        padding: '7px 12px',
+                        background: '#1b2333',
+                        color: '#f5d08c',
+                        fontSize: 12,
+                    }}
+                >
+                    <span
+                        style={{
+                            width: 7, height: 7, borderRadius: '50%',
+                            background: '#f5d08c', flexShrink: 0,
+                        }}
+                    />
+                    <span className="truncate">
+                        Viewing p{citePage}
+                        {citeRuleId ? (
+                            <> — cited by finding <span className="font-mono">{citeRuleId}</span></>
+                        ) : null}
+                    </span>
+                    {onClearCite && (
+                        <button
+                            type="button"
+                            onClick={onClearCite}
+                            className="ml-auto bg-transparent border-0 cursor-pointer"
+                            style={{ color: '#f5d08c', fontSize: 14, opacity: 0.8 }}
+                            aria-label="Clear citation"
+                        >
+                            ×
+                        </button>
+                    )}
+                </div>
+            )}
+
+            {/* Canvas well */}
+            <div
+                ref={wellRef}
+                className="flex-1 min-h-0 overflow-auto grid place-items-start justify-center"
+                style={{ padding: 16 }}
+            >
+                {loading && (
+                    <p className="text-sm italic" style={{ color: '#9aa3b2', marginTop: 40 }}>Loading PDF…</p>
+                )}
+                {error && (
+                    <p className="text-sm" style={{ color: '#f87171', marginTop: 40 }}>{error}</p>
+                )}
+                {!loading && !error && (
+                    <canvas
+                        ref={canvasRef}
+                        style={{
+                            maxWidth: 820,
+                            background: '#fff',
+                            borderRadius: 4,
+                            boxShadow: '0 12px 40px rgba(0,0,0,.45)',
+                        }}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default PdfReadViewer;

--- a/frontend/src/components/PdfReadViewer.test.jsx
+++ b/frontend/src/components/PdfReadViewer.test.jsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PdfReadViewer } from './PdfReadViewer.jsx';
+
+describe('PdfReadViewer', () => {
+    it('shows empty state when no fileUrl', () => {
+        render(<PdfReadViewer fileUrl={null} />);
+        expect(screen.getByText(/Select a drawing to preview/i)).toBeInTheDocument();
+    });
+
+    it('shows citation bar when citePage is set with a url', () => {
+        // Without a real PDF fetch this still mounts the shell; cite bar is independent of load.
+        // Stub fetch so the load effect does not explode.
+        const orig = global.fetch;
+        global.fetch = () => Promise.reject(new Error('no pdf in unit test'));
+        try {
+            render(
+                <PdfReadViewer
+                    fileUrl="https://example.test/doc.pdf"
+                    fileName="Stair.pdf"
+                    citePage={4}
+                    citeRuleId="stair-terminal-rise-over-max"
+                />
+            );
+            expect(screen.getByText(/Viewing p4/)).toBeInTheDocument();
+            expect(screen.getByText('stair-terminal-rise-over-max')).toBeInTheDocument();
+            expect(screen.getByText('Stair.pdf')).toBeInTheDocument();
+        } finally {
+            global.fetch = orig;
+        }
+    });
+});

--- a/frontend/src/components/PdfVersionHistoryModal.jsx
+++ b/frontend/src/components/PdfVersionHistoryModal.jsx
@@ -1,12 +1,10 @@
 /**
- * Attachment hub for a release, split into two columns:
- *   - Drawings: the saved PDF version history. Each row offers View (read-only)
- *     and Edit (opens the markup modal seeded from that version).
- *   - Photos: a flat list of image attachments, each with an editable optional
- *     note. A "Take photo" button captures straight from the device camera.
+ * Attachment hub for a release:
+ *   - Standalone modal: two-column drawings + photos (legacy layout).
+ *   - Embedded in ReleaseHubModal: left rail (drawings/findings/photos) + thin
+ *     read-only PDF viewer on the right with finding cite jumps.
  *
- * The single "Choose file" picker lives above both columns: PDFs are routed to
- * the Drawings flow (next version), images are routed to the Photos flow.
+ * PDFs → drawing versions; images → photos. Markup authoring stays in PdfMarkupModal.
  */
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -15,6 +13,8 @@ import { jobsApi } from '../services/jobsApi';
 import { fetchMentionableUsers } from '../services/notificationApi';
 import { checkAuth } from '../utils/auth';
 import { BBReviewPanel } from './BBReviewPanel';
+import { PdfReadViewer } from './PdfReadViewer';
+import { actionableCount } from './bbReview/urgency';
 import MentionInput from './shared/MentionInput';
 
 const isPdfFile = (file) =>
@@ -55,6 +55,9 @@ export function PdfVersionHistoryModal({
     // header, Close button) so the hub modal can host the body inside a tab.
     // The host owns closing; only the gate-confirm action survives in the footer.
     embedded = false,
+    // Optional: report total actionable Carmen findings for the hub tab badge.
+    // Wired fully when reviews are prefetched; safe no-op until then.
+    onActionableCount = null,
 }) {
     const [versions, setVersions] = useState([]);
     const [photos, setPhotos] = useState([]);
@@ -70,10 +73,18 @@ export function PdfVersionHistoryModal({
     const [commentDrafts, setCommentDrafts] = useState({});            // versionId -> string
     const [commentBusy, setCommentBusy] = useState({});               // versionId -> bool
     const [mentionableUsers, setMentionableUsers] = useState([]);
-    // Carmen review is admin-only (backend also enforces @admin_required); gate the panel UX.
-    const [isAdmin, setIsAdmin] = useState(false);
+    // Carmen review loop: admin OR drafter (backend: drafter_or_admin_required).
+    const [canReview, setCanReview] = useState(false);
+    // Embedded hub: which version is in the right-pane viewer + cite bar.
+    const [viewingVersionId, setViewingVersionId] = useState(null);
+    const [citePage, setCitePage] = useState(null);
+    const [citeRuleId, setCiteRuleId] = useState(null);
+    // versionId → actionable finding count (for hub tab badge).
+    const [flagsByVersion, setFlagsByVersion] = useState({});
     const fileInputRef = useRef(null);
+    const pdfInputRef = useRef(null);
     const cameraInputRef = useRef(null);
+    const photoInputRef = useRef(null);
 
     const loadVersions = async () => {
         if (!releaseId) return;
@@ -126,11 +137,52 @@ export function PdfVersionHistoryModal({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen]);
 
-    // Admin gate for the Carmen review panel — resolved once when the modal opens.
+    // Admin or drafter may run/view Carmen reviews on a version.
     useEffect(() => {
         if (!isOpen) return;
-        checkAuth().then((u) => setIsAdmin(!!u?.is_admin)).catch(() => setIsAdmin(false));
+        checkAuth()
+            .then((u) => setCanReview(!!(u?.is_admin || u?.is_drafter)))
+            .catch(() => setCanReview(false));
     }, [isOpen]);
+
+    // Default the embedded viewer to the newest drawing once versions load.
+    useEffect(() => {
+        if (!embedded || !versions.length) return;
+        setViewingVersionId((cur) => {
+            if (cur != null && versions.some((v) => v.id === cur)) return cur;
+            return versions[0].id;
+        });
+    }, [embedded, versions]);
+
+    // Sum actionable flags → hub Attachments tab badge.
+    useEffect(() => {
+        if (!onActionableCount) return;
+        const total = Object.values(flagsByVersion).reduce((s, n) => s + (Number(n) || 0), 0);
+        onActionableCount(total);
+    }, [flagsByVersion, onActionableCount]);
+
+    // Prefetch reviews for badge when reviewer can access Carmen.
+    useEffect(() => {
+        if (!isOpen || !canReview || !releaseId || !versions.length) return;
+        let cancelled = false;
+        (async () => {
+            const next = {};
+            await Promise.all(versions.map(async (v) => {
+                try {
+                    const r = await jobsApi.getBBReview(releaseId, v.id);
+                    if (r?.status === 'complete') {
+                        next[v.id] = actionableCount(r.findings || []);
+                    } else {
+                        next[v.id] = 0;
+                    }
+                } catch {
+                    next[v.id] = 0;
+                }
+            }));
+            if (!cancelled) setFlagsByVersion((prev) => ({ ...prev, ...next }));
+        })();
+        return () => { cancelled = true; };
+    }, [isOpen, canReview, releaseId, versions]);
 
     // Auto-expand the version a notification pointed at, once it appears.
     useEffect(() => {
@@ -338,31 +390,7 @@ export function PdfVersionHistoryModal({
                         PDFs go to Drawings; images go to Photos.
                     </span>
                     {(uploading || photoBusy) && <span className="text-sm text-gray-500 dark:text-slate-400">Uploading…</span>}
-                    {/* Embedded: the Procore link has no header to live in, so it
-                        rides at the end of the toolbar instead. */}
-                    {embedded && (
-                        <span className="ml-auto">
-                            {hasViewerUrl ? (
-                                <a
-                                    href={viewerUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-semibold bg-accent-600 text-white hover:bg-accent-700 whitespace-nowrap"
-                                    title="Open this drawing in Procore"
-                                >
-                                    ↗ View in Procore
-                                </a>
-                            ) : (
-                                <span
-                                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-semibold bg-gray-200 dark:bg-slate-600 text-gray-500 dark:text-slate-400 cursor-help select-none whitespace-nowrap"
-                                    title="No FC link found"
-                                    aria-disabled="true"
-                                >
-                                    ↗ View in Procore
-                                </span>
-                            )}
-                        </span>
-                    )}
+                    {/* Embedded hub: Procore lives on the ReleaseHub header — no duplicate link. */}
                 </div>
 
                 {gateStage && (
@@ -493,11 +521,11 @@ export function PdfVersionHistoryModal({
                                             )}
                                         </div>
 
-                                        {/* Carmen Miranda code-compliance review (admin-only) */}
+                                        {/* Carmen review — admin or drafter */}
                                         <BBReviewPanel
                                             releaseId={releaseId}
                                             versionId={v.id}
-                                            enabled={isAdmin}
+                                            enabled={canReview}
                                         />
                                     </li>
                                     );
@@ -628,10 +656,341 @@ export function PdfVersionHistoryModal({
         </>
     );
 
-    // The hub renders the body directly inside its tab pane; the surface follows
-    // the theme so the tab matches the Details pane beside it.
+    // ── Embedded hub: left rail + thin read viewer ─────────────────────────
     if (embedded) {
-        return <div className="flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-800">{body}</div>;
+        const viewing = versions.find((v) => v.id === viewingVersionId) || null;
+        const fileUrl = viewing
+            ? `${API_BASE_URL}/brain/releases/${releaseId}/drawing/versions/${viewing.id}/file`
+            : null;
+        const fileName = viewing
+            ? (viewing.original_filename || `v${viewing.version_number}.pdf`)
+            : '';
+
+        const openInViewer = (versionId) => {
+            setViewingVersionId(versionId);
+            setCitePage(null);
+            setCiteRuleId(null);
+        };
+
+        const handleCite = (page, ruleId) => {
+            setCitePage(page);
+            setCiteRuleId(ruleId);
+        };
+
+        const pillBtn = {
+            fontSize: 11.5,
+            padding: '4px 10px',
+            borderRadius: 999,
+            border: 0,
+            cursor: 'pointer',
+            fontWeight: 600,
+        };
+
+        return (
+            <div className="flex flex-1 min-h-0 bg-surface">
+                {/* Left rail */}
+                <div
+                    className="shrink-0 flex flex-col min-h-0 border-r border-hairline bg-surface overflow-hidden"
+                    style={{ width: 404 }}
+                >
+                    <div className="flex-1 min-h-0 overflow-y-auto" style={{ padding: '12px 14px 18px' }}>
+                        {error && (
+                            <p className="text-sm mb-2" style={{ color: 'var(--fl-red-bg)' }}>{error}</p>
+                        )}
+
+                        {/* DRAWINGS */}
+                        <div className="flex items-center justify-between gap-2" style={{ marginBottom: 10 }}>
+                            <span className="text-jl-label font-bold uppercase text-ink-3">Drawings</span>
+                            <div className="flex items-center gap-1.5">
+                                <button
+                                    type="button"
+                                    onClick={() => pdfInputRef.current?.click()}
+                                    disabled={uploading}
+                                    style={{
+                                        ...pillBtn,
+                                        background: 'var(--accent-soft)',
+                                        color: 'var(--accent)',
+                                        opacity: uploading ? 0.5 : 1,
+                                    }}
+                                >
+                                    {uploading ? 'Uploading…' : '+ Upload PDF'}
+                                </button>
+                                <input
+                                    ref={pdfInputRef}
+                                    type="file"
+                                    accept="application/pdf,.pdf"
+                                    className="hidden"
+                                    onChange={async (e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) await uploadDrawing(file);
+                                        if (pdfInputRef.current) pdfInputRef.current.value = '';
+                                    }}
+                                />
+                            </div>
+                        </div>
+
+                        {loading && <p className="text-jl-2 text-ink-3 italic">Loading…</p>}
+                        {!loading && versions.length === 0 && (
+                            <p className="text-jl-2 text-ink-3 italic" style={{ marginBottom: 16 }}>
+                                No drawings yet — upload a PDF to create v1.
+                            </p>
+                        )}
+                        {!loading && versions.length > 0 && (
+                            <ul className="space-y-2.5" style={{ marginBottom: 18 }}>
+                                {versions.map((v) => {
+                                    const active = v.id === viewingVersionId;
+                                    const flags = flagsByVersion[v.id] || 0;
+                                    return (
+                                        <li
+                                            key={v.id}
+                                            className="border border-hairline bg-surface"
+                                            style={{
+                                                borderRadius: 10,
+                                                padding: 12,
+                                                boxShadow: active ? 'inset 0 0 0 1.5px var(--accent)' : undefined,
+                                            }}
+                                        >
+                                            <div className="flex items-baseline gap-2 flex-wrap">
+                                                <span className="font-semibold text-ink truncate" style={{ fontSize: 13 }}>
+                                                    {v.original_filename || `Drawing v${v.version_number}`}
+                                                </span>
+                                                <span className="font-mono text-ink-3" style={{ fontSize: 11 }}>
+                                                    v{v.version_number}
+                                                </span>
+                                                <span className="text-ink-3 ml-auto" style={{ fontSize: 11 }}>
+                                                    {fmtSize(v.file_size_bytes)}
+                                                </span>
+                                            </div>
+                                            <p className="text-ink-3" style={{ fontSize: 11.5, marginTop: 3 }}>
+                                                {fmtDate(v.uploaded_at)}
+                                                {v.uploaded_by?.name ? ` · ${v.uploaded_by.name}` : ''}
+                                            </p>
+                                            {flags > 0 && (
+                                                <span
+                                                    className="inline-block font-mono font-semibold"
+                                                    style={{
+                                                        marginTop: 6,
+                                                        fontSize: 10.5,
+                                                        padding: '1px 6px',
+                                                        borderRadius: 999,
+                                                        background: '#fef3c7',
+                                                        color: '#b45309',
+                                                    }}
+                                                >
+                                                    ⚠ {flags} to confirm
+                                                </span>
+                                            )}
+                                            <div className="flex items-center flex-wrap" style={{ gap: 8, marginTop: 8 }}>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => openInViewer(v.id)}
+                                                    className="text-brand font-semibold bg-transparent border-0 cursor-pointer"
+                                                    style={{ fontSize: 12 }}
+                                                >
+                                                    View
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => onOpenVersion?.(v.id, 'edit')}
+                                                    className="text-ink-2 font-semibold bg-transparent border-0 cursor-pointer"
+                                                    style={{ fontSize: 12 }}
+                                                >
+                                                    Edit markup
+                                                </button>
+                                            </div>
+                                            {canReview && (
+                                                <BBReviewPanel
+                                                    releaseId={releaseId}
+                                                    versionId={v.id}
+                                                    enabled
+                                                    autoLoad
+                                                    defaultOpen={active && flags > 0}
+                                                    onCite={(page, ruleId) => {
+                                                        openInViewer(v.id);
+                                                        handleCite(page, ruleId);
+                                                    }}
+                                                    onFlagsChange={(n) => {
+                                                        setFlagsByVersion((prev) => (
+                                                            prev[v.id] === n ? prev : { ...prev, [v.id]: n }
+                                                        ));
+                                                    }}
+                                                />
+                                            )}
+                                            {/* Comments still available */}
+                                            <div className="mt-2 pt-2 border-t border-hairline">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => toggleComments(v.id)}
+                                                    className="text-xs font-medium text-brand bg-transparent border-0 cursor-pointer flex items-center gap-1"
+                                                >
+                                                    <span>{expandedComments[v.id] ? '▾' : '▸'}</span>
+                                                    Comments
+                                                    {commentsByVersion[v.id]?.length
+                                                        ? ` (${commentsByVersion[v.id].length})`
+                                                        : ''}
+                                                </button>
+                                                {expandedComments[v.id] && (
+                                                    <div className="mt-2 space-y-2">
+                                                        {commentsByVersion[v.id] === undefined && (
+                                                            <p className="text-xs text-ink-3 italic">Loading…</p>
+                                                        )}
+                                                        {commentsByVersion[v.id]?.map((c) => (
+                                                            <div key={c.id} className="text-sm">
+                                                                <div className="flex items-baseline gap-2">
+                                                                    <span className="font-semibold text-ink">{c.author_name}</span>
+                                                                    <span className="text-xs text-ink-3">{fmtDate(c.created_at)}</span>
+                                                                </div>
+                                                                <p className="text-ink-2 break-words whitespace-pre-wrap">
+                                                                    {renderCommentBody(c.body)}
+                                                                </p>
+                                                            </div>
+                                                        ))}
+                                                        <div className="flex items-end gap-2 pt-1">
+                                                            <MentionInput
+                                                                value={commentDrafts[v.id] || ''}
+                                                                onChange={(val) => setCommentDrafts((prev) => ({ ...prev, [v.id]: val }))}
+                                                                onSubmit={() => submitComment(v.id)}
+                                                                users={mentionableUsers}
+                                                                placeholder="Add a comment… @ to tag"
+                                                                multiline
+                                                                disabled={!!commentBusy[v.id]}
+                                                            />
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => submitComment(v.id)}
+                                                                disabled={!!commentBusy[v.id] || !(commentDrafts[v.id] || '').trim()}
+                                                                className="px-3 py-1.5 text-xs bg-accent-600 text-white rounded-md font-semibold disabled:opacity-50 shrink-0"
+                                                            >
+                                                                Post
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        )}
+
+                        {/* PHOTOS */}
+                        <div className="flex items-center justify-between gap-2" style={{ marginBottom: 10, marginTop: 8 }}>
+                            <span className="text-jl-label font-bold uppercase text-ink-3">Photos</span>
+                            <div className="flex items-center gap-1.5">
+                                <button
+                                    type="button"
+                                    onClick={() => photoInputRef.current?.click()}
+                                    disabled={photoBusy}
+                                    style={{
+                                        ...pillBtn,
+                                        background: 'var(--accent-soft)',
+                                        color: 'var(--accent)',
+                                        opacity: photoBusy ? 0.5 : 1,
+                                    }}
+                                >
+                                    + Upload photo
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => cameraInputRef.current?.click()}
+                                    disabled={photoBusy}
+                                    className="font-semibold border border-hairline-strong bg-surface text-ink-2"
+                                    style={{
+                                        fontSize: 11.5,
+                                        padding: '4px 10px',
+                                        borderRadius: 999,
+                                        opacity: photoBusy ? 0.5 : 1,
+                                    }}
+                                >
+                                    📷 Take
+                                </button>
+                                <input
+                                    ref={photoInputRef}
+                                    type="file"
+                                    accept="image/*"
+                                    className="hidden"
+                                    onChange={async (e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) await uploadPhoto(file, gateStage);
+                                        if (photoInputRef.current) photoInputRef.current.value = '';
+                                    }}
+                                />
+                                <input
+                                    ref={cameraInputRef}
+                                    type="file"
+                                    accept="image/*"
+                                    capture="environment"
+                                    className="hidden"
+                                    onChange={handleCameraCapture}
+                                />
+                            </div>
+                        </div>
+                        {photosLoading && <p className="text-jl-2 text-ink-3 italic">Loading…</p>}
+                        {!photosLoading && photos.length === 0 && (
+                            <p className="text-jl-2 text-ink-3 italic">No photos yet.</p>
+                        )}
+                        {!photosLoading && photos.length > 0 && (
+                            <div
+                                className="grid"
+                                style={{ gridTemplateColumns: '1fr 1fr', gap: 8 }}
+                            >
+                                {photos.map((p) => (
+                                    <a
+                                        key={p.id}
+                                        href={`${API_BASE_URL}/brain/releases/${releaseId}/photos/${p.id}/file`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="block border border-hairline overflow-hidden bg-surface-2"
+                                        style={{ borderRadius: 8, height: 96 }}
+                                        title={p.note || p.original_filename || 'photo'}
+                                    >
+                                        <img
+                                            src={`${API_BASE_URL}/brain/releases/${releaseId}/photos/${p.id}/file`}
+                                            alt={p.original_filename || 'photo'}
+                                            className="w-full h-full object-cover"
+                                        />
+                                    </a>
+                                ))}
+                            </div>
+                        )}
+
+                        {gateStage && (
+                            <div
+                                className="mt-4 p-3 rounded-lg text-sm border"
+                                style={{
+                                    background: gateSatisfied ? 'var(--st-green-bg)' : 'var(--st-amber-bg)',
+                                    color: gateSatisfied ? 'var(--st-green-fg)' : 'var(--st-amber-fg)',
+                                    borderColor: 'var(--border)',
+                                }}
+                            >
+                                {gateSatisfied
+                                    ? `✓ Photo for ${gateStage} attached.`
+                                    : `A photo is required to move to ${gateStage}.`}
+                                {gateSatisfied && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onConfirmStage?.()}
+                                        className="mt-2 block font-semibold underline bg-transparent border-0 cursor-pointer"
+                                        style={{ color: 'inherit' }}
+                                    >
+                                        Confirm {gateStage}
+                                    </button>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                {/* Right: read viewer */}
+                <PdfReadViewer
+                    fileUrl={fileUrl}
+                    fileName={fileName}
+                    citePage={citePage}
+                    citeRuleId={citeRuleId}
+                    onClearCite={() => { setCitePage(null); setCiteRuleId(null); }}
+                />
+            </div>
+        );
     }
 
     return createPortal(

--- a/frontend/src/components/ReleaseActivityFeed.jsx
+++ b/frontend/src/components/ReleaseActivityFeed.jsx
@@ -1,0 +1,83 @@
+/**
+ * @milehigh-header
+ * schema_version: 1
+ * purpose: Shared helpers for date/stage activity summaries used by the release hub
+ *   right rail (intermingled with notes). Display-only over ReleaseEvents.
+ * exports:
+ *   ACTIVITY_ACTIONS: Set of event actions that count as date/stage updates.
+ *   summarizeActivity: One human sentence + author for a ReleaseEvents row.
+ * imports_from: []
+ * imported_by: [frontend/src/components/ReleaseNotesRail.jsx,
+ *   frontend/src/components/ReleaseActivityFeed.test.jsx]
+ * invariants:
+ *   - Dates and stage changes only: update_stage, update_ship_date, update_start_install,
+ *     clear_hard_date. Notes stay on their own action.
+ *   - Pure helpers — no network, no React render of a standalone feed.
+ * updated_by_agent: 2026-08-08T00:00:00Z
+ */
+
+/** Actions that belong in the mixed activity rail (roadmap N7: dates + stage). */
+export const ACTIVITY_ACTIONS = new Set([
+    'update_stage',
+    'update_ship_date',
+    'update_start_install',
+    'clear_hard_date',
+]);
+
+/** Display a date payload value (ISO date or ASAP flag) without UTC off-by-one. */
+const formatDateValue = (value) => {
+    if (value == null || value === '') return null;
+    const s = String(value);
+    if (/^asap$/i.test(s.trim())) return 'ASAP';
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+    if (m) {
+        const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+        if (!isNaN(d)) {
+            return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+    }
+    return s;
+};
+
+const fromTo = (payload = {}) => {
+    const from = payload.from ?? payload.old ?? payload.old_value ?? null;
+    const to = payload.to ?? payload.new ?? payload.new_value ?? null;
+    return { from, to };
+};
+
+/**
+ * One human sentence per event. Full undo / payload detail lives on the Change Log tab.
+ */
+export function summarizeActivity(event) {
+    const action = event.action;
+    const payload = event.payload || {};
+    const { from, to } = fromTo(payload);
+    const author = event.user_name || event.source || 'System';
+
+    if (action === 'update_stage') {
+        if (from && to && from !== to) return { text: `Stage ${from} → ${to}`, author };
+        if (to) return { text: `Stage set to ${to}`, author };
+        return { text: 'Stage updated', author };
+    }
+
+    if (action === 'update_ship_date') {
+        const toLabel = formatDateValue(to);
+        if (toLabel == null) return { text: 'Ship date cleared', author };
+        return { text: `Ship date set to ${toLabel}`, author };
+    }
+
+    if (action === 'update_start_install') {
+        if (payload.asap === true || payload.to_asap === true || /^asap$/i.test(String(to || ''))) {
+            return { text: 'Start install set to ASAP', author };
+        }
+        const toLabel = formatDateValue(to);
+        if (toLabel == null) return { text: 'Start install cleared', author };
+        return { text: `Start install set to ${toLabel}`, author };
+    }
+
+    if (action === 'clear_hard_date') {
+        return { text: 'Hard start-install date cleared', author };
+    }
+
+    return null;
+}

--- a/frontend/src/components/ReleaseActivityFeed.jsx
+++ b/frontend/src/components/ReleaseActivityFeed.jsx
@@ -1,31 +1,32 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: Shared helpers for date/stage activity summaries used by the release hub
- *   right rail (intermingled with notes). Display-only over ReleaseEvents.
+ * purpose: Shared helpers for the release hub Activity rail (notes + stage/date/fab).
  * exports:
- *   ACTIVITY_ACTIONS: Set of event actions that count as date/stage updates.
- *   summarizeActivity: One human sentence + author for a ReleaseEvents row.
+ *   ACTIVITY_ACTIONS: Set of non-note event actions that appear in the rail
+ *   summarizeActivity: One human sentence + author for a ReleaseEvents row
+ *   formatDateValue: Display a date payload without UTC off-by-one
  * imports_from: []
  * imported_by: [frontend/src/components/ReleaseNotesRail.jsx,
  *   frontend/src/components/ReleaseActivityFeed.test.jsx]
  * invariants:
- *   - Dates and stage changes only: update_stage, update_ship_date, update_start_install,
- *     clear_hard_date. Notes stay on their own action.
- *   - Pure helpers — no network, no React render of a standalone feed.
+ *   - Activity rail: notes (separate action), stage, fab order, ship date, start install,
+ *     clear_hard_date. Everything else stays on Change Log only.
+ *   - Pure helpers — no network, no React.
  * updated_by_agent: 2026-08-08T00:00:00Z
  */
 
-/** Actions that belong in the mixed activity rail (roadmap N7: dates + stage). */
+/** Non-note actions that belong in the mixed activity rail. */
 export const ACTIVITY_ACTIONS = new Set([
     'update_stage',
+    'update_fab_order',
     'update_ship_date',
     'update_start_install',
     'clear_hard_date',
 ]);
 
 /** Display a date payload value (ISO date or ASAP flag) without UTC off-by-one. */
-const formatDateValue = (value) => {
+export const formatDateValue = (value) => {
     if (value == null || value === '') return null;
     const s = String(value);
     if (/^asap$/i.test(s.trim())) return 'ASAP';
@@ -39,14 +40,15 @@ const formatDateValue = (value) => {
     return s;
 };
 
-const fromTo = (payload = {}) => {
+export const fromTo = (payload = {}) => {
     const from = payload.from ?? payload.old ?? payload.old_value ?? null;
     const to = payload.to ?? payload.new ?? payload.new_value ?? null;
     return { from, to };
 };
 
 /**
- * One human sentence per event. Full undo / payload detail lives on the Change Log tab.
+ * One human sentence per event (Change Log / fallbacks). Rich chip rendering
+ * in the rail uses structured fields from buildTimeline instead.
  */
 export function summarizeActivity(event) {
     const action = event.action;
@@ -58,6 +60,14 @@ export function summarizeActivity(event) {
         if (from && to && from !== to) return { text: `Stage ${from} → ${to}`, author };
         if (to) return { text: `Stage set to ${to}`, author };
         return { text: 'Stage updated', author };
+    }
+
+    if (action === 'update_fab_order') {
+        if (from != null && to != null && String(from) !== String(to)) {
+            return { text: `Fab Order ${from} → ${to}`, author };
+        }
+        if (to != null) return { text: `Fab Order set to ${to}`, author };
+        return { text: 'Fab Order updated', author };
     }
 
     if (action === 'update_ship_date') {

--- a/frontend/src/components/ReleaseActivityFeed.test.jsx
+++ b/frontend/src/components/ReleaseActivityFeed.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeActivity, ACTIVITY_ACTIONS } from './ReleaseActivityFeed.jsx';
+
+describe('summarizeActivity', () => {
+    it('formats stage transitions with from → to', () => {
+        const s = summarizeActivity({
+            action: 'update_stage',
+            user_name: 'Ryan',
+            payload: { from: 'Cut Start', to: 'Cut Complete' },
+        });
+        expect(s).toEqual({ text: 'Stage Cut Start → Cut Complete', author: 'Ryan' });
+    });
+
+    it('formats ship date sets and clears', () => {
+        expect(summarizeActivity({
+            action: 'update_ship_date',
+            user_name: 'Dave',
+            payload: { from: null, to: '2026-07-28' },
+        }).text).toBe('Ship date set to Jul 28, 2026');
+
+        expect(summarizeActivity({
+            action: 'update_ship_date',
+            user_name: 'Dave',
+            payload: { from: '2026-07-28', to: null },
+        }).text).toBe('Ship date cleared');
+    });
+
+    it('formats start install hard dates and ASAP', () => {
+        expect(summarizeActivity({
+            action: 'update_start_install',
+            user_name: 'Doug',
+            payload: { from: null, to: '2026-08-01' },
+        }).text).toBe('Start install set to Aug 1, 2026');
+
+        expect(summarizeActivity({
+            action: 'update_start_install',
+            user_name: 'Doug',
+            payload: { from: null, to: null, asap: true },
+        }).text).toBe('Start install set to ASAP');
+    });
+
+    it('falls back to source when no user_name', () => {
+        const s = summarizeActivity({
+            action: 'update_stage',
+            source: 'Trello',
+            payload: { to: 'Paint Start' },
+        });
+        expect(s.author).toBe('Trello');
+    });
+
+    it('only treats date + stage actions as feed material', () => {
+        expect(ACTIVITY_ACTIONS.has('update_notes')).toBe(false);
+        expect(ACTIVITY_ACTIONS.has('update_fab_order')).toBe(false);
+        expect(ACTIVITY_ACTIONS.has('update_stage')).toBe(true);
+        expect(ACTIVITY_ACTIONS.has('update_ship_date')).toBe(true);
+        expect(ACTIVITY_ACTIONS.has('update_start_install')).toBe(true);
+        expect(ACTIVITY_ACTIONS.has('clear_hard_date')).toBe(true);
+    });
+});

--- a/frontend/src/components/ReleaseActivityFeed.test.jsx
+++ b/frontend/src/components/ReleaseActivityFeed.test.jsx
@@ -48,12 +48,20 @@ describe('summarizeActivity', () => {
         expect(s.author).toBe('Trello');
     });
 
-    it('only treats date + stage actions as feed material', () => {
+    it('includes stage, fab, and date actions (notes handled separately)', () => {
         expect(ACTIVITY_ACTIONS.has('update_notes')).toBe(false);
-        expect(ACTIVITY_ACTIONS.has('update_fab_order')).toBe(false);
+        expect(ACTIVITY_ACTIONS.has('update_fab_order')).toBe(true);
         expect(ACTIVITY_ACTIONS.has('update_stage')).toBe(true);
         expect(ACTIVITY_ACTIONS.has('update_ship_date')).toBe(true);
         expect(ACTIVITY_ACTIONS.has('update_start_install')).toBe(true);
         expect(ACTIVITY_ACTIONS.has('clear_hard_date')).toBe(true);
+    });
+
+    it('formats fab order transitions', () => {
+        expect(summarizeActivity({
+            action: 'update_fab_order',
+            user_name: 'David',
+            payload: { from: 3, to: 1 },
+        }).text).toBe('Fab Order 3 → 1');
     });
 });

--- a/frontend/src/components/ReleaseHubModal.jsx
+++ b/frontend/src/components/ReleaseHubModal.jsx
@@ -1,17 +1,20 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: Single modal for a release — details, drawings/photos and change log behind tabs, with a threaded notes rail. Styled to the Aug 2026 redesign handoff §4.
+ * purpose: Single modal for a release — Details / Attachments / Change Log, with an
+ *   Activity rail on Details and Change Log (hidden on Attachments for full-width viewer).
  * exports:
- *   ReleaseHubModal: Portal modal with Details / Drawings & Photos / Change Log tabs
- * imports_from: [react, react-dom, ./JobDetailsBody, ./PdfVersionHistoryModal, ./EventsList, ./ReleaseNotesRail, ../utils/stageTint]
- * imported_by: [frontend/src/components/JobsTableRow.jsx, frontend/src/components/JobLogCardGrid.jsx, frontend/src/components/GanttChart.jsx]
+ *   ReleaseHubModal: Portal modal shell for a release
+ * imports_from: [react, react-dom, ./JobDetailsBody, ./PdfVersionHistoryModal, ./EventsList,
+ *   ./ReleaseNotesRail, ../utils/stageTint]
+ * imported_by: [frontend/src/components/JobsTableRow.jsx, frontend/src/components/JobLogCardGrid.jsx,
+ *   frontend/src/components/GanttChart.jsx]
  * invariants:
  *   - Renders via createPortal to document.body to escape table overflow clipping
  *   - Leaves a click-out margin around the panel: the backdrop stays reachable on every edge
  *   - A tab pane stays mounted once visited, so drafts and uploads survive tab switching
- *   - The notes rail sits OUTSIDE the tab panes — notes stay readable whichever tab is open
- * updated_by_agent: 2026-08-06T00:00:00Z
+ *   - Activity rail renders on Details + Change Log only — Attachments takes the full width
+ * updated_by_agent: 2026-08-08T00:00:00Z
  */
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -24,9 +27,14 @@ import { stageTint } from '../utils/stageTint';
 
 const TABS = [
     { key: 'details', label: 'Details' },
-    { key: 'drawings', label: 'Drawings & Photos' },
+    { key: 'attachments', label: 'Attachments' },
     { key: 'changelog', label: 'Change Log' },
 ];
+
+/** Map legacy initialTab values from callers that still pass 'drawings'. */
+const normalizeTab = (tab) => (tab === 'drawings' ? 'attachments' : tab);
+
+const ACTIVITY_RAIL_WIDTH = 346;
 
 export function ReleaseHubModal({
     isOpen,
@@ -39,16 +47,26 @@ export function ReleaseHubModal({
     onOrdersChanged = null,
     initialCommentVersionId = null,
     onOpenVersion = null,
+    /** Actionable Carmen findings count for the Attachments tab badge (0 = hidden). */
+    attachmentsBadgeCount = 0,
+    onAttachmentsBadgeCount = null,
+    /** Called after Activity rail overwrites Job Log notes (parent can refresh row). */
+    onNotesChanged = null,
 }) {
-    const [activeTab, setActiveTab] = useState(initialTab);
+    const startTab = normalizeTab(initialTab);
+    const [activeTab, setActiveTab] = useState(startTab);
     // Panes render once activated and then stay mounted (hidden) so an
     // in-progress comment or note draft isn't thrown away by a tab switch.
-    const [visited, setVisited] = useState(() => ({ [initialTab]: true }));
+    const [visited, setVisited] = useState(() => ({ [startTab]: true }));
+    // Local badge can be lifted from the Attachments pane once reviews load.
+    const [badgeFromPane, setBadgeFromPane] = useState(0);
 
     useEffect(() => {
         if (!isOpen) return;
-        setActiveTab(initialTab);
-        setVisited((prev) => ({ ...prev, [initialTab]: true }));
+        const tab = normalizeTab(initialTab);
+        setActiveTab(tab);
+        setVisited((prev) => ({ ...prev, [tab]: true }));
+        setBadgeFromPane(0);
     }, [isOpen, initialTab]);
 
     useEffect(() => {
@@ -87,6 +105,15 @@ export function ReleaseHubModal({
     const context = [jobName, pm ? `PM ${pm}` : null, by ? `Detailed by ${by}` : null]
         .filter(Boolean).join(' · ');
 
+    const showActivityRail = activeTab === 'details' || activeTab === 'changelog';
+    const badgeCount = Math.max(0, Number(attachmentsBadgeCount) || 0, Number(badgeFromPane) || 0);
+
+    const reportBadge = (n) => {
+        const count = Math.max(0, Number(n) || 0);
+        setBadgeFromPane(count);
+        onAttachmentsBadgeCount?.(count);
+    };
+
     const content = (
         <div
             className="fixed inset-0 z-50 dc-fade flex items-center justify-center p-4"
@@ -96,8 +123,8 @@ export function ReleaseHubModal({
             <div
                 className="dc-pop bg-surface border border-hairline-strong flex flex-col overflow-hidden"
                 style={{
-                    width: 'min(1180px, 94vw)',
-                    height: 'min(760px, 92vh)',
+                    width: 'min(1380px, 96vw)',
+                    height: 'min(860px, 94vh)',
                     borderRadius: 14,
                     boxShadow: 'var(--shadow)',
                 }}
@@ -164,10 +191,11 @@ export function ReleaseHubModal({
                     </div>
 
                     <div className="flex items-center" style={{ gap: 18, marginTop: 12 }}>
-                        {/* Drawings needs the release row's id to fetch versions/photos;
+                        {/* Attachments needs the release row's id to fetch versions/photos;
                             without it the pane would just render 404s, so drop the tab. */}
-                        {TABS.filter((tab) => tab.key !== 'drawings' || releaseId != null).map((tab) => {
+                        {TABS.filter((tab) => tab.key !== 'attachments' || releaseId != null).map((tab) => {
                             const active = tab.key === activeTab;
+                            const showBadge = tab.key === 'attachments' && badgeCount > 0;
                             return (
                                 <button
                                     key={tab.key}
@@ -175,7 +203,7 @@ export function ReleaseHubModal({
                                     onClick={() => selectTab(tab.key)}
                                     aria-selected={active}
                                     role="tab"
-                                    className="bg-transparent border-0 cursor-pointer"
+                                    className="bg-transparent border-0 cursor-pointer inline-flex items-center gap-1.5"
                                     style={{
                                         padding: '8px 0 9px',
                                         fontSize: 13,
@@ -185,15 +213,37 @@ export function ReleaseHubModal({
                                     }}
                                 >
                                     {tab.label}
+                                    {showBadge && (
+                                        <span
+                                            className="font-mono font-semibold"
+                                            style={{
+                                                fontSize: 10.5,
+                                                padding: '1px 6px',
+                                                borderRadius: 999,
+                                                background: '#fef3c7',
+                                                color: '#b45309',
+                                                lineHeight: 1.3,
+                                            }}
+                                            aria-label={`${badgeCount} findings to confirm`}
+                                        >
+                                            {badgeCount}
+                                        </span>
+                                    )}
                                 </button>
                             );
                         })}
                     </div>
                 </div>
 
-                {/* Body: pane | notes rail. The rail is a sibling of the panes, not
-                    inside one, so notes stay visible on every tab. */}
-                <div className="flex-1 min-h-0 grid" style={{ gridTemplateColumns: 'minmax(0,1fr) 372px' }}>
+                {/* Body: pane | activity rail (rail only on Details + Change Log). */}
+                <div
+                    className="flex-1 min-h-0 grid"
+                    style={{
+                        gridTemplateColumns: showActivityRail
+                            ? `minmax(0,1fr) ${ACTIVITY_RAIL_WIDTH}px`
+                            : 'minmax(0,1fr)',
+                    }}
+                >
                     <div className="min-w-0 relative">
                         {visited.details && (
                             <div
@@ -209,9 +259,9 @@ export function ReleaseHubModal({
                             </div>
                         )}
 
-                        {visited.drawings && releaseId != null && (
+                        {visited.attachments && releaseId != null && (
                             <div
-                                className={`absolute inset-0 flex flex-col ${activeTab === 'drawings' ? '' : 'hidden'}`}
+                                className={`absolute inset-0 flex flex-col ${activeTab === 'attachments' ? '' : 'hidden'}`}
                                 role="tabpanel"
                             >
                                 <PdfVersionHistoryModal
@@ -223,6 +273,7 @@ export function ReleaseHubModal({
                                     initialCommentVersionId={initialCommentVersionId}
                                     onClose={onClose}
                                     onOpenVersion={onOpenVersion}
+                                    onActionableCount={reportBadge}
                                 />
                             </div>
                         )}
@@ -233,16 +284,23 @@ export function ReleaseHubModal({
                                 style={{ padding: '16px 18px 22px' }}
                                 role="tabpanel"
                             >
-                                <EventsList jobFilter={jobNumber} releaseFilter={releaseNumber} />
+                                <EventsList
+                                    jobFilter={jobNumber}
+                                    releaseFilter={releaseNumber}
+                                    variant="hub"
+                                />
                             </div>
                         )}
                     </div>
 
-                    <ReleaseNotesRail
-                        job={jobNumber}
-                        release={releaseNumber}
-                        currentNotes={job['Notes'] ?? job.notes}
-                    />
+                    {showActivityRail && (
+                        <ReleaseNotesRail
+                            job={jobNumber}
+                            release={releaseNumber}
+                            currentNotes={job['Notes'] ?? job.notes}
+                            onNotesChanged={onNotesChanged}
+                        />
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/components/ReleaseHubModal.test.jsx
+++ b/frontend/src/components/ReleaseHubModal.test.jsx
@@ -3,8 +3,9 @@
 // shell, the initialTab entry points, the dossier content, and the click-out
 // margin that dismisses it.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import { ReleaseHubModal } from './ReleaseHubModal.jsx';
+import { jobsApi } from '../services/jobsApi';
 
 // The details body fetches material orders; the drawings body fetches versions
 // and photos; the rail fetches notes. None of those network shapes are under
@@ -12,7 +13,9 @@ import { ReleaseHubModal } from './ReleaseHubModal.jsx';
 vi.mock('../services/jobsApi', () => ({
     jobsApi: {
         getMaterialOrders: vi.fn(() => Promise.resolve({ orders: [] })),
-        markMaterialOrderReceived: vi.fn(() => Promise.resolve({})),
+        markMaterialOrderReceived: vi.fn((id, received = true) =>
+            Promise.resolve({ order: { id, status: received ? 'received' : 'ordered', description: 'Part' } })
+        ),
         updateNotes: vi.fn(() => Promise.resolve({})),
         getBBReview: vi.fn(() => Promise.resolve(null)),
         requestBBReview: vi.fn(() => Promise.resolve({ status: 'pending' })),
@@ -103,6 +106,9 @@ const JOB = {
 };
 
 beforeEach(() => {
+    jobsApi.getMaterialOrders.mockReset();
+    jobsApi.getMaterialOrders.mockResolvedValue({ orders: [] });
+    jobsApi.markMaterialOrderReceived.mockClear();
     vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ versions: [], photos: [], events: [] }),
@@ -317,6 +323,25 @@ describe('ReleaseHubModal', () => {
         fireEvent.click(screen.getByRole('button', { name: '+ Note' }));
         expect(screen.getByPlaceholderText(/Overwrite Job Log notes/i)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Save note' })).toBeInTheDocument();
+    });
+
+    it('shows Mark all received on Materials ordered when orders are pending', async () => {
+        jobsApi.getMaterialOrders.mockResolvedValue({
+            orders: [
+                { id: 1, description: 'Plate A', status: 'ordered', quantity: 6 },
+                { id: 2, description: 'Plate B', status: 'ordered', quantity: 2 },
+                { id: 3, description: 'Galv', shipping_status: 'planning' },
+            ],
+        });
+        renderHub();
+        const btn = await screen.findByRole('button', { name: 'Mark all received' });
+        fireEvent.click(btn);
+        await waitFor(() => {
+            // Two itemized pending rows — status-order skipped.
+            expect(jobsApi.markMaterialOrderReceived).toHaveBeenCalledTimes(2);
+            expect(jobsApi.markMaterialOrderReceived).toHaveBeenCalledWith(1, true);
+            expect(jobsApi.markMaterialOrderReceived).toHaveBeenCalledWith(2, true);
+        });
     });
 
     it('opens Change Log with hub layout (no Identifier table)', async () => {

--- a/frontend/src/components/ReleaseHubModal.test.jsx
+++ b/frontend/src/components/ReleaseHubModal.test.jsx
@@ -13,8 +13,10 @@ vi.mock('../services/jobsApi', () => ({
     jobsApi: {
         getMaterialOrders: vi.fn(() => Promise.resolve({ orders: [] })),
         markMaterialOrderReceived: vi.fn(() => Promise.resolve({})),
-        // The notes rail reads the update_notes event stream — the same feed the
-        // Notes cell's history glyph used before it was folded into the modal.
+        updateNotes: vi.fn(() => Promise.resolve({})),
+        getBBReview: vi.fn(() => Promise.resolve(null)),
+        requestBBReview: vi.fn(() => Promise.resolve({ status: 'pending' })),
+        // Activity rail reads the release event stream (notes + stage/date/fab).
         getNotesHistory: vi.fn(() => Promise.resolve({
             events: [
                 {
@@ -33,8 +35,6 @@ vi.mock('../services/jobsApi', () => ({
                     created_at: '2026-07-02T09:10:00',
                     payload: { from: '', to: 'Fab has pack' },
                 },
-                // Stage + ship date land on the main-card activity feed (N7),
-                // not the notes rail.
                 {
                     id: 4,
                     action: 'update_stage',
@@ -51,6 +51,14 @@ vi.mock('../services/jobsApi', () => ({
                     created_at: '2026-07-04T11:00:00',
                     payload: { from: null, to: '2026-07-28' },
                 },
+                {
+                    id: 6,
+                    action: 'update_fab_order',
+                    user_name: 'Ryan Lopez',
+                    source: 'Brain',
+                    created_at: '2026-07-03T09:10:30',
+                    payload: { from: 5, to: 3 },
+                },
             ],
         })),
     },
@@ -59,7 +67,8 @@ vi.mock('../services/notificationApi', () => ({
     fetchMentionableUsers: vi.fn(() => Promise.resolve([])),
 }));
 vi.mock('../utils/auth', () => ({
-    checkAuth: vi.fn(() => Promise.resolve({ authenticated: true, user: { is_admin: false } })),
+    // /api/auth/me shape — admin/drafter flags at top level.
+    checkAuth: vi.fn(() => Promise.resolve({ is_admin: true, is_drafter: true })),
 }));
 
 // Shaped like a real Job Log row (app/brain/job_log/routes.py) — display keys
@@ -130,22 +139,29 @@ describe('ReleaseHubModal', () => {
     it('offers all three tabs with Details active by default', () => {
         renderHub();
         expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');
-        expect(screen.getByRole('tab', { name: 'Drawings & Photos' })).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByRole('tab', { name: 'Attachments' })).toHaveAttribute('aria-selected', 'false');
         expect(screen.getByRole('tab', { name: 'Change Log' })).toHaveAttribute('aria-selected', 'false');
     });
 
-    it('opens straight to Drawings & Photos when asked', () => {
+    it('opens straight to Attachments when asked (legacy drawings key still works)', async () => {
         renderHub({ initialTab: 'drawings' });
-        expect(screen.getByRole('tab', { name: 'Drawings & Photos' })).toHaveAttribute('aria-selected', 'true');
-        expect(screen.getByText('Drawings')).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Attachments' })).toHaveAttribute('aria-selected', 'true');
+        // Embedded split pane: left rail Drawings section + empty viewer prompt.
+        expect(await screen.findByText('Drawings')).toBeInTheDocument();
+        expect(screen.getByText('+ Upload PDF')).toBeInTheDocument();
+        expect(screen.getByText('Photos')).toBeInTheDocument();
+        // Empty release: left rail empty-state and/or right viewer prompt.
+        expect(
+            screen.getAllByText(/No drawings yet|Select a drawing to preview/i).length,
+        ).toBeGreaterThanOrEqual(1);
     });
 
-    it('drops the Drawings & Photos tab when no releaseId is available', () => {
+    it('drops the Attachments tab when no releaseId is available', () => {
         // A caller with only job/release digits (e.g. a Timeline material-order
         // chip whose release row is not loaded) cannot fetch versions/photos —
         // offering the tab would just render 404s.
         renderHub({ releaseId: null });
-        expect(screen.queryByRole('tab', { name: 'Drawings & Photos' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('tab', { name: 'Attachments' })).not.toBeInTheDocument();
         expect(screen.getByRole('tab', { name: 'Details' })).toBeInTheDocument();
         expect(screen.getByRole('tab', { name: 'Change Log' })).toBeInTheDocument();
     });
@@ -154,18 +170,48 @@ describe('ReleaseHubModal', () => {
         renderHub();
         expect(screen.getByText('Materials ordered')).toBeInTheDocument();
 
-        fireEvent.click(screen.getByRole('tab', { name: 'Drawings & Photos' }));
-        expect(screen.getByRole('tab', { name: 'Drawings & Photos' })).toHaveAttribute('aria-selected', 'true');
+        fireEvent.click(screen.getByRole('tab', { name: 'Attachments' }));
+        expect(screen.getByRole('tab', { name: 'Attachments' })).toHaveAttribute('aria-selected', 'true');
         expect(screen.getByText('Drawings')).toBeInTheDocument();
         // Details stays in the DOM (hidden) so its state survives the switch.
         expect(screen.getByText('Materials ordered')).toBeInTheDocument();
     });
 
-    it('lays the release out as a dossier, not three lonely facts', () => {
+    it('hides the Activity rail on Attachments and shows it on Details', () => {
         renderHub();
-        for (const heading of ['Schedule', 'Production', 'Assignment', 'Materials ordered', 'Stage progress']) {
+        expect(screen.getByText('Activity')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Attachments' }));
+        expect(screen.queryByText('Activity')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Details' }));
+        expect(screen.getByText('Activity')).toBeInTheDocument();
+    });
+
+    it('shows an amber findings badge on Attachments when count > 0', () => {
+        renderHub({ attachmentsBadgeCount: 8 });
+        const tab = screen.getByRole('tab', { name: /Attachments/ });
+        expect(within(tab).getByText('8')).toBeInTheDocument();
+    });
+
+    it('hides the findings badge when count is 0', () => {
+        renderHub({ attachmentsBadgeCount: 0 });
+        const tab = screen.getByRole('tab', { name: 'Attachments' });
+        expect(within(tab).queryByText('0')).not.toBeInTheDocument();
+    });
+
+    it('lays the release out as date hero + 3-col metadata + stage progress', () => {
+        renderHub();
+        // Date-flow hero labels (Install Prog also labels the Production field).
+        for (const label of ['Released', 'Ship Date', 'Start Install', 'Comp. ETA']) {
+            expect(screen.getByText(label)).toBeInTheDocument();
+        }
+        expect(screen.getAllByText('Install Prog').length).toBeGreaterThanOrEqual(1);
+        for (const heading of ['Production', 'Assignment', 'Materials ordered', 'Stage progress']) {
             expect(screen.getByText(heading)).toBeInTheDocument();
         }
+        // Schedule is no longer a section — dates live in the hero only.
+        expect(screen.queryByText('Schedule')).not.toBeInTheDocument();
     });
 
     it('renders the banana-code icon row instead of the 17-segment progress bar', () => {
@@ -175,23 +221,24 @@ describe('ReleaseHubModal', () => {
         expect(screen.getByAltText(/Install/i)).toBeInTheDocument();
     });
 
-    it('intermingles stage/date updates with notes on the right Activity rail', async () => {
+    it('intermingles stage/date/fab updates with notes on the Activity rail', async () => {
         renderHub();
-        // Stage + ship from the events mock, plus a note body — one timeline.
-        expect(await screen.findByText('Stage Cut Start → Cut Complete')).toBeInTheDocument();
-        expect(screen.getByText(/Ship date set to Jul 28, 2026/)).toBeInTheDocument();
+        // Stage chips + merged fab (same user/minute as stage) + ship + notes.
+        // Stage chips (also appears as header/Production stage pill — use getAll).
+        expect(await screen.findByText(/also Fab Order 5 → 3/)).toBeInTheDocument();
+        expect(screen.getAllByText('Cut Complete').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Cut Start').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText(/Ship date set to/)).toBeInTheDocument();
         expect(screen.getByText('Waiting on GC embed approval')).toBeInTheDocument();
-        // Kind chips distinguish note rows from system updates (chip text is uppercase CSS).
         expect(screen.getAllByText('Note').length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText('Ship').length).toBeGreaterThanOrEqual(1);
-        // Header renamed from Notes → Activity.
         expect(screen.getByText('Activity')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '+ Note' })).toBeInTheDocument();
     });
 
     it('renders the release fields the Job Log row carries', () => {
         renderHub();
         const dialog = screen.getByRole('dialog');
-        // Schedule dates are reformatted from ISO.
+        // Hero dates are reformatted from ISO.
         expect(within(dialog).getByText('Jun 2, 2026')).toBeInTheDocument();
         expect(within(dialog).getByText('Aug 1, 2026')).toBeInTheDocument();
         // Production + assignment.
@@ -204,8 +251,15 @@ describe('ReleaseHubModal', () => {
     it('shows an em dash for empty fields rather than dropping the row', () => {
         renderHub();
         const dialog = screen.getByRole('dialog');
-        // Job Comp and Invoiced are null on this release.
+        // Job Comp / Install Prog and Invoiced are null on this release.
         expect(within(dialog).getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('appends % to whole-number Install Prog', () => {
+        renderHub({ job: { ...JOB, 'Job Comp': 75 } });
+        const dialog = screen.getByRole('dialog');
+        // Hero + Production field both show 75%.
+        expect(within(dialog).getAllByText('75%').length).toBeGreaterThanOrEqual(1);
     });
 
     it('flags an ASAP install with the mini-flag beside the date', () => {
@@ -220,13 +274,12 @@ describe('ReleaseHubModal', () => {
         expect(screen.getByText('HARD')).toBeInTheDocument();
     });
 
-    it('walks the real stage ladder, not the shortened prototype one', () => {
+    it('renders banana-code department icons for stage progress', () => {
         renderHub();
-        const dialog = screen.getByRole('dialog');
-        // Stages the handoff prototype's 10-step ladder drops entirely.
-        for (const stage of ['Material Ordered', 'Cut Start', 'Store at MHMW']) {
-            expect(within(dialog).getByTitle(stage)).toBeInTheDocument();
-        }
+        // Banana Code uses department alts (Admin…Install), not per-stage titles.
+        expect(screen.getByAltText(/Admin/i)).toBeInTheDocument();
+        expect(screen.getByAltText(/Cut/i)).toBeInTheDocument();
+        expect(screen.getByAltText(/Install/i)).toBeInTheDocument();
     });
 
     it('puts the external links in the header, enabled only when there is a target', () => {
@@ -236,31 +289,61 @@ describe('ReleaseHubModal', () => {
         expect(screen.getByText('Procore').tagName).not.toBe('A');
     });
 
-    it('renders the notes history newest-first, badging the current note', async () => {
+    it('renders notes history newest-first on the Activity rail', async () => {
         renderHub();
-        expect(screen.getByText('Notes')).toBeInTheDocument();
+        expect(screen.getByText('Activity')).toBeInTheDocument();
 
         expect(await screen.findByText('Waiting on GC embed approval')).toBeInTheDocument();
         expect(screen.getByText('Fab has pack')).toBeInTheDocument();
-        // The newest event matches the release's Notes field, so it carries the
-        // badge rather than the text being printed twice.
-        expect(screen.getByText('Current')).toBeInTheDocument();
+        // Newest note matches the release Notes field once (not duplicated as orphan).
         expect(screen.getAllByText('Waiting on GC embed approval')).toHaveLength(1);
     });
 
-    it('keeps non-notes events out of the notes rail', async () => {
+    it('shows stage/date authors on the Activity rail alongside note authors', async () => {
         renderHub();
         await screen.findByText('Fab has pack');
-        expect(screen.queryByText('Cut Complete — from Cut Start')).not.toBeInTheDocument();
-        // Two update_notes events, so two authors; the stage change contributes none.
-        expect(screen.getByText('Dave Cruz')).toBeInTheDocument();
-        expect(screen.getByText('Ryan Lopez')).toBeInTheDocument();
+        expect(screen.getAllByText('Dave Cruz').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Ryan Lopez').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Cut Complete').length).toBeGreaterThanOrEqual(1);
     });
 
-    it('points at the Job Log cell as the place notes are edited', () => {
+    it('points at the Change Log for full undo history', () => {
         renderHub();
-        expect(screen.getByText(/edited in the Job Log's Notes column/)).toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: /Post note/ })).not.toBeInTheDocument();
+        expect(screen.getByText(/full undo history is on the Change Log tab/i)).toBeInTheDocument();
+    });
+
+    it('opens a note composer from + Note', async () => {
+        renderHub();
+        fireEvent.click(screen.getByRole('button', { name: '+ Note' }));
+        expect(screen.getByPlaceholderText(/Overwrite Job Log notes/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Save note' })).toBeInTheDocument();
+    });
+
+    it('opens Change Log with hub layout (no Identifier table)', async () => {
+        // EventsList fetches via axios; stub a small list for the hub pane.
+        const axios = (await import('axios')).default;
+        if (axios.get && typeof axios.get.mockResolvedValue === 'function') {
+            axios.get.mockResolvedValue({
+                data: {
+                    events: [{
+                        id: 1,
+                        type: 'job',
+                        action: 'update_stage',
+                        user_name: 'Ryan',
+                        source: 'Brain',
+                        created_at: '2026-07-03T09:10:00',
+                        job: 560,
+                        release: '923',
+                        payload: { from: 'Cut Start', to: 'Cut Complete' },
+                        current_value: 'Cut Complete',
+                    }],
+                },
+            });
+        }
+        renderHub();
+        fireEvent.click(screen.getByRole('tab', { name: 'Change Log' }));
+        // Hub summary or loading — either means the pane mounted without Identifier.
+        expect(screen.queryByText('Identifier')).not.toBeInTheDocument();
     });
 
     it('closes on the backdrop, on the × button, and on Escape', () => {

--- a/frontend/src/components/ReleaseHubModal.test.jsx
+++ b/frontend/src/components/ReleaseHubModal.test.jsx
@@ -33,7 +33,8 @@ vi.mock('../services/jobsApi', () => ({
                     created_at: '2026-07-02T09:10:00',
                     payload: { from: '', to: 'Fab has pack' },
                 },
-                // A stage change must not leak into the notes rail.
+                // Stage + ship date land on the main-card activity feed (N7),
+                // not the notes rail.
                 {
                     id: 4,
                     action: 'update_stage',
@@ -41,6 +42,14 @@ vi.mock('../services/jobsApi', () => ({
                     source: 'Brain',
                     created_at: '2026-07-03T09:10:00',
                     payload: { from: 'Cut Start', to: 'Cut Complete' },
+                },
+                {
+                    id: 5,
+                    action: 'update_ship_date',
+                    user_name: 'Dave Cruz',
+                    source: 'Brain',
+                    created_at: '2026-07-04T11:00:00',
+                    payload: { from: null, to: '2026-07-28' },
                 },
             ],
         })),
@@ -157,6 +166,26 @@ describe('ReleaseHubModal', () => {
         for (const heading of ['Schedule', 'Production', 'Assignment', 'Materials ordered', 'Stage progress']) {
             expect(screen.getByText(heading)).toBeInTheDocument();
         }
+    });
+
+    it('renders the banana-code icon row instead of the 17-segment progress bar', () => {
+        renderHub();
+        // StageIconRow exposes each department as an img alt like "Cut yellow".
+        expect(screen.getByAltText(/Admin/i)).toBeInTheDocument();
+        expect(screen.getByAltText(/Install/i)).toBeInTheDocument();
+    });
+
+    it('intermingles stage/date updates with notes on the right Activity rail', async () => {
+        renderHub();
+        // Stage + ship from the events mock, plus a note body — one timeline.
+        expect(await screen.findByText('Stage Cut Start → Cut Complete')).toBeInTheDocument();
+        expect(screen.getByText(/Ship date set to Jul 28, 2026/)).toBeInTheDocument();
+        expect(screen.getByText('Waiting on GC embed approval')).toBeInTheDocument();
+        // Kind chips distinguish note rows from system updates (chip text is uppercase CSS).
+        expect(screen.getAllByText('Note').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Ship').length).toBeGreaterThanOrEqual(1);
+        // Header renamed from Notes → Activity.
+        expect(screen.getByText('Activity')).toBeInTheDocument();
     });
 
     it('renders the release fields the Job Log row carries', () => {

--- a/frontend/src/components/ReleaseNotesRail.jsx
+++ b/frontend/src/components/ReleaseNotesRail.jsx
@@ -1,24 +1,24 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: Notes history rail on the release hub — every value the release's Notes field has held, newest first, read from the existing update_notes event stream.
+ * purpose: Right rail on the release hub — a single newest-first timeline of notes
+ *   intermingled with stage and date changes (who + when), all from ReleaseEvents.
  * exports:
- *   ReleaseNotesRail: Right-hand notes column. Props: job, release, currentNotes.
- * imports_from: [react, ../services/jobsApi]
+ *   ReleaseNotesRail: Right-hand activity column. Props: job, release, currentNotes.
+ * imports_from: [react, ../services/jobsApi, ./ReleaseActivityFeed]
  * imported_by: [frontend/src/components/ReleaseHubModal.jsx]
  * invariants:
- *   - Read-only. The Notes field is edited in the Job Log cell; this renders what that
- *     editing has already recorded. There is no second notes store — an earlier pass added
- *     one and it was removed as a duplicate of this event stream.
- *   - Source is /brain/events filtered to action === 'update_notes', the same feed
- *     NotesHistoryModal used before it was folded in here.
- *   - No-op edits (from === to) are dropped: saving a cell without changing it still emits
- *     an event, and showing those would pad the history with duplicates.
- * updated_by_agent: 2026-08-06T00:00:00Z
+ *   - Read-only. Notes are still edited in the Job Log cell; stage/date writes stay
+ *     on their own controls. This is a filtered render of /brain/events only.
+ *   - Notes keep the full-body treatment; system updates render as compact chips so
+ *     the feed stays scannable when both kinds mix.
+ *   - No-op edits (from === to) are dropped.
+ * updated_by_agent: 2026-08-08T00:00:00Z
  */
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { jobsApi } from '../services/jobsApi';
+import { ACTIVITY_ACTIONS, summarizeActivity } from './ReleaseActivityFeed';
 
 const initialsOf = (name) => {
     const s = (name || '').toString().trim();
@@ -38,7 +38,6 @@ const formatStamp = (iso) => {
     return `${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })} · ${time}`;
 };
 
-/** Pull the note text out of an event payload, tolerating the shapes /brain/events returns. */
 const noteValues = (evt) => {
     const p = evt.payload || evt;
     const to = p.to ?? p.new ?? p.new_value ?? p.notes ?? null;
@@ -46,7 +45,27 @@ const noteValues = (evt) => {
     return { to, from };
 };
 
-function Entry({ author, at, body, current, cleared }) {
+const fromTo = (payload = {}) => {
+    const from = payload.from ?? payload.old ?? payload.old_value ?? null;
+    const to = payload.to ?? payload.new ?? payload.new_value ?? null;
+    return { from, to };
+};
+
+/** Short kind label for the chip on non-note rows. */
+const kindLabel = (action) => {
+    if (action === 'update_stage') return 'Stage';
+    if (action === 'update_ship_date') return 'Ship';
+    if (action === 'update_start_install' || action === 'clear_hard_date') return 'Install';
+    return 'Update';
+};
+
+const sortMs = (iso) => {
+    if (!iso) return 0;
+    const t = new Date(iso).getTime();
+    return Number.isFinite(t) ? t : 0;
+};
+
+function NoteEntry({ author, at, body, current, cleared }) {
     return (
         <div style={{ marginBottom: 14 }}>
             <div className="flex items-start" style={{ gap: 9 }}>
@@ -79,6 +98,15 @@ function Entry({ author, at, body, current, cleared }) {
                                 Current
                             </span>
                         )}
+                        <span
+                            className="font-bold uppercase text-ink-3"
+                            style={{
+                                fontSize: 9.5, letterSpacing: '.05em', padding: '1px 5px',
+                                borderRadius: 4, background: 'var(--surface)', border: '1px solid var(--hairline)',
+                            }}
+                        >
+                            Note
+                        </span>
                     </div>
                     <div
                         className={`whitespace-pre-wrap break-words ${cleared ? 'text-ink-3 italic' : 'text-ink'}`}
@@ -92,8 +120,120 @@ function Entry({ author, at, body, current, cleared }) {
     );
 }
 
+/** Compact system update — sits in the same timeline as notes without competing for weight. */
+function UpdateEntry({ author, at, text, kind }) {
+    return (
+        <div style={{ marginBottom: 12 }}>
+            <div className="flex items-start" style={{ gap: 9 }}>
+                <div
+                    className="shrink-0 grid place-items-center font-bold text-ink-3"
+                    style={{
+                        width: 26, height: 26, borderRadius: '50%', fontSize: 10.5,
+                        background: 'var(--surface)',
+                        border: '1px solid var(--hairline-strong)',
+                    }}
+                >
+                    {kind === 'Stage' ? 'S' : kind === 'Ship' ? 'Sh' : kind === 'Install' ? 'In' : '·'}
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline flex-wrap" style={{ gap: 7 }}>
+                        <span className="font-bold text-ink" style={{ fontSize: 12.5 }}>
+                            {author || 'System'}
+                        </span>
+                        <span className="font-mono text-ink-3" style={{ fontSize: 11 }}>
+                            {formatStamp(at)}
+                        </span>
+                        <span
+                            className="font-bold uppercase"
+                            style={{
+                                fontSize: 9.5, letterSpacing: '.05em', padding: '1px 5px',
+                                borderRadius: 4,
+                                background: 'var(--surface)',
+                                border: '1px solid var(--hairline)',
+                                color: 'var(--text-2)',
+                            }}
+                        >
+                            {kind}
+                        </span>
+                    </div>
+                    <div
+                        className="text-ink-2"
+                        style={{ marginTop: 3, fontSize: 12.5, lineHeight: 1.45 }}
+                    >
+                        {text}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Turn the raw /brain/events list into a mixed timeline: notes + stage/date updates.
+ * Newest first. Exported for unit tests.
+ */
+export function buildTimeline(rawEvents, { currentNotes = '' } = {}) {
+    const items = [];
+
+    for (const e of rawEvents || []) {
+        const at = e.created_at || e.timestamp;
+        const author = e.user_name || e.source || 'Brain';
+        const payload = e.payload || {};
+        const { from, to } = fromTo(payload);
+        if (from != null && to != null && String(from) === String(to)) continue;
+
+        if (e.action === 'update_notes') {
+            const { to: noteTo, from: noteFrom } = noteValues(e);
+            const body = (noteTo ?? '').toString();
+            const prev = (noteFrom ?? '').toString();
+            if (body === prev) continue;
+            items.push({
+                id: e.id,
+                kind: 'note',
+                author,
+                at,
+                body,
+                sortKey: sortMs(at),
+            });
+            continue;
+        }
+
+        if (ACTIVITY_ACTIONS.has(e.action)) {
+            const summary = summarizeActivity(e);
+            if (!summary) continue;
+            items.push({
+                id: e.id,
+                kind: 'update',
+                updateKind: kindLabel(e.action),
+                author: summary.author,
+                at,
+                text: summary.text,
+                sortKey: sortMs(at),
+            });
+        }
+    }
+
+    items.sort((a, b) => b.sortKey - a.sortKey || (b.id || 0) - (a.id || 0));
+
+    const current = (currentNotes ?? '').toString().trim();
+    const firstNote = items.find((i) => i.kind === 'note');
+    const newestNoteMatches = firstNote && firstNote.body.trim() === current;
+    const orphanNote = current !== '' && !newestNoteMatches
+        ? { id: 'field-current', kind: 'note', author: 'Job Log', at: null, body: current, current: true, sortKey: Number.MAX_SAFE_INTEGER }
+        : null;
+
+    if (orphanNote) items.unshift(orphanNote);
+
+    // Badge the newest matching note as Current (same behavior as the old rail).
+    if (newestNoteMatches && firstNote) {
+        firstNote.current = true;
+    }
+
+    return items;
+}
+
 export function ReleaseNotesRail({ job, release, currentNotes }) {
-    const [entries, setEntries] = useState([]);
+    const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
@@ -103,79 +243,65 @@ export function ReleaseNotesRail({ job, release, currentNotes }) {
         jobsApi.getNotesHistory(job, release, 200)
             .then((data) => {
                 const raw = Array.isArray(data) ? data : (data?.events || []);
-                const notes = raw
-                    .filter((e) => e.action === 'update_notes')
-                    .map((e) => {
-                        const { to, from } = noteValues(e);
-                        return {
-                            id: e.id,
-                            // /brain/events names the author `user_name`; `source`
-                            // is the SYSTEM that made the change (Brain / Trello),
-                            // so it's only the fallback when no person is attached.
-                            author: e.user_name || e.source || 'Brain',
-                            at: e.created_at || e.timestamp,
-                            body: (to ?? '').toString(),
-                            from: (from ?? '').toString(),
-                        };
-                    })
-                    // A save that didn't change anything still emits an event.
-                    .filter((n) => n.body !== n.from);
-                setEntries(notes);
+                setItems(buildTimeline(raw, { currentNotes }));
                 setError(null);
             })
-            .catch(() => setError('Could not load notes history.'))
+            .catch(() => setError('Could not load activity.'))
             .finally(() => setLoading(false));
-    }, [job, release]);
+    }, [job, release, currentNotes]);
 
     useEffect(() => { load(); }, [load]);
 
-    const current = (currentNotes ?? '').toString().trim();
-    // The newest event usually IS the current note. When it is, don't print the
-    // same text twice — badge that entry as Current instead.
-    const newestMatchesField = entries.length > 0 && entries[0].body.trim() === current;
-    const showFieldOnTop = current !== '' && !newestMatchesField;
+    const noteCount = items.filter((i) => i.kind === 'note').length;
+    const updateCount = items.filter((i) => i.kind === 'update').length;
 
     return (
         <div className="flex flex-col min-h-0 border-l border-hairline bg-surface-2">
             <div className="shrink-0 flex items-center border-b border-hairline" style={{ gap: 8, padding: '12px 16px 10px' }}>
-                <span className="text-jl-label font-bold uppercase text-ink-3">Notes</span>
-                <span className="font-mono text-ink-3" style={{ fontSize: 11 }}>
-                    {entries.length + (showFieldOnTop ? 1 : 0)}
+                <span className="text-jl-label font-bold uppercase text-ink-3">Activity</span>
+                <span className="font-mono text-ink-3" style={{ fontSize: 11 }} title={`${noteCount} notes · ${updateCount} updates`}>
+                    {items.length}
                 </span>
                 <div className="flex-1" />
                 <span className="text-ink-3" style={{ fontSize: 10.5 }}>Newest first</span>
             </div>
 
             <div className="flex-1 min-h-0 overflow-auto" style={{ padding: '12px 16px' }}>
-                {loading && <p className="text-jl-2 text-ink-3 italic">Loading notes…</p>}
+                {loading && <p className="text-jl-2 text-ink-3 italic">Loading activity…</p>}
                 {error && <p className="text-jl-2" style={{ color: 'var(--fl-red-fg)' }}>{error}</p>}
 
-                {/* The field can hold a note older than the event stream's window, or one
-                    written before events were recorded — show it rather than imply
-                    the release has no note. */}
-                {!loading && showFieldOnTop && (
-                    <Entry author="Job Log" at={null} body={current} current />
-                )}
-
-                {!loading && !error && entries.map((n, i) => (
-                    <Entry
-                        key={n.id ?? i}
-                        author={n.author}
-                        at={n.at}
-                        body={n.body}
-                        cleared={n.body.trim() === ''}
-                        current={i === 0 && newestMatchesField}
-                    />
+                {!loading && !error && items.map((item, i) => (
+                    item.kind === 'note' ? (
+                        <NoteEntry
+                            key={item.id ?? `n-${i}`}
+                            author={item.author}
+                            at={item.at}
+                            body={item.body}
+                            cleared={item.body.trim() === ''}
+                            current={!!item.current}
+                        />
+                    ) : (
+                        <UpdateEntry
+                            key={item.id ?? `u-${i}`}
+                            author={item.author}
+                            at={item.at}
+                            text={item.text}
+                            kind={item.updateKind}
+                        />
+                    )
                 ))}
 
-                {!loading && !error && entries.length === 0 && !showFieldOnTop && (
-                    <p className="text-jl-2 text-ink-3 italic">No notes on this release yet.</p>
+                {!loading && !error && items.length === 0 && (
+                    <p className="text-jl-2 text-ink-3 italic">
+                        No notes or date/stage changes on this release yet.
+                    </p>
                 )}
             </div>
 
             <div className="shrink-0 border-t border-hairline bg-surface" style={{ padding: '10px 14px 12px' }}>
                 <p className="text-ink-3" style={{ fontSize: 11, lineHeight: 1.4 }}>
-                    Notes are edited in the Job Log's Notes column. Every change lands here.
+                    Notes are edited in the Job Log. Stage and date changes show up here
+                    automatically — full undo history is on the Change Log tab.
                 </p>
             </div>
         </div>

--- a/frontend/src/components/ReleaseNotesRail.jsx
+++ b/frontend/src/components/ReleaseNotesRail.jsx
@@ -1,26 +1,35 @@
 /**
  * @milehigh-header
  * schema_version: 1
- * purpose: Right rail on the release hub — a single newest-first timeline of notes
- *   intermingled with stage and date changes (who + when), all from ReleaseEvents.
+ * purpose: Right Activity rail on the release hub — day-grouped timeline of notes,
+ *   stage, fab order, and date changes; + Note overwrites Job Log notes.
  * exports:
- *   ReleaseNotesRail: Right-hand activity column. Props: job, release, currentNotes.
- * imports_from: [react, ../services/jobsApi, ./ReleaseActivityFeed]
+ *   ReleaseNotesRail: Right-hand activity column
+ *   buildTimeline: pure transform of /brain/events → rail items (tests)
+ *   groupByDay: pure day grouping helper (tests)
+ * imports_from: [react, ../services/jobsApi, ../utils/stageTint, ./ReleaseActivityFeed]
  * imported_by: [frontend/src/components/ReleaseHubModal.jsx]
  * invariants:
- *   - Read-only. Notes are still edited in the Job Log cell; stage/date writes stay
- *     on their own controls. This is a filtered render of /brain/events only.
- *   - Notes keep the full-body treatment; system updates render as compact chips so
- *     the feed stays scannable when both kinds mix.
- *   - No-op edits (from === to) are dropped.
+ *   - Activity includes notes, stage, fab order, ship date, start install / hard clear
+ *   - Notes are full history: every update_notes `to`, plus any `from` not already
+ *     covered by an older event's `to` (so a first overwrite still shows prior text)
+ *   - Same-user same-minute fab_order folds into a stage entry as "also Fab Order…"
+ *   - Notes write via existing updateNotes (full field overwrite) + event history
+ *   - No CURRENT badge; no-op edits (from === to) dropped
  * updated_by_agent: 2026-08-08T00:00:00Z
  */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { jobsApi } from '../services/jobsApi';
-import { ACTIVITY_ACTIONS, summarizeActivity } from './ReleaseActivityFeed';
+import { stageTint } from '../utils/stageTint';
+import {
+    ACTIVITY_ACTIONS,
+    formatDateValue,
+    fromTo,
+    summarizeActivity,
+} from './ReleaseActivityFeed';
 
-const initialsOf = (name) => {
+export const initialsOf = (name) => {
     const s = (name || '').toString().trim();
     if (!s) return '?';
     const parts = s.split(/\s+/);
@@ -28,14 +37,24 @@ const initialsOf = (name) => {
     return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 };
 
-const formatStamp = (iso) => {
+/** Time only — day lives on the group divider. */
+const formatTime = (iso) => {
     if (!iso) return '';
     const d = new Date(iso);
     if (isNaN(d)) return '';
-    const sameDay = d.toDateString() === new Date().toDateString();
-    const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-    if (sameDay) return `Today · ${time}`;
-    return `${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })} · ${time}`;
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+};
+
+/** Day bucket key + display label: "TUE · APR 7". */
+export const dayBucket = (iso) => {
+    if (!iso) return { key: 'unknown', label: 'UNKNOWN DATE' };
+    const d = new Date(iso);
+    if (isNaN(d)) return { key: 'unknown', label: 'UNKNOWN DATE' };
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const dow = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase();
+    const mon = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase();
+    const day = d.getDate();
+    return { key, label: `${dow} · ${mon} ${day}` };
 };
 
 const noteValues = (evt) => {
@@ -45,74 +64,120 @@ const noteValues = (evt) => {
     return { to, from };
 };
 
-const fromTo = (payload = {}) => {
-    const from = payload.from ?? payload.old ?? payload.old_value ?? null;
-    const to = payload.to ?? payload.new ?? payload.new_value ?? null;
-    return { from, to };
-};
-
-/** Short kind label for the chip on non-note rows. */
-const kindLabel = (action) => {
-    if (action === 'update_stage') return 'Stage';
-    if (action === 'update_ship_date') return 'Ship';
-    if (action === 'update_start_install' || action === 'clear_hard_date') return 'Install';
-    return 'Update';
-};
-
 const sortMs = (iso) => {
     if (!iso) return 0;
     const t = new Date(iso).getTime();
     return Number.isFinite(t) ? t : 0;
 };
 
-function NoteEntry({ author, at, body, current, cleared }) {
+/** Floor timestamp to minute for merge matching. */
+const minuteKey = (iso) => {
+    const t = sortMs(iso);
+    if (!t) return 0;
+    return Math.floor(t / 60000);
+};
+
+const authorKey = (name) => (name || '').toString().trim().toLowerCase();
+
+function DayDivider({ label }) {
     return (
-        <div style={{ marginBottom: 14 }}>
+        <div className="flex items-center" style={{ gap: 8, margin: '14px 0 10px' }}>
+            <span
+                className="font-bold uppercase shrink-0"
+                style={{ fontSize: 10, letterSpacing: '.04em', color: 'var(--text-3)' }}
+            >
+                {label}
+            </span>
+            <div className="flex-1 min-w-0" style={{ height: 1, background: 'var(--border)' }} />
+        </div>
+    );
+}
+
+function Avatar({ name }) {
+    return (
+        <div
+            className="shrink-0 grid place-items-center font-bold"
+            style={{
+                width: 26,
+                height: 26,
+                borderRadius: '50%',
+                fontSize: 10.5,
+                background: 'var(--accent-soft)',
+                color: 'var(--accent)',
+            }}
+        >
+            {initialsOf(name)}
+        </div>
+    );
+}
+
+function EntryHeader({ author, at }) {
+    return (
+        <div className="flex items-baseline flex-wrap" style={{ gap: 7 }}>
+            <span className="font-bold text-ink" style={{ fontSize: 12.5 }}>
+                {author || 'Unknown'}
+            </span>
+            <span className="font-mono text-ink-3" style={{ fontSize: 10.5 }}>
+                {formatTime(at)}
+            </span>
+        </div>
+    );
+}
+
+function Chip({ children, bg, fg, mono = false }) {
+    return (
+        <span
+            className={`inline-block font-semibold ${mono ? 'font-mono' : ''}`}
+            style={{
+                fontSize: 11,
+                padding: '2px 7px',
+                borderRadius: 5,
+                background: bg,
+                color: fg,
+                maxWidth: 160,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                verticalAlign: 'middle',
+            }}
+            title={typeof children === 'string' ? children : undefined}
+        >
+            {children}
+        </span>
+    );
+}
+
+function NoteEntry({ author, at, body, cleared }) {
+    return (
+        <div style={{ marginBottom: 12 }}>
             <div className="flex items-start" style={{ gap: 9 }}>
-                <div
-                    className="shrink-0 grid place-items-center font-bold"
-                    style={{
-                        width: 26, height: 26, borderRadius: '50%', fontSize: 10.5,
-                        background: current ? 'var(--accent)' : 'var(--accent-soft)',
-                        color: current ? 'var(--accent-ink)' : 'var(--accent)',
-                    }}
-                >
-                    {initialsOf(author)}
-                </div>
+                <Avatar name={author} />
                 <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline flex-wrap" style={{ gap: 7 }}>
-                        <span className="font-bold text-ink" style={{ fontSize: 12.5 }}>
-                            {author || 'Unknown'}
-                        </span>
-                        <span className="font-mono text-ink-3" style={{ fontSize: 11 }}>
-                            {formatStamp(at)}
-                        </span>
-                        {current && (
-                            <span
-                                className="font-bold uppercase"
-                                style={{
-                                    fontSize: 9.5, letterSpacing: '.05em', padding: '1px 5px',
-                                    borderRadius: 4, background: 'var(--accent-soft)', color: 'var(--accent)',
-                                }}
-                            >
-                                Current
-                            </span>
-                        )}
+                    <EntryHeader author={author} at={at} />
+                    <div
+                        className="bg-surface border border-hairline"
+                        style={{ marginTop: 6, borderRadius: 8, padding: '8px 10px' }}
+                    >
                         <span
-                            className="font-bold uppercase text-ink-3"
+                            className="font-bold uppercase inline-block"
                             style={{
-                                fontSize: 9.5, letterSpacing: '.05em', padding: '1px 5px',
-                                borderRadius: 4, background: 'var(--surface)', border: '1px solid var(--hairline)',
+                                fontSize: 9.5,
+                                letterSpacing: '.05em',
+                                padding: '1px 5px',
+                                borderRadius: 4,
+                                background: 'var(--st-amber-bg)',
+                                color: 'var(--st-amber-fg)',
+                                marginBottom: 6,
                             }}
                         >
                             Note
                         </span>
-                    </div>
-                    <div
-                        className={`whitespace-pre-wrap break-words ${cleared ? 'text-ink-3 italic' : 'text-ink'}`}
-                        style={{ marginTop: 3, fontSize: 12.5, lineHeight: 1.45 }}
-                    >
-                        {cleared ? 'Note cleared' : body}
+                        <div
+                            className={`whitespace-pre-wrap break-words ${cleared ? 'text-ink-3 italic' : 'text-ink'}`}
+                            style={{ fontSize: 12.5, lineHeight: 1.45 }}
+                        >
+                            {cleared ? 'Note cleared' : body}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -120,47 +185,71 @@ function NoteEntry({ author, at, body, current, cleared }) {
     );
 }
 
-/** Compact system update — sits in the same timeline as notes without competing for weight. */
-function UpdateEntry({ author, at, text, kind }) {
+function StageEntry({ author, at, from, to, alsoFab }) {
+    const toTint = stageTint(to);
     return (
         <div style={{ marginBottom: 12 }}>
             <div className="flex items-start" style={{ gap: 9 }}>
-                <div
-                    className="shrink-0 grid place-items-center font-bold text-ink-3"
-                    style={{
-                        width: 26, height: 26, borderRadius: '50%', fontSize: 10.5,
-                        background: 'var(--surface)',
-                        border: '1px solid var(--hairline-strong)',
-                    }}
-                >
-                    {kind === 'Stage' ? 'S' : kind === 'Ship' ? 'Sh' : kind === 'Install' ? 'In' : '·'}
-                </div>
+                <Avatar name={author} />
                 <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline flex-wrap" style={{ gap: 7 }}>
-                        <span className="font-bold text-ink" style={{ fontSize: 12.5 }}>
-                            {author || 'System'}
-                        </span>
-                        <span className="font-mono text-ink-3" style={{ fontSize: 11 }}>
-                            {formatStamp(at)}
-                        </span>
-                        <span
-                            className="font-bold uppercase"
-                            style={{
-                                fontSize: 9.5, letterSpacing: '.05em', padding: '1px 5px',
-                                borderRadius: 4,
-                                background: 'var(--surface)',
-                                border: '1px solid var(--hairline)',
-                                color: 'var(--text-2)',
-                            }}
-                        >
-                            {kind}
-                        </span>
+                    <EntryHeader author={author} at={at} />
+                    <div className="flex items-center flex-wrap" style={{ gap: 6, marginTop: 5 }}>
+                        {from != null && from !== '' && (
+                            <Chip bg="var(--head-bg)" fg="var(--text-2)">{String(from)}</Chip>
+                        )}
+                        <span className="text-ink-3" style={{ fontSize: 12 }}>→</span>
+                        <Chip bg={toTint.bg} fg={toTint.fg}>{String(to || '—')}</Chip>
                     </div>
-                    <div
-                        className="text-ink-2"
-                        style={{ marginTop: 3, fontSize: 12.5, lineHeight: 1.45 }}
-                    >
-                        {text}
+                    {alsoFab && (
+                        <div className="text-ink-3" style={{ marginTop: 4, fontSize: 11.5 }}>
+                            also Fab Order {alsoFab.from ?? '—'} → {alsoFab.to ?? '—'}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function FabEntry({ author, at, from, to }) {
+    return (
+        <div style={{ marginBottom: 12 }}>
+            <div className="flex items-start" style={{ gap: 9 }}>
+                <Avatar name={author} />
+                <div className="min-w-0 flex-1">
+                    <EntryHeader author={author} at={at} />
+                    <div className="flex items-center flex-wrap text-ink-2" style={{ gap: 6, marginTop: 5, fontSize: 12.5 }}>
+                        <span>Fab Order</span>
+                        <Chip bg="var(--head-bg)" fg="var(--text-2)" mono>{String(from ?? '—')}</Chip>
+                        <span className="text-ink-3">→</span>
+                        <Chip bg="var(--st-green-bg)" fg="var(--st-green-fg)" mono>{String(to ?? '—')}</Chip>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function DateEntry({ author, at, label, valueLabel, hard, cleared }) {
+    return (
+        <div style={{ marginBottom: 12 }}>
+            <div className="flex items-start" style={{ gap: 9 }}>
+                <Avatar name={author} />
+                <div className="min-w-0 flex-1">
+                    <EntryHeader author={author} at={at} />
+                    <div className="flex items-center flex-wrap" style={{ gap: 6, marginTop: 5, fontSize: 12.5 }}>
+                        <span className="text-ink-2">{cleared ? `${label} cleared` : `${label} set to`}</span>
+                        {!cleared && valueLabel != null && (
+                            <Chip bg="var(--st-green-bg)" fg="var(--st-green-fg)" mono>{valueLabel}</Chip>
+                        )}
+                        {hard && (
+                            <span
+                                className="jl-flag-green font-bold uppercase"
+                                style={{ fontSize: 10, letterSpacing: '.05em', padding: '2px 6px', borderRadius: 4 }}
+                            >
+                                HARD
+                            </span>
+                        )}
                     </div>
                 </div>
             </div>
@@ -169,11 +258,18 @@ function UpdateEntry({ author, at, text, kind }) {
 }
 
 /**
- * Turn the raw /brain/events list into a mixed timeline: notes + stage/date updates.
- * Newest first. Exported for unit tests.
+ * Turn raw /brain/events into mixed timeline items (notes + stage/date/fab).
+ * Newest first. Merges same-user same-minute fab into stage.
+ * Notes history includes every `to` and backfills missing `from` text so an
+ * overwrite always leaves a traceback (not only the latest body).
+ * Exported for tests.
  */
 export function buildTimeline(rawEvents, { currentNotes = '' } = {}) {
-    const items = [];
+    const notes = [];
+    const noteEvents = []; // raw note changes for history backfill
+    const stages = [];
+    const fabs = [];
+    const others = [];
 
     for (const e of rawEvents || []) {
         const at = e.created_at || e.timestamp;
@@ -187,55 +283,220 @@ export function buildTimeline(rawEvents, { currentNotes = '' } = {}) {
             const body = (noteTo ?? '').toString();
             const prev = (noteFrom ?? '').toString();
             if (body === prev) continue;
-            items.push({
+            const sk = sortMs(at);
+            noteEvents.push({
+                id: e.id,
+                author,
+                at,
+                from: prev,
+                to: body,
+                sortKey: sk,
+            });
+            notes.push({
                 id: e.id,
                 kind: 'note',
                 author,
                 at,
                 body,
+                sortKey: sk,
+            });
+            continue;
+        }
+
+        if (!ACTIVITY_ACTIONS.has(e.action)) continue;
+
+        if (e.action === 'update_stage') {
+            stages.push({
+                id: e.id,
+                kind: 'stage',
+                author,
+                at,
+                from,
+                to,
                 sortKey: sortMs(at),
             });
             continue;
         }
 
-        if (ACTIVITY_ACTIONS.has(e.action)) {
-            const summary = summarizeActivity(e);
-            if (!summary) continue;
-            items.push({
+        if (e.action === 'update_fab_order') {
+            fabs.push({
                 id: e.id,
-                kind: 'update',
-                updateKind: kindLabel(e.action),
-                author: summary.author,
+                kind: 'fab',
+                author,
                 at,
-                text: summary.text,
+                from,
+                to,
                 sortKey: sortMs(at),
             });
+            continue;
         }
+
+        // Dates / hard clear — structured for chips.
+        if (e.action === 'update_ship_date') {
+            const toLabel = formatDateValue(to);
+            others.push({
+                id: e.id,
+                kind: 'date',
+                author,
+                at,
+                label: 'Ship date',
+                valueLabel: toLabel,
+                cleared: toLabel == null,
+                hard: false,
+                sortKey: sortMs(at),
+            });
+            continue;
+        }
+
+        if (e.action === 'update_start_install') {
+            const asap = payload.asap === true || payload.to_asap === true
+                || /^asap$/i.test(String(to || ''));
+            const hard = payload.hard === true || payload.is_hard === true
+                || payload.start_install_formulaTF === false;
+            const toLabel = asap ? 'ASAP' : formatDateValue(to);
+            others.push({
+                id: e.id,
+                kind: 'date',
+                author,
+                at,
+                label: 'Start install',
+                valueLabel: toLabel,
+                cleared: !asap && toLabel == null,
+                hard: hard && !asap && toLabel != null,
+                sortKey: sortMs(at),
+            });
+            continue;
+        }
+
+        if (e.action === 'clear_hard_date') {
+            others.push({
+                id: e.id,
+                kind: 'date',
+                author,
+                at,
+                label: 'Hard start-install date',
+                valueLabel: null,
+                cleared: true,
+                hard: false,
+                sortKey: sortMs(at),
+            });
+            continue;
+        }
+
+        // Fallback sentence for anything else in ACTIVITY_ACTIONS.
+        const summary = summarizeActivity(e);
+        if (!summary) continue;
+        others.push({
+            id: e.id,
+            kind: 'date',
+            author: summary.author,
+            at,
+            label: summary.text,
+            valueLabel: null,
+            cleared: true,
+            hard: false,
+            sortKey: sortMs(at),
+        });
     }
 
-    items.sort((a, b) => b.sortKey - a.sortKey || (b.id || 0) - (a.id || 0));
+    // Backfill note history: if an overwrite's `from` is not already some event's
+    // `to`, the prior text never had its own event (seed / first modal save).
+    // Inject it so Activity is a full notes traceback, not only the latest body.
+    const knownTos = new Set(noteEvents.map((e) => e.to));
+    const injectedFrom = new Set();
+    const oldestFirst = [...noteEvents].sort(
+        (a, b) => a.sortKey - b.sortKey || (a.id || 0) - (b.id || 0)
+    );
+    for (const e of oldestFirst) {
+        const prev = (e.from ?? '').toString();
+        if (!prev || knownTos.has(prev) || injectedFrom.has(prev)) continue;
+        if (prev === e.to) continue;
+        injectedFrom.add(prev);
+        notes.push({
+            id: `from-${e.id}`,
+            kind: 'note',
+            author: 'Job Log',
+            at: e.at,
+            body: prev,
+            // Sit just under the overwrite that replaced it (same day bucket).
+            sortKey: e.sortKey > 0 ? e.sortKey - 1 : 0,
+            prior: true,
+        });
+    }
 
+    // Merge fab into stage when same author + same minute.
+    const consumedFab = new Set();
+    for (const stage of stages) {
+        const match = fabs.find((f) =>
+            !consumedFab.has(f.id)
+            && authorKey(f.author) === authorKey(stage.author)
+            && minuteKey(f.at) === minuteKey(stage.at)
+            && minuteKey(f.at) !== 0
+        );
+        if (match) {
+            stage.alsoFab = { from: match.from, to: match.to };
+            consumedFab.add(match.id);
+        }
+    }
+    const standaloneFab = fabs.filter((f) => !consumedFab.has(f.id));
+
+    const items = [...notes, ...stages, ...standaloneFab, ...others];
+    items.sort((a, b) => b.sortKey - a.sortKey || String(b.id).localeCompare(String(a.id)));
+
+    // Surface Job Log field notes not yet present in the event window (no CURRENT badge).
     const current = (currentNotes ?? '').toString().trim();
     const firstNote = items.find((i) => i.kind === 'note');
     const newestNoteMatches = firstNote && firstNote.body.trim() === current;
-    const orphanNote = current !== '' && !newestNoteMatches
-        ? { id: 'field-current', kind: 'note', author: 'Job Log', at: null, body: current, current: true, sortKey: Number.MAX_SAFE_INTEGER }
-        : null;
-
-    if (orphanNote) items.unshift(orphanNote);
-
-    // Badge the newest matching note as Current (same behavior as the old rail).
-    if (newestNoteMatches && firstNote) {
-        firstNote.current = true;
+    if (current !== '' && !newestNoteMatches) {
+        items.unshift({
+            id: 'field-current',
+            kind: 'note',
+            author: 'Job Log',
+            at: null,
+            body: current,
+            sortKey: Number.MAX_SAFE_INTEGER,
+        });
     }
 
     return items;
 }
 
-export function ReleaseNotesRail({ job, release, currentNotes }) {
+/** Group timeline items by calendar day (newest day first). Exported for tests. */
+export function groupByDay(items) {
+    const groups = [];
+    const indexByKey = new Map();
+    for (const item of items || []) {
+        const { key, label } = dayBucket(item.at);
+        let g = indexByKey.get(key);
+        if (!g) {
+            g = { key, label, items: [] };
+            indexByKey.set(key, g);
+            groups.push(g);
+        }
+        g.items.push(item);
+    }
+    return groups;
+}
+
+export function ReleaseNotesRail({
+    job,
+    release,
+    currentNotes,
+    onNotesChanged = null,
+}) {
     const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [composing, setComposing] = useState(false);
+    const [draft, setDraft] = useState('');
+    const [saving, setSaving] = useState(false);
+    const [saveError, setSaveError] = useState(null);
+    const [localNotes, setLocalNotes] = useState(currentNotes ?? '');
+    const textareaRef = useRef(null);
+
+    useEffect(() => {
+        setLocalNotes(currentNotes ?? '');
+    }, [currentNotes]);
 
     const load = useCallback(() => {
         if (job == null || !release) { setLoading(false); return; }
@@ -243,65 +504,202 @@ export function ReleaseNotesRail({ job, release, currentNotes }) {
         jobsApi.getNotesHistory(job, release, 200)
             .then((data) => {
                 const raw = Array.isArray(data) ? data : (data?.events || []);
-                setItems(buildTimeline(raw, { currentNotes }));
+                setItems(buildTimeline(raw, { currentNotes: localNotes }));
                 setError(null);
             })
             .catch(() => setError('Could not load activity.'))
             .finally(() => setLoading(false));
-    }, [job, release, currentNotes]);
+    }, [job, release, localNotes]);
 
     useEffect(() => { load(); }, [load]);
 
-    const noteCount = items.filter((i) => i.kind === 'note').length;
-    const updateCount = items.filter((i) => i.kind === 'update').length;
+    const openComposer = () => {
+        setComposing(true);
+        setDraft('');
+        setSaveError(null);
+        // Focus after paint.
+        requestAnimationFrame(() => textareaRef.current?.focus());
+    };
+
+    const cancelComposer = () => {
+        setComposing(false);
+        setDraft('');
+        setSaveError(null);
+    };
+
+    const saveNote = async () => {
+        if (job == null || !release) return;
+        setSaving(true);
+        setSaveError(null);
+        const next = draft; // full overwrite of Job Log Notes field
+        try {
+            await jobsApi.updateNotes(job, release, next);
+            setLocalNotes(next);
+            onNotesChanged?.(next);
+            setComposing(false);
+            setDraft('');
+            // Reload history so the new update_notes event appears.
+            const data = await jobsApi.getNotesHistory(job, release, 200);
+            const raw = Array.isArray(data) ? data : (data?.events || []);
+            setItems(buildTimeline(raw, { currentNotes: next }));
+        } catch (err) {
+            setSaveError(err?.message || 'Could not save note.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const groups = groupByDay(items);
 
     return (
         <div className="flex flex-col min-h-0 border-l border-hairline bg-surface-2">
             <div className="shrink-0 flex items-center border-b border-hairline" style={{ gap: 8, padding: '12px 16px 10px' }}>
                 <span className="text-jl-label font-bold uppercase text-ink-3">Activity</span>
-                <span className="font-mono text-ink-3" style={{ fontSize: 11 }} title={`${noteCount} notes · ${updateCount} updates`}>
+                <span
+                    className="font-mono font-semibold"
+                    style={{
+                        fontSize: 10.5,
+                        padding: '1px 6px',
+                        borderRadius: 999,
+                        background: 'var(--head-bg)',
+                        color: 'var(--text-3)',
+                    }}
+                >
                     {items.length}
                 </span>
                 <div className="flex-1" />
                 <span className="text-ink-3" style={{ fontSize: 10.5 }}>Newest first</span>
+                <button
+                    type="button"
+                    onClick={openComposer}
+                    className="font-semibold border-0 cursor-pointer"
+                    style={{
+                        fontSize: 11.5,
+                        padding: '4px 9px',
+                        borderRadius: 999,
+                        background: 'var(--accent-soft)',
+                        color: 'var(--accent)',
+                    }}
+                >
+                    + Note
+                </button>
             </div>
 
-            <div className="flex-1 min-h-0 overflow-auto" style={{ padding: '12px 16px' }}>
-                {loading && <p className="text-jl-2 text-ink-3 italic">Loading activity…</p>}
-                {error && <p className="text-jl-2" style={{ color: 'var(--fl-red-fg)' }}>{error}</p>}
+            {composing && (
+                <div className="shrink-0 border-b border-hairline bg-surface" style={{ padding: '10px 14px' }}>
+                    <textarea
+                        ref={textareaRef}
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        rows={3}
+                        placeholder="Overwrite Job Log notes…"
+                        disabled={saving}
+                        className="w-full text-ink bg-surface-2 border border-hairline rounded-md resize-y"
+                        style={{ fontSize: 12.5, padding: '8px 10px', lineHeight: 1.4 }}
+                    />
+                    {saveError && (
+                        <p className="text-jl-2" style={{ color: 'var(--fl-red-fg)', marginTop: 6 }}>{saveError}</p>
+                    )}
+                    <div className="flex items-center justify-end" style={{ gap: 8, marginTop: 8 }}>
+                        <button
+                            type="button"
+                            onClick={cancelComposer}
+                            disabled={saving}
+                            className="text-ink-2 bg-transparent border-0 cursor-pointer font-medium"
+                            style={{ fontSize: 12, padding: '4px 8px' }}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={saveNote}
+                            disabled={saving}
+                            className="font-semibold border-0 cursor-pointer text-white disabled:opacity-50"
+                            style={{
+                                fontSize: 12,
+                                padding: '5px 12px',
+                                borderRadius: 7,
+                                background: 'var(--accent)',
+                            }}
+                        >
+                            {saving ? 'Saving…' : 'Save note'}
+                        </button>
+                    </div>
+                    <p className="text-ink-3" style={{ fontSize: 10.5, marginTop: 6, lineHeight: 1.35 }}>
+                        Saves replace the Job Log Notes field (same as editing the cell).
+                    </p>
+                </div>
+            )}
 
-                {!loading && !error && items.map((item, i) => (
-                    item.kind === 'note' ? (
-                        <NoteEntry
-                            key={item.id ?? `n-${i}`}
-                            author={item.author}
-                            at={item.at}
-                            body={item.body}
-                            cleared={item.body.trim() === ''}
-                            current={!!item.current}
-                        />
-                    ) : (
-                        <UpdateEntry
-                            key={item.id ?? `u-${i}`}
-                            author={item.author}
-                            at={item.at}
-                            text={item.text}
-                            kind={item.updateKind}
-                        />
-                    )
+            <div className="flex-1 min-h-0 overflow-auto" style={{ padding: '4px 16px 12px' }}>
+                {loading && <p className="text-jl-2 text-ink-3 italic" style={{ marginTop: 8 }}>Loading activity…</p>}
+                {error && <p className="text-jl-2" style={{ color: 'var(--fl-red-fg)', marginTop: 8 }}>{error}</p>}
+
+                {!loading && !error && groups.map((group) => (
+                    <div key={group.key}>
+                        <DayDivider label={group.label} />
+                        {group.items.map((item, i) => {
+                            const key = item.id ?? `${group.key}-${i}`;
+                            if (item.kind === 'note') {
+                                return (
+                                    <NoteEntry
+                                        key={key}
+                                        author={item.author}
+                                        at={item.at}
+                                        body={item.body}
+                                        cleared={item.body.trim() === ''}
+                                    />
+                                );
+                            }
+                            if (item.kind === 'stage') {
+                                return (
+                                    <StageEntry
+                                        key={key}
+                                        author={item.author}
+                                        at={item.at}
+                                        from={item.from}
+                                        to={item.to}
+                                        alsoFab={item.alsoFab}
+                                    />
+                                );
+                            }
+                            if (item.kind === 'fab') {
+                                return (
+                                    <FabEntry
+                                        key={key}
+                                        author={item.author}
+                                        at={item.at}
+                                        from={item.from}
+                                        to={item.to}
+                                    />
+                                );
+                            }
+                            return (
+                                <DateEntry
+                                    key={key}
+                                    author={item.author}
+                                    at={item.at}
+                                    label={item.label}
+                                    valueLabel={item.valueLabel}
+                                    hard={item.hard}
+                                    cleared={item.cleared}
+                                />
+                            );
+                        })}
+                    </div>
                 ))}
 
                 {!loading && !error && items.length === 0 && (
-                    <p className="text-jl-2 text-ink-3 italic">
-                        No notes or date/stage changes on this release yet.
+                    <p className="text-jl-2 text-ink-3 italic" style={{ marginTop: 8 }}>
+                        No notes, stage, fab, or date changes on this release yet.
                     </p>
                 )}
             </div>
 
             <div className="shrink-0 border-t border-hairline bg-surface" style={{ padding: '10px 14px 12px' }}>
                 <p className="text-ink-3" style={{ fontSize: 11, lineHeight: 1.4 }}>
-                    Notes are edited in the Job Log. Stage and date changes show up here
-                    automatically — full undo history is on the Change Log tab.
+                    Notes are edited here or in the Job Log. Stage and date changes land
+                    here automatically — full undo history is on the Change Log tab.
                 </p>
             </div>
         </div>

--- a/frontend/src/components/ReleaseNotesRail.test.jsx
+++ b/frontend/src/components/ReleaseNotesRail.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { buildTimeline } from './ReleaseNotesRail.jsx';
+
+const EVENTS = [
+    {
+        id: 10,
+        action: 'update_notes',
+        user_name: 'Dave Cruz',
+        created_at: '2026-07-19T12:46:16',
+        payload: { from: 'Fab has pack', to: 'Waiting on GC' },
+    },
+    {
+        id: 9,
+        action: 'update_stage',
+        user_name: 'Ryan Lopez',
+        created_at: '2026-07-18T09:10:00',
+        payload: { from: 'Cut Start', to: 'Cut Complete' },
+    },
+    {
+        id: 8,
+        action: 'update_ship_date',
+        user_name: 'Dave Cruz',
+        created_at: '2026-07-17T11:00:00',
+        payload: { from: null, to: '2026-07-28' },
+    },
+    {
+        id: 7,
+        action: 'update_notes',
+        user_name: 'Ryan Lopez',
+        created_at: '2026-07-02T09:10:00',
+        payload: { from: '', to: 'Fab has pack' },
+    },
+    // No-op stage — must be dropped.
+    {
+        id: 6,
+        action: 'update_stage',
+        user_name: 'Ryan Lopez',
+        created_at: '2026-07-16T09:10:00',
+        payload: { from: 'Cut Start', to: 'Cut Start' },
+    },
+    // Fab order — not in the mixed feed.
+    {
+        id: 5,
+        action: 'update_fab_order',
+        user_name: 'Admin',
+        created_at: '2026-07-15T09:10:00',
+        payload: { from: 1, to: 2 },
+    },
+];
+
+describe('buildTimeline', () => {
+    it('intermingles notes and date/stage updates newest-first', () => {
+        const items = buildTimeline(EVENTS, { currentNotes: 'Waiting on GC' });
+        expect(items.map((i) => i.kind)).toEqual(['note', 'update', 'update', 'note']);
+        expect(items[0].body).toBe('Waiting on GC');
+        expect(items[0].current).toBe(true);
+        expect(items[1].text).toBe('Stage Cut Start → Cut Complete');
+        expect(items[2].updateKind).toBe('Ship');
+        expect(items[3].body).toBe('Fab has pack');
+    });
+
+    it('drops no-ops and non-activity actions', () => {
+        const items = buildTimeline(EVENTS);
+        expect(items.find((i) => i.id === 6)).toBeUndefined();
+        expect(items.find((i) => i.id === 5)).toBeUndefined();
+    });
+
+    it('surfaces the current field note when it is not in the event window', () => {
+        const items = buildTimeline([], { currentNotes: 'Orphan note on the cell' });
+        expect(items).toHaveLength(1);
+        expect(items[0].body).toBe('Orphan note on the cell');
+        expect(items[0].current).toBe(true);
+    });
+});

--- a/frontend/src/components/ReleaseNotesRail.test.jsx
+++ b/frontend/src/components/ReleaseNotesRail.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTimeline } from './ReleaseNotesRail.jsx';
+import { buildTimeline, groupByDay, dayBucket } from './ReleaseNotesRail.jsx';
 
 const EVENTS = [
     {
@@ -38,7 +38,7 @@ const EVENTS = [
         created_at: '2026-07-16T09:10:00',
         payload: { from: 'Cut Start', to: 'Cut Start' },
     },
-    // Fab order — not in the mixed feed.
+    // Standalone fab (different minute from any stage).
     {
         id: 5,
         action: 'update_fab_order',
@@ -49,26 +49,144 @@ const EVENTS = [
 ];
 
 describe('buildTimeline', () => {
-    it('intermingles notes and date/stage updates newest-first', () => {
+    it('intermingles notes, stage, ship, and fab newest-first', () => {
         const items = buildTimeline(EVENTS, { currentNotes: 'Waiting on GC' });
-        expect(items.map((i) => i.kind)).toEqual(['note', 'update', 'update', 'note']);
+        // Newest-first: note 7/19, stage 7/18, ship 7/17, fab 7/15, note 7/2.
+        expect(items.map((i) => i.kind)).toEqual(['note', 'stage', 'date', 'fab', 'note']);
         expect(items[0].body).toBe('Waiting on GC');
-        expect(items[0].current).toBe(true);
-        expect(items[1].text).toBe('Stage Cut Start → Cut Complete');
-        expect(items[2].updateKind).toBe('Ship');
-        expect(items[3].body).toBe('Fab has pack');
+        expect(items[0].current).toBeUndefined();
+        expect(items[1].kind).toBe('stage');
+        expect(items[1].from).toBe('Cut Start');
+        expect(items[1].to).toBe('Cut Complete');
+        expect(items[2].kind).toBe('date');
+        expect(items[2].valueLabel).toMatch(/Jul 28/);
+        expect(items[3].kind).toBe('fab');
+        expect(items[3].from).toBe(1);
+        expect(items[3].to).toBe(2);
     });
 
-    it('drops no-ops and non-activity actions', () => {
+    it('drops no-ops', () => {
         const items = buildTimeline(EVENTS);
         expect(items.find((i) => i.id === 6)).toBeUndefined();
-        expect(items.find((i) => i.id === 5)).toBeUndefined();
+    });
+
+    it('merges same-user same-minute fab into stage', () => {
+        const raw = [
+            {
+                id: 20,
+                action: 'update_stage',
+                user_name: 'David Servold',
+                created_at: '2026-04-16T07:00:10',
+                payload: { from: 'Paint complete', to: 'Shipping completed' },
+            },
+            {
+                id: 21,
+                action: 'update_fab_order',
+                user_name: 'David Servold',
+                created_at: '2026-04-16T07:00:40',
+                payload: { from: 3, to: 1 },
+            },
+        ];
+        const items = buildTimeline(raw);
+        expect(items).toHaveLength(1);
+        expect(items[0].kind).toBe('stage');
+        expect(items[0].alsoFab).toEqual({ from: 3, to: 1 });
+    });
+
+    it('does not merge fab from a different user or minute', () => {
+        const raw = [
+            {
+                id: 20,
+                action: 'update_stage',
+                user_name: 'David Servold',
+                created_at: '2026-04-16T07:00:10',
+                payload: { from: 'A', to: 'B' },
+            },
+            {
+                id: 21,
+                action: 'update_fab_order',
+                user_name: 'Someone Else',
+                created_at: '2026-04-16T07:00:40',
+                payload: { from: 3, to: 1 },
+            },
+            {
+                id: 22,
+                action: 'update_fab_order',
+                user_name: 'David Servold',
+                created_at: '2026-04-16T08:00:00',
+                payload: { from: 5, to: 4 },
+            },
+        ];
+        const items = buildTimeline(raw);
+        expect(items.filter((i) => i.kind === 'stage')).toHaveLength(1);
+        expect(items.find((i) => i.kind === 'stage').alsoFab).toBeUndefined();
+        expect(items.filter((i) => i.kind === 'fab')).toHaveLength(2);
     });
 
     it('surfaces the current field note when it is not in the event window', () => {
         const items = buildTimeline([], { currentNotes: 'Orphan note on the cell' });
         expect(items).toHaveLength(1);
         expect(items[0].body).toBe('Orphan note on the cell');
-        expect(items[0].current).toBe(true);
+        expect(items[0].current).toBeUndefined();
+    });
+
+    it('backfills prior note text from payload.from when it has no own event', () => {
+        // One overwrite only: previous body lived only in `from` (user's screenshot case).
+        const raw = [
+            {
+                id: 99,
+                action: 'update_notes',
+                user_name: 'Daniel McGarey',
+                created_at: '2026-08-08T16:42:00',
+                payload: { from: 'Need clevis rods painted', to: 'Test' },
+            },
+        ];
+        const items = buildTimeline(raw, { currentNotes: 'Test' });
+        const noteBodies = items.filter((i) => i.kind === 'note').map((i) => i.body);
+        expect(noteBodies).toEqual(['Test', 'Need clevis rods painted']);
+        expect(items.find((i) => i.body === 'Need clevis rods painted').prior).toBe(true);
+    });
+
+    it('does not duplicate prior text already recorded as an older note event to', () => {
+        const raw = [
+            {
+                id: 10,
+                action: 'update_notes',
+                user_name: 'Dave',
+                created_at: '2026-07-19T12:00:00',
+                payload: { from: 'Fab has pack', to: 'Waiting on GC' },
+            },
+            {
+                id: 7,
+                action: 'update_notes',
+                user_name: 'Ryan',
+                created_at: '2026-07-02T09:00:00',
+                payload: { from: '', to: 'Fab has pack' },
+            },
+        ];
+        const items = buildTimeline(raw);
+        const noteBodies = items.filter((i) => i.kind === 'note').map((i) => i.body);
+        // Both tos only — no synthetic "Fab has pack" from id 10's from.
+        expect(noteBodies).toEqual(['Waiting on GC', 'Fab has pack']);
+        expect(items.filter((i) => i.prior)).toHaveLength(0);
+    });
+});
+
+describe('groupByDay / dayBucket', () => {
+    it('formats day labels like TUE · APR 7', () => {
+        // Local date constructor avoids UTC off-by-one.
+        const d = new Date(2026, 3, 7, 8, 28); // Apr 7 2026
+        const { label } = dayBucket(d.toISOString());
+        expect(label).toMatch(/^[A-Z]{3} · [A-Z]{3} \d{1,2}$/);
+        expect(label).toContain('APR');
+        expect(label).toContain('7');
+    });
+
+    it('groups items under day dividers newest-first within build order', () => {
+        const items = buildTimeline(EVENTS);
+        const groups = groupByDay(items);
+        expect(groups.length).toBeGreaterThanOrEqual(2);
+        // First group's first item is the newest overall.
+        expect(groups[0].items[0].id).toBe(items[0].id);
     });
 });

--- a/frontend/src/services/jobsApi.js
+++ b/frontend/src/services/jobsApi.js
@@ -263,7 +263,7 @@ class JobsApi {
         }
     }
 
-    // Carmen Miranda code-compliance review of a drawing version (admin-only).
+    // Carmen code-compliance review of a drawing version (admin or drafter).
     async getBBReview(releaseId, versionId) {
         try {
             const response = await axios.get(


### PR DESCRIPTION
## Summary
- Enlarge the release hub shell: **Details / Attachments / Change Log**, activity rail on Details + Change Log only, amber findings badge on Attachments.
- **Details**: date-flow hero, 3-column metadata, banana-code stage progress, Install Prog whole-number `%`.
- **Activity**: day-grouped notes + stage/fab/date updates, fab merge, **+ Note** overwrite with full notes history traceback, Job Log row sync.
- **Change Log** (hub only): plain-language field diffs, day groups, undo; Events page layout unchanged.
- **Attachments**: left documents/photos rail + thin read-only PDF viewer with finding cite jumps; Carmen review open to **admin and drafter**.

## Test plan
- [ ] Open a busy release from Job Log; confirm larger modal and three tabs
- [ ] Details: date hero, 3-col fields, bananas, install prog `%`
- [ ] Activity: day groups, stage chips, fab merge, + Note save updates cell + history
- [ ] Change Log: no Identifier, field labels not `update_*`, undo still works
- [ ] Attachments: split pane, View loads PDF, Fit/Width/zoom/page nav
- [ ] Admin or drafter: run/view Carmen findings; jump when finding has page
- [ ] Attachments badge shows when actionable findings exist
- [ ] Events page still uses the classic events table
- [ ] `cd frontend && npx vitest run src/components/ReleaseHubModal.test.jsx src/components/ReleaseNotesRail.test.jsx src/components/EventsList.hub.test.jsx src/components/PdfReadViewer.test.jsx`