### PR TITLE
BUG-9, BUG-10, BUG-8: Consolidate fab_order rules, fix invite links, archive-aware rel numbers

### DIFF
--- a/app/brain/drafting_work_load/routes.py
+++ b/app/brain/drafting_work_load/routes.py
@@ -799,12 +799,20 @@ def get_next_rel():
     """Suggest the next available Rel number, used to prefill the assign popup.
 
     Optional ``submittal_id`` query param excludes that submittal's own current
-    Rel from the suggestion (for reassignment)."""
+    Rel from the suggestion (for reassignment) and, via the submittal's project
+    number, scopes out Rels that job already burned — including on archived
+    releases the DWL cannot see (BUG-8)."""
     from app.procore.procore import next_rel_number
 
     submittal_id = request.args.get('submittal_id') or None
+    job_number = None
+    if submittal_id:
+        submittal = Submittals.query.filter_by(submittal_id=str(submittal_id)).first()
+        if submittal is not None:
+            job_number = submittal.project_number
+
     try:
-        suggestion = next_rel_number(exclude_submittal_id=submittal_id)
+        suggestion = next_rel_number(exclude_submittal_id=submittal_id, job_number=job_number)
     except RuntimeError:
         return jsonify({"next_rel": None}), 200
     return jsonify({"next_rel": suggestion}), 200

--- a/app/brain/job_log/features/fab_order/tier.py
+++ b/app/brain/job_log/features/fab_order/tier.py
@@ -1,0 +1,222 @@
+"""
+@milehigh-header
+schema_version: 1
+purpose: Single source of truth for the fab_order a release should hold at a given stage, shared by every code path that writes a stage.
+exports:
+  FabOrderPlan: The value + reason a stage change implies for fab_order
+  plan_fab_order_for_stage: Decide the fab_order for a stage (None = leave it alone)
+  apply_fab_order_for_stage: Execute a plan — write the field and emit the linked event
+imports_from: [app.models, app.api.helpers, app.services.job_event_service, app.logging_config]
+imported_by: [app/brain/job_log/features/stage/command.py, app/brain/job_log/routes.py, app/trello/sync.py]
+invariants:
+  - Stage 'Complete' is terminal — fab_order is always NULL there
+  - Fixed-tier stages always hold their tier value (0 Install, 1 Ship Complete, 2 Paint Complete/Store/Ship Planning)
+  - Dynamic stages never hold a reserved value (< 3) or NULL — arriving with one is repaired to the back of that stage's deck
+  - The DB field is written even when the audit event deduplicates; a dropped event must never leave fab_order stale
+updated_by_agent: 2026-08-15T00:00:00Z
+
+BUG-9. `fab_order` tier assignment used to live inline inside
+`UpdateStageCommand`, which meant it only ran when a stage change came through
+that one command. Three other paths write a stage:
+
+  * the inbound Trello sync (`TrelloListMapper.apply_trello_list_to_db`) — how
+    the shop actually moves work, and it touched `fab_order` not at all, so a
+    card dragged from the paint list to a shipping list kept its tier-2 value
+    forever ("it's not flipping the two and the one");
+  * `update_job_comp` setting Install Start via `update_job_stage_fields` —
+    same silence, so a tier-0 stage kept whatever the paint deck left behind;
+  * `update_job_comp` setting Install Complete — which *cleared* fab_order to
+    NULL, while `UpdateStageCommand` sets the same stage to tier 0. The same
+    end state, two answers, depending on which button you pressed ("the fab
+    order is being cleared and not cleared").
+
+The rules were never in dispute — they are stated identically in
+`migrate_unified.py`'s invariants and in `FIXED_TIER_STAGES`. They were just
+implemented once and skipped three times. This module is that implementation,
+and the four write paths call it instead of restating it.
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from app.logging_config import get_logger
+from app.services.job_event_service import JobEventService
+
+logger = get_logger(__name__)
+
+#: Tiers 0-2 are reserved for fixed-tier stages, so a dynamic stage's fab_order
+#: is always >= 3. A dynamic release holding less than this drifted there.
+RESERVED_TIER_CEILING = 3
+
+#: Terminal stage — ordering is meaningless once a release is done.
+TERMINAL_STAGE = "Complete"
+
+
+@dataclass(frozen=True)
+class FabOrderPlan:
+    """What a stage change implies for fab_order. `reason` lands in the event
+    payload, so it is the explanation a user reads in the change log."""
+    fab_order: Optional[float]
+    reason: str
+
+
+def _back_of_deck(stages, exclude_job, exclude_release) -> float:
+    """First free slot behind everything currently sitting in `stages`.
+
+    Floors the max at 2 so the result is never inside the reserved tier band,
+    and ignores the DEFAULT_FAB_ORDER placeholder (80.555) — that value marks
+    "unordered", not "last in line", and treating it as the back of the deck
+    would push every repair into the eighties.
+    """
+    from sqlalchemy import func, or_
+    from app.api.helpers import DEFAULT_FAB_ORDER, _get_all_variants_for_stages
+    from app.models import Releases, db
+
+    variants = _get_all_variants_for_stages(list(stages))
+    current_max = db.session.query(func.max(Releases.fab_order)).filter(
+        Releases.stage.in_(variants),
+        Releases.fab_order.isnot(None),
+        Releases.fab_order != DEFAULT_FAB_ORDER,
+        Releases.is_archived != True,  # noqa: E712
+        or_(
+            Releases.job != exclude_job,
+            Releases.release != exclude_release,
+        ),
+    ).scalar()
+    base = current_max if current_max is not None and current_max >= 2 else 2
+    return base + 1
+
+
+def plan_fab_order_for_stage(job_record, new_stage, old_stage_group=None) -> Optional[FabOrderPlan]:
+    """Decide what fab_order a release should hold once it sits at `new_stage`.
+
+    Returns None when the current value is already right — callers write
+    nothing and emit no event in that case. `old_stage_group` is the record's
+    stage_group *before* the move and must be captured by the caller before it
+    overwrites the field; it only affects the Welded QC department handoff.
+    """
+    from app.api.helpers import (
+        DEFAULT_FAB_ORDER,
+        STAGE_ORDER_EXEMPT,
+        _normalize_stage,
+        get_fixed_tier,
+    )
+
+    normalized = _normalize_stage(new_stage)
+    if normalized is None:
+        # Unrecognised stage: refuse to guess. Leaving the old value is the
+        # conservative move — the stage itself is already suspect.
+        return None
+
+    current = job_record.fab_order
+
+    # Complete is terminal — nothing to order.
+    if normalized == TERMINAL_STAGE:
+        return None if current is None else FabOrderPlan(None, "complete_clears_fab_order")
+
+    tier = get_fixed_tier(normalized)
+    if tier is not None:
+        return None if current == tier else FabOrderPlan(tier, "fixed_tier")
+
+    # Hold is a pause, not a position — it keeps whatever it had so the release
+    # returns to roughly where it left.
+    if normalized in STAGE_ORDER_EXEMPT:
+        return None
+
+    # Dynamic stage from here down.
+    if normalized == "Welded QC" and old_stage_group != "READY_TO_SHIP":
+        # Department handoff, Fab → Paint: land at the back of the paint deck so
+        # a fresh arrival doesn't jump the line on work already in the booth.
+        return FabOrderPlan(
+            _back_of_deck(["Welded QC", "Paint Start"], job_record.job, job_record.release),
+            "paint_handoff",
+        )
+
+    if current is not None and current >= RESERVED_TIER_CEILING:
+        return None  # already a valid dynamic position; the user owns it
+
+    # Arrived on a dynamic stage holding a reserved tier value or nothing at
+    # all — i.e. it came back down from shipping/install, or was cleared by
+    # Complete and then reopened. Either way it has no real position, and
+    # leaving 0/1/2 in place sorts it in front of the entire shop.
+    if normalized == "Released":
+        # Released is the unordered pool; DEFAULT_FAB_ORDER is its placeholder
+        # (same convention as fix_null_fab_orders).
+        return FabOrderPlan(DEFAULT_FAB_ORDER, "reserved_tier_released")
+
+    return FabOrderPlan(
+        _back_of_deck([normalized], job_record.job, job_record.release),
+        "reserved_tier_released",
+    )
+
+
+def apply_fab_order_for_stage(
+    job_record,
+    new_stage,
+    old_stage_group=None,
+    *,
+    source="Brain",
+    parent_event_id=None,
+    stage_reason=None,
+):
+    """Plan and apply the fab_order for a stage move. Returns the FabOrderPlan
+    that was applied, or None when nothing needed to change.
+
+    The field is written whether or not the audit event survives dedup. The old
+    inline version wrote the field only inside the `if event:` branch, so a
+    deduplicated event left the release sitting on a stale tier — the very
+    "cleared and not cleared" inconsistency this is fixing. The DB value is the
+    truth; the event is the record of it.
+    """
+    plan = plan_fab_order_for_stage(job_record, new_stage, old_stage_group)
+    if plan is None:
+        return None
+
+    old_fab_order = _json_safe(job_record.fab_order)
+    payload = {
+        "from": old_fab_order,
+        "to": _json_safe(plan.fab_order),
+        "reason": plan.reason if stage_reason is None else f"{plan.reason}:{stage_reason}",
+    }
+    if parent_event_id is not None:
+        payload["parent_event_id"] = parent_event_id
+
+    event = JobEventService.create(
+        job=job_record.job,
+        release=job_record.release,
+        action="update_fab_order",
+        source=source,
+        payload=payload,
+    )
+
+    job_record.fab_order = plan.fab_order
+
+    if event is None:
+        logger.debug(
+            "fab_order_event_deduplicated",
+            job=job_record.job,
+            release=job_record.release,
+            fab_order=plan.fab_order,
+        )
+    else:
+        JobEventService.close(event.id)
+
+    logger.info(
+        "fab_order_retiered",
+        release_id=job_record.id,
+        job=job_record.job,
+        release=job_record.release,
+        to_stage=new_stage,
+        fab_order=plan.fab_order,
+        reason=plan.reason,
+    )
+    return plan
+
+
+def _json_safe(value):
+    """NaN is not JSON — it has turned up in fab_order before (see the coercion
+    in UpdateFabOrderCommand) and would poison the event payload."""
+    import math
+
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    return value

--- a/app/brain/job_log/features/stage/command.py
+++ b/app/brain/job_log/features/stage/command.py
@@ -5,10 +5,10 @@ purpose: Encapsulate the full stage update workflow (DB write, stage_group sync,
 exports:
   UpdateStageCommand: Dataclass command that executes a stage update with all side effects
   StageUpdateResult: Dataclass result with event_id, job_comp/fab_order extras
-imports_from: [app.models, app.services.outbox_service, app.services.job_event_service, app.api.helpers, app.brain.job_log.scheduling.service, app.brain.job_log.features.start_install.neutralize_install_date_cascade, app.brain.job_log.features.start_install.shipping_stage_date_discipline]
+imports_from: [app.models, app.services.outbox_service, app.services.job_event_service, app.api.helpers, app.brain.job_log.scheduling.service, app.brain.job_log.features.fab_order.tier, app.brain.job_log.features.start_install.neutralize_install_date_cascade, app.brain.job_log.features.start_install.shipping_stage_date_discipline]
 imported_by: [app/brain/job_log/routes.py]
 invariants:
-  - Fixed-tier stages (Ready-to-Ship / Complete groups) auto-assign fab_order via get_fixed_tier
+  - fab_order re-tiering is delegated to features/fab_order/tier.py, shared with the Trello sync and job_comp paths
   - Setting stage='Complete' cascades job_comp='X'; leaving Complete clears job_comp='X'
   - Paint Complete + hard start_install auto-rolls to Ship Planning (N5; generalizes ASAP intercept)
   - Ship Planning / Ship Complete apply N5 date discipline (formula blank or hard-date wash)
@@ -18,12 +18,12 @@ invariants:
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Any
-import math
 
 from app.models import Releases, db
 from app.services.job_event_service import JobEventService
 from app.services.outbox_service import OutboxService
 from app.logging_config import get_logger
+from app.brain.job_log.features.fab_order.tier import apply_fab_order_for_stage
 from app.brain.job_log.features.start_install.neutralize_install_date_cascade import neutralize_install_date_cascade
 from app.brain.job_log.features.start_install.shipping_stage_date_discipline import (
     apply_shipping_stage_date_discipline,
@@ -107,7 +107,7 @@ class UpdateStageCommand:
     undone_event_id: Optional[int] = None
 
     def execute(self) -> StageUpdateResult:
-        from app.api.helpers import get_stage_group_from_stage, get_fixed_tier, STAGE_PROGRESSION_RANK
+        from app.api.helpers import get_stage_group_from_stage, STAGE_PROGRESSION_RANK
 
         job_record: Releases = Releases.resolve(self.job_id, self.release)
         if not job_record:
@@ -198,46 +198,6 @@ class UpdateStageCommand:
             from_stage=old_stage,
             to_stage=self.stage,
         )
-
-        fab_order_to_set = None
-        old_fab_order_for_update = job_record.fab_order
-        tier = get_fixed_tier(self.stage)
-        if tier is not None:
-            fab_order_to_set = tier
-            logger.debug(
-                "fab_order_fixed_tier_planned",
-                job=self.job_id,
-                release=self.release,
-                stage=self.stage,
-                tier=tier,
-                old=old_fab_order_for_update,
-                new=fab_order_to_set,
-            )
-        elif self.stage == "Welded QC" and old_stage_group != "READY_TO_SHIP":
-            # Department handoff: Fab → Paint. Land at the back of the paint
-            # deck so the fresh arrival doesn't jump the line on existing
-            # Welded QC / Paint Start work. Tiers 1-2 are reserved, so floor
-            # the max at 2 — minimum result is 3.
-            from sqlalchemy import func, or_
-            current_max = db.session.query(func.max(Releases.fab_order)).filter(
-                Releases.stage.in_(["Welded QC", "Paint Start"]),
-                Releases.fab_order.isnot(None),
-                Releases.is_archived != True,  # noqa: E712
-                or_(
-                    Releases.job != self.job_id,
-                    Releases.release != self.release,
-                ),
-            ).scalar()
-            base = current_max if current_max is not None and current_max >= 2 else 2
-            fab_order_to_set = base + 1
-            logger.debug(
-                "fab_order_paint_handoff_planned",
-                job=self.job_id,
-                release=self.release,
-                old=old_fab_order_for_update,
-                new=fab_order_to_set,
-                current_max=current_max,
-            )
 
         # Apply stage + stage_group
         job_record.stage = self.stage
@@ -352,67 +312,18 @@ class UpdateStageCommand:
         job_record.last_updated_at = datetime.utcnow()
         job_record.source_of_update = self.source_of_update
 
-        # Complete is terminal — fab_order is always NULL.
-        if self.stage == 'Complete' and old_fab_order_for_update is not None:
-            payload_from = (
-                None if (isinstance(old_fab_order_for_update, float) and math.isnan(old_fab_order_for_update))
-                else old_fab_order_for_update
-            )
-            fab_order_event = JobEventService.create(
-                job=self.job_id,
-                release=self.release,
-                action='update_fab_order',
-                source=self.source,
-                payload={
-                    'from': payload_from,
-                    'to': None,
-                    'reason': 'stage_change_complete_clears_fab_order',
-                    'parent_event_id': event.id,
-                },
-            )
-            if fab_order_event is None:
-                logger.debug(
-                    "fab_order_clear_deduplicated",
-                    job=self.job_id,
-                    release=self.release,
-                )
-            else:
-                job_record.fab_order = None
-                JobEventService.close(fab_order_event.id)
-                extras['fab_order'] = None
-
-        # fab_order auto-assign for fixed-tier stages
-        if fab_order_to_set is not None and fab_order_to_set != old_fab_order_for_update:
-            payload_from = (
-                None if (isinstance(old_fab_order_for_update, float) and math.isnan(old_fab_order_for_update))
-                else old_fab_order_for_update
-            )
-            payload_to = (
-                None if (isinstance(fab_order_to_set, float) and math.isnan(fab_order_to_set))
-                else fab_order_to_set
-            )
-            fab_order_event = JobEventService.create(
-                job=self.job_id,
-                release=self.release,
-                action='update_fab_order',
-                source=self.source,
-                payload={
-                    'from': payload_from,
-                    'to': payload_to,
-                    'reason': 'stage_change_unified',
-                    'parent_event_id': event.id,
-                },
-            )
-            if fab_order_event is None:
-                logger.debug(
-                    "fab_order_update_deduplicated",
-                    job=self.job_id,
-                    release=self.release,
-                )
-            else:
-                job_record.fab_order = fab_order_to_set
-                JobEventService.close(fab_order_event.id)
-                extras['fab_order'] = fab_order_to_set
+        # fab_order re-tiering. One rule set, shared with the Trello inbound sync
+        # and the job_comp routes — see features/fab_order/tier.py (BUG-9).
+        fab_order_plan = apply_fab_order_for_stage(
+            job_record,
+            self.stage,
+            old_stage_group,
+            source=self.source,
+            parent_event_id=event.id,
+            stage_reason='stage_change_unified',
+        )
+        if fab_order_plan is not None:
+            extras['fab_order'] = fab_order_plan.fab_order
 
         # Trello outbox — push only when the DB stage's forward-mapped Trello list
         # actually differs from the card's current list. This avoids redundant API

--- a/app/brain/job_log/routes.py
+++ b/app/brain/job_log/routes.py
@@ -2122,13 +2122,19 @@ def get_next_release_number():
     popup (next_rel_number), but -- unlike that popup's route -- is open to
     any logged-in user (not just drafter/admin), since a PM pushing a verbal
     release through needs it too. The suggestion is editable in the form; the
-    real duplicate guard is the (job, release) collision check the release
-    endpoint already runs on submit.
+    real duplicate guard is the (job, release, job_name) collision check the
+    release endpoint already runs on submit.
+
+    Optional ``job`` query param scopes out release numbers that job has already
+    used, archived rows included (BUG-8) — the paste path knows the job number
+    before it asks for a suggestion, so it passes it. Opening the empty modal
+    does not know it yet and stays unscoped; the submit-time guard is still the
+    backstop there.
     """
     from app.procore.procore import next_rel_number
 
     try:
-        suggestion = next_rel_number()
+        suggestion = next_rel_number(job_number=request.args.get('job') or None)
     except RuntimeError:
         return jsonify({'next_release': None}), 200
     return jsonify({'next_release': str(suggestion)}), 200

--- a/app/brain/job_log/routes.py
+++ b/app/brain/job_log/routes.py
@@ -46,6 +46,7 @@ from app.auth.utils import (
 )
 from app.route_utils import handle_errors, require_json, get_or_404, get_release_or_404
 from app.api.helpers import DEFAULT_FAB_ORDER, active_releases_filter
+from app.brain.job_log.features.fab_order.tier import apply_fab_order_for_stage
 from app.brain.job_log.features.start_install.command import UpdateStartInstallCommand
 from app.brain.job_log.features.start_install.assign_installer import AssignInstallerCommand
 from app.brain.job_log.features.start_install.neutralize_install_date_cascade import neutralize_install_date_cascade
@@ -1598,14 +1599,21 @@ def update_job_comp(job, release):
     old_was_x = old_job_comp and old_job_comp.strip().upper() == 'X'
     new_is_x = job_comp_str and job_comp_str.upper() == 'X'
 
+    # Both branches below re-tier fab_order through the shared rule set
+    # (features/fab_order/tier.py) rather than deciding for themselves. Before
+    # BUG-9 the percentage branch left fab_order untouched — so a release
+    # arriving at Install Start kept the paint deck's tier 2 — and the 'X'
+    # branch cleared it to NULL, disagreeing with UpdateStageCommand, which
+    # gives the same stage tier 0. Same stage, two answers, depending on which
+    # control the office used.
     if new_is_pct:
         # Entering a percentage moves the release to 'Install Start'. Does NOT
-        # clear the hard start-install date or fab_order — install has begun,
-        # not finished.
+        # clear the hard start-install date — install has begun, not finished.
         current_stage = job_record.stage or 'Released'
         if current_stage != 'Install Start':
+            old_stage_group = job_record.stage_group
             update_job_stage_fields(job_record, 'Install Start')
-            JobEventService.create_and_close(
+            stage_event = JobEventService.create_and_close(
                 job=job, release=release,
                 action='update_stage', source='Brain',
                 payload={'from': current_stage, 'to': 'Install Start', 'reason': 'job_comp_pct_set'},
@@ -1614,11 +1622,20 @@ def update_job_comp(job, release):
             from app.api.helpers import get_stage_group_from_stage
             response_extras['stage_group'] = get_stage_group_from_stage('Install Start')
 
+            fab_plan = apply_fab_order_for_stage(
+                job_record, 'Install Start', old_stage_group,
+                parent_event_id=stage_event.id if stage_event else None,
+                stage_reason='job_comp_pct_set',
+            )
+            if fab_plan is not None:
+                response_extras['fab_order'] = fab_plan.fab_order
+
     if new_is_x:
         current_stage = job_record.stage or 'Released'
         if current_stage != 'Install Complete':
+            old_stage_group = job_record.stage_group
             update_job_stage_fields(job_record, 'Install Complete')
-            JobEventService.create_and_close(
+            stage_event = JobEventService.create_and_close(
                 job=job, release=release,
                 action='update_stage', source='Brain',
                 payload={'from': current_stage, 'to': 'Install Complete', 'reason': 'job_comp_set_to_x'},
@@ -1627,17 +1644,13 @@ def update_job_comp(job, release):
             from app.api.helpers import get_stage_group_from_stage
             response_extras['stage_group'] = get_stage_group_from_stage('Install Complete')
 
-        if job_record.fab_order is not None:
-            old_fab = job_record.fab_order
-            job_record.fab_order = None
-            fab_event = JobEventService.create(
-                job=job, release=release,
-                action='update_fab_order', source='Brain',
-                payload={'from': old_fab, 'to': None, 'reason': 'job_comp_complete'},
+            fab_plan = apply_fab_order_for_stage(
+                job_record, 'Install Complete', old_stage_group,
+                parent_event_id=stage_event.id if stage_event else None,
+                stage_reason='job_comp_set_to_x',
             )
-            if fab_event:
-                JobEventService.close(fab_event.id)
-            response_extras['fab_order'] = None
+            if fab_plan is not None:
+                response_extras['fab_order'] = fab_plan.fab_order
 
     if new_is_x and not old_was_x and primary_event is not None:
         if neutralize_install_date_cascade(

--- a/app/brain/tm/subcontractors/command.py
+++ b/app/brain/tm/subcontractors/command.py
@@ -23,13 +23,18 @@ subcontractor's only path to the account/ticket. The admin-facing confirmation
 IS swallowed (logged as ERROR, not raised) — it's a courtesy receipt, and the
 real action (invite/assignment) already succeeded, so a flaky second send
 shouldn't read as a failed action.
+
+Every link in those emails is built through `_external_link`, which refuses to
+mail a link against the localhost APP_BASE_URL default outside a local
+environment. BUG-10 was that failing silently: an invite went to a real inbox
+carrying http://localhost:5173/... and nothing anywhere said so.
 """
 import hashlib
 import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from app.config import Config as cfg
+from app.config import Config as cfg, LOCAL_APP_BASE_URL, current_environment, is_local_environment
 from app.models import Subcontractor, TMTicket, TMTicketSubcontractor, db
 from app.microsoft.mailer import send_mail
 from app.logging_config import get_logger
@@ -37,6 +42,58 @@ from app.logging_config import get_logger
 logger = get_logger(__name__)
 
 INVITE_TOKEN_TTL_DAYS = 7
+
+
+class OutboundLinkNotConfiguredError(RuntimeError):
+    """APP_BASE_URL is unset (or still the localhost default) on a deployed
+    environment, so any link built here would be unreachable by the recipient.
+
+    Raised instead of mailing a dead link. BUG-10 was exactly this failing
+    silently: a real invite went to a real inbox carrying
+    http://localhost:5173/sub/accept-invite/... and the only symptom anyone
+    could see was "the link doesn't work".
+    """
+
+
+def _external_link(path: str) -> str:
+    """Build an absolute link for an outbound email, or refuse to.
+
+    Deployed environments must have APP_BASE_URL set to the real domain; if it
+    is missing we raise rather than send, because the recipient has no way to
+    recover from a localhost link and the sender gets no signal. Locally the
+    default is legitimate (it points at the Vite dev server) and only whispers
+    at DEBUG.
+    """
+    base = (cfg.APP_BASE_URL or "").strip().rstrip("/")
+    if not base or base == LOCAL_APP_BASE_URL:
+        if not is_local_environment():
+            logger.error(
+                "app_base_url_not_configured",
+                environment=current_environment(),
+                path=path,
+                status="refused",
+                error="APP_BASE_URL is unset; refusing to email a localhost link",
+                error_type="OutboundLinkNotConfiguredError",
+                exc_info=True,
+            )
+            raise OutboundLinkNotConfiguredError(
+                "APP_BASE_URL is not set for this environment, so the email would "
+                "carry an unreachable link. Set APP_BASE_URL to the Brain's public "
+                "domain and try again."
+            )
+        logger.debug("app_base_url_local_default", path=path)
+    return f"{base}{path}"
+
+
+def _require_external_link_base() -> None:
+    """Fail before any state changes when outbound links are unbuildable.
+
+    The invite paths commit (a new row, or a rotated token that invalidates the
+    previous one) before they send. Checking up front means a misconfigured
+    environment costs nothing instead of leaving a dead subcontractor row or a
+    burned token behind.
+    """
+    _external_link("")
 
 
 def _generate_and_store_invite_token(subcontractor: Subcontractor) -> str:
@@ -49,7 +106,7 @@ def _generate_and_store_invite_token(subcontractor: Subcontractor) -> str:
 
 
 def _invite_email_html(subcontractor: Subcontractor, raw_token: str, invited_by_name: str) -> str:
-    link = f"{cfg.APP_BASE_URL}/sub/accept-invite/{raw_token}"
+    link = _external_link(f"/sub/accept-invite/{raw_token}")
     return (
         f"<p>Hi {subcontractor.contact_name},</p>"
         f"<p>{invited_by_name} has invited you to MHMW Brain to fill out Time &amp; Material "
@@ -60,7 +117,7 @@ def _invite_email_html(subcontractor: Subcontractor, raw_token: str, invited_by_
 
 
 def _assignment_email_html(ticket: TMTicket, subcontractor: Subcontractor, assigned_by_name: str) -> str:
-    link = f"{cfg.APP_BASE_URL}/sub/tickets/{ticket.id}"
+    link = _external_link(f"/sub/tickets/{ticket.id}")
     job_bit = f" for job {ticket.job}" if ticket.job else ""
     where_bit = f" ({ticket.location})" if ticket.location else ""
     return (
@@ -107,6 +164,7 @@ class InviteSubcontractorCommand:
     invited_by_name: str
 
     def execute(self) -> Subcontractor:
+        _require_external_link_base()  # fail before the row exists, not after
         sub = Subcontractor(
             company_name=self.company_name,
             contact_name=self.contact_name,
@@ -147,6 +205,7 @@ def resend_invite(subcontractor: Subcontractor, resent_by_email: str, resent_by_
     original-invite audit field; the resend's confirmation just goes to this
     call's requester, not persisted anywhere). Send identity is always
     CARMEN_MAILBOX."""
+    _require_external_link_base()  # fail before the old token is rotated away
     raw_token = _generate_and_store_invite_token(subcontractor)
     subcontractor.invited_at = datetime.utcnow()
     db.session.commit()

--- a/app/brain/tm/subcontractors/routes.py
+++ b/app/brain/tm/subcontractors/routes.py
@@ -55,6 +55,11 @@ def create_subcontractor():
             invited_by_email=user.username,
             invited_by_name=_display_name(user),
         ).execute()
+    except command.OutboundLinkNotConfiguredError as exc:
+        # Misconfiguration, not a mail-server failure — say so, because "email
+        # send failed" sends the admin looking in entirely the wrong place.
+        logger.error("subcontractor_invite_misconfigured", email=email, error=str(exc), exc_info=True)
+        return jsonify({'error': str(exc)}), 500
     except Exception as exc:
         logger.error("subcontractor_invite_failed", email=email, error=str(exc), exc_info=True)
         return jsonify({'error': 'Subcontractor could not be invited (email send failed)'}), 502
@@ -90,6 +95,9 @@ def resend_subcontractor_invite(sub_id):
     user = get_current_user()
     try:
         command.resend_invite(sub, resent_by_email=user.username, resent_by_name=_display_name(user))
+    except command.OutboundLinkNotConfiguredError as exc:
+        logger.error("subcontractor_resend_misconfigured", subcontractor_id=sub_id, error=str(exc), exc_info=True)
+        return jsonify({'error': str(exc)}), 500
     except Exception as exc:
         logger.error("subcontractor_resend_invite_failed", subcontractor_id=sub_id, error=str(exc), exc_info=True)
         return jsonify({'error': 'Resend failed (email send error)'}), 502

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,31 @@ load_dotenv(Path(__file__).resolve().parents[1] / '.env')
 FRONTEND_BUILD_DIR = Path(__file__).parent.parent / "frontend" / "dist"
 
 
+#: The APP_BASE_URL value that means "nobody configured this". Named so the
+#: outbound-link builders can recognise it and refuse to mail it out (BUG-10:
+#: an unset APP_BASE_URL shipped a localhost invite link to a real inbox).
+LOCAL_APP_BASE_URL = "http://localhost:5173"
+
+
+def current_environment():
+    """Return the normalised environment name ('local' / 'sandbox' / 'production' / …).
+
+    Reads the same FLASK_ENV / ENVIRONMENT pair get_config() does, but lowercases
+    whichever one wins rather than only the ENVIRONMENT branch.
+    """
+    return (os.environ.get("FLASK_ENV") or os.environ.get("ENVIRONMENT") or "local").strip().lower()
+
+
+def is_local_environment():
+    """True when the app is running on a developer machine.
+
+    Anything that is not recognisably local is treated as deployed — an
+    unrecognised ENVIRONMENT value must not buy a pass on the checks that only
+    make sense locally (e.g. a localhost link in an outbound email).
+    """
+    return current_environment() in ("local", "development", "dev", "test", "testing")
+
+
 def _carmen_env(suffix, default=None):
     """Read CARMEN_<suffix>, falling back to the legacy BB_<suffix> name.
 
@@ -52,12 +77,15 @@ class Config:
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SAMESITE = 'Lax'
 
-    # Base URL for links embedded in outbound email (e.g. a subcontractor
-    # invite-accept link). Nothing built a frontend link into an email before
-    # this feature — no other code path reads this var. No real prod/test
-    # domain is live yet, so this defaults to the local Vite dev server;
-    # override via .env once a real domain exists.
-    APP_BASE_URL = os.environ.get("APP_BASE_URL", "http://localhost:5173")
+    # Base URL for links embedded in outbound email (the subcontractor
+    # invite-accept link and the T&M ticket-assignment link — both read this
+    # var and nothing else does). Defaults to the local Vite dev server so a
+    # developer checkout works with no .env entry. Deployed environments MUST
+    # set APP_BASE_URL to the real domain: leaving it unset once shipped a
+    # localhost invite link to a client's Gmail (BUG-10). The default is no
+    # longer silent — app/brain/tm/subcontractors/command.py refuses to build a
+    # link against it outside a local environment.
+    APP_BASE_URL = os.environ.get("APP_BASE_URL", LOCAL_APP_BASE_URL)
 
     # Trello configuration
     TRELLO_API_KEY = os.environ.get("TRELLO_API_KEY")

--- a/app/procore/procore.py
+++ b/app/procore/procore.py
@@ -77,7 +77,37 @@ class RelAssignmentError(Exception):
         self.message = message
 
 
-def _globally_taken_rel_numbers(exclude_submittal_id=None):
+def _archived_rel_numbers_for_job(job_number):
+    """Rel numbers already used by ANY release of one job number, archived included.
+
+    BUG-8. The job log's uniqueness constraint is (job, release, job_name) and it
+    counts archived rows — an archived 410-108 permanently blocks a new 410-108
+    on the same project. The DWL generator only ever looked at ACTIVE releases,
+    so archiving a release silently handed its number back, the DWL reissued it,
+    and the job log rejected the release later, at the point where someone had
+    already done the work. Bill diagnosed it himself: "it should have caught that
+    when it got to 108."
+
+    Scoped to one job number on purpose. Reserving every archived number globally
+    and forever would burn the 101..998 range down over a few years, which is why
+    ``_globally_taken_rel_numbers`` excluded the archive in the first place;
+    scoping to the job closes the gap the job log actually enforces and costs
+    nothing, since a single job holds a handful of releases. Long-term identity
+    (and whether to auto-advance rather than block) is AUD2's question, not this
+    fix's.
+
+    Returns an empty set when ``job_number`` is None or isn't a clean integer —
+    a suggestion made with no job in hand simply gets no archive scoping.
+    """
+    job = _to_int_or_none(job_number)
+    if job is None:
+        return set()
+
+    rows = db.session.query(Releases.release).filter(Releases.job == job).all()
+    return {n for n in (_to_int_or_none(value) for (value,) in rows) if n is not None}
+
+
+def _globally_taken_rel_numbers(exclude_submittal_id=None, job_number=None):
     """Rel numbers that are unavailable system-wide, keyed on the value alone.
 
     Uniqueness is locked on the 3-digit Rel value (job-agnostic). A number is
@@ -93,8 +123,13 @@ def _globally_taken_rel_numbers(exclude_submittal_id=None):
     is intentionally not reserved here -- otherwise every historical Closed DRR
     would hold its number forever and exhaust the 101..998 range. Values that
     aren't clean integers are ignored. Returns the set of taken integers.
+
+    ``job_number`` adds a third source: every Rel already used by that job,
+    archived rows included (see ``_archived_rel_numbers_for_job``). Callers that
+    know which job they are numbering for should always pass it -- without it the
+    suggestion can land on a number the job log will refuse (BUG-8).
     """
-    taken = set()
+    taken = set(_archived_rel_numbers_for_job(job_number))
 
     release_rows = (
         db.session.query(Releases.release)
@@ -126,7 +161,7 @@ def _globally_taken_rel_numbers(exclude_submittal_id=None):
     return taken
 
 
-def next_rel_number(exclude_submittal_id=None):
+def next_rel_number(exclude_submittal_id=None, job_number=None):
     """Return the suggested next Rel number (used to prefill the manual popup).
 
     Assignment is "semi-chronological": the sequence climbs to the next highest
@@ -136,17 +171,19 @@ def next_rel_number(exclude_submittal_id=None):
     >= 653 and the next suggestion is 654, never a low/freed number like 101.
     (Nothing above the max is taken, so ``max + 1`` is always free.)
 
-    Freed numbers -- archived releases and never-used gaps below the max -- are
-    NOT reused until the sequence rolls over. Rollover happens only once REL_MAX
-    is occupied: the suggestion then drops to the lowest free value from REL_MIN
-    up, recycling the freed low numbers.
+    Freed numbers -- never-used gaps below the max, and numbers freed by
+    archiving a release on some OTHER job -- are NOT reused until the sequence
+    rolls over. Rollover happens only once REL_MAX is occupied: the suggestion
+    then drops to the lowest free value from REL_MIN up, recycling those freed
+    low numbers. ``job_number``'s own archived Rels are never recycled at all --
+    the job log would reject the release later (BUG-8).
 
     "Taken" is the union in ``_globally_taken_rel_numbers``.
     ``exclude_submittal_id`` lets the submittal being edited ignore its own
     current Rel. Returns REL_MIN when nothing is taken. Raises RuntimeError only
     in the pathological case where every number in [REL_MIN, REL_MAX] is taken.
     """
-    taken = _globally_taken_rel_numbers(exclude_submittal_id)
+    taken = _globally_taken_rel_numbers(exclude_submittal_id, job_number=job_number)
     in_range = [n for n in taken if REL_MIN <= n <= REL_MAX]
     if not in_range:
         return REL_MIN
@@ -185,8 +222,20 @@ def assign_rel_manual(submittal, desired_rel):
         raise RelAssignmentError(
             "range", f"Rel must be a whole number from {REL_MIN} to {REL_MAX}."
         )
-    taken = _globally_taken_rel_numbers(exclude_submittal_id=submittal.submittal_id)
+    taken = _globally_taken_rel_numbers(
+        exclude_submittal_id=submittal.submittal_id,
+        job_number=submittal.project_number,
+    )
     if number in taken:
+        if number in _archived_rel_numbers_for_job(submittal.project_number):
+            # Say which wall they hit — "already assigned to an active release"
+            # is actively misleading when the holder is an archived release the
+            # user cannot see from the DWL.
+            raise RelAssignmentError(
+                "collision",
+                f"Rel {number} was already used on job {submittal.project_number} "
+                f"(the release is archived). The job log will not accept it again.",
+            )
         raise RelAssignmentError(
             "collision",
             f"Rel {number} is already assigned to an active release or pending DRR.",

--- a/app/trello/sync.py
+++ b/app/trello/sync.py
@@ -4,7 +4,7 @@ schema_version: 1
 purpose: Processes inbound Trello webhooks by reconciling card changes (moves, edits, due-date updates) with the DB and creating JobEvents for the audit trail.
 exports:
   sync_from_trello: Main webhook handler that fetches card data, updates the Job record, and emits JobEvents.
-imports_from: [app.trello.api, app.trello.utils, app.trello.operations, app.trello.context, app.trello.logging, app.trello.list_mapper, app.models, app.services.job_event_service, app.config]
+imports_from: [app.trello.api, app.trello.utils, app.trello.operations, app.trello.context, app.trello.logging, app.trello.list_mapper, app.models, app.services.job_event_service, app.brain.job_log.features.fab_order.tier, app.config]
 imported_by: [app/trello/__init__.py]
 invariants:
   - Echo webhooks from Brain's own outbox calls are detected and skipped (90-second window, content-matched).
@@ -44,6 +44,7 @@ from datetime import datetime, date, timezone, time, timedelta
 from zoneinfo import ZoneInfo
 from app.logging_config import get_logger, SyncContext, log_sync_operation
 from app.services.job_event_service import JobEventService
+from app.brain.job_log.features.fab_order.tier import apply_fab_order_for_stage
 import uuid
 import re
 from app.config import Config as cfg
@@ -558,6 +559,10 @@ def sync_from_trello(event_info):
             
             # Capture old stage value before applying list mapping
             old_stage_before_list_move = rec.stage
+            # stage_group is overwritten by the apply below, and the fab_order
+            # re-tier needs the pre-move value (it decides the Fab → Paint
+            # department handoff).
+            old_stage_group_before_list_move = rec.stage_group
 
             # Apply list mapping to database. Returns True only if the rank gate
             # actually advanced rec.stage; False means the inbound was skipped
@@ -598,6 +603,33 @@ def sync_from_trello(event_info):
                     payload={"from": from_stage, "to": stage},
                     external_user_id=trello_user_id,
                 )
+
+                # Re-tier fab_order for the new stage (BUG-9). The inbound sync
+                # is how the shop actually advances work — a card dragged from
+                # the paint list to a shipping list used to keep its tier-2
+                # fab_order forever, because only UpdateStageCommand knew the
+                # tier rules. Applied off rec.stage (what apply_trello_list_to_db
+                # actually set), not the raw Trello list name.
+                fab_plan = apply_fab_order_for_stage(
+                    rec,
+                    rec.stage,
+                    old_stage_group_before_list_move,
+                    source=trello_source,
+                    parent_event_id=event.id if event else None,
+                    stage_reason="trello_list_move",
+                )
+                if fab_plan is not None:
+                    safe_log_sync_event(
+                        sync_op.operation_id,
+                        "INFO",
+                        "Re-tiered fab_order for inbound Trello list move",
+                        job=rec.job,
+                        release=rec.release,
+                        new_stage=rec.stage,
+                        fab_order=fab_plan.fab_order,
+                        reason=fab_plan.reason,
+                    )
+
                 if event:
                     created_events.append(event)
                     safe_log_sync_event(

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -799,12 +799,39 @@ Another job's archived 108 is still fair game. Tests:
 `tests/procore/test_rel_assignment.py` (BUG-8 block) + two route tests in
 `tests/dwl/test_dwl_routes.py`.
 
+**A second caller was found on verification and fixed the same day:**
+`/job-log/release/next-number` — the **Verbal Release form's** prefill, open to
+any logged-in user — shares `next_rel_number` with the DWL popup and was calling
+it unscoped. The paste path already knows the job number, so it now passes it;
+opening the empty modal still can't, and stays unscoped with the submit-time
+guard as the backstop. Worth noting because the entry point named in the fix
+queue ("DWL number request path") was accurate but not exhaustive.
+
+**The two sides do not enforce the same rule, and should not.** Verified and
+pinned in `tests/procore/test_rel_vs_joblog_agreement.py`:
+
+| | rule |
+|---|---|
+| Job log | (job, release, normalized job_name), archived included |
+| DWL | the Rel **value alone** across all active releases (job-agnostic) + pending DRRs + every number **this job** has used, archived included |
+
+The property that matters is containment, not equality: **anything the job log
+would reject, the DWL already refuses.** Two deliberate disagreements survive —
+the DWL is stricter across jobs on active work (pre-existing design), and it
+skips a number an archived row on the same job used even when a *different*
+project name would make the job log accept it. That second one is a conscious
+trade: `Submittals.project_name` and `Releases.job_name` come from different
+sources, so name-matching at suggestion time would miss collisions exactly where
+the data is fuzzy. Being stricter costs a skipped number; being looser costs a
+rejected release after the work is done.
+
 **Unchanged, and still AUD2's:** collision still **blocks and suggests** rather
 than auto-advancing — Bill wants advance [#L173] and that is a client decision,
 not a bug fix. Long-term identity likewise.
 
 **Trail**
 - 2026-08-15 · build · src — — archive-aware generator, scoped to the job number; block-vs-auto-advance deliberately left to AUD2
+- 2026-08-15 · build · src — — verification pass found the Verbal Release prefill (`/job-log/release/next-number`) calling the same generator unscoped; job now passed on the paste path. DWL/job-log containment pinned by cross-check tests, including the two places they deliberately disagree
 
 ### BUG-9 · Fab order clunk at paint → complete
 *W3 · built · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L201 · upd 2026-08-15*
@@ -853,6 +880,14 @@ code say them once. Two behavior changes worth naming:
 - **The DB field is written even when the audit event deduplicates.** The old
   inline code wrote `fab_order` only inside `if event:`, so a dropped event left
   the release on a stale tier — a second, quieter source of the same symptom.
+
+**Verified through the real webhook path, not just the helper**
+(`tests/test_trello_stage_sync.py::TestInboundListMoveRetiersFabOrder` drives
+`sync_from_trello` itself). Re-run against the pre-fix `sync.py`, a paint →
+shipping card move leaves `fab_order` at **2.0** and writes no `update_fab_order`
+event; with the fix it flips to 1 and records the event. The rank gate still
+holds — a backward drag changes neither stage nor fab_order, so the sync never
+half-applies an inbound it rejected.
 
 **One prior decision was overruled, deliberately:** the comment on the job_comp
 percentage path said fab_order was left alone on purpose, and a test asserted it

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,8 +14,8 @@ classes:                      # what KIND of work an item is — orthogonal to e
   deferred: off the active path, with a stated re-check trigger
 queue:                        # agent-maintained, set by agreement in session
   now: T1
-  next: [T2, BUG-9, BUG-10, AUD1]
-  awaiting: [A1, N11]
+  next: [T2, AUD1]             # BUG-8/BUG-9 built 2026-08-15; BUG-10's code half built
+  awaiting: [A1, N11, BUG-10]  # BUG-10 awaits the Render APP_BASE_URL change, and A1 awaits BUG-10
 ---
 
 # MHMW · ROADMAP
@@ -59,11 +59,14 @@ big. They are independent — a fix can be L, a build can be S.
 Small, self-contained, no client sign-off. Entry points included so a session can
 start cold (phone included) without exploring first.
 
+**All three cleared 2026-08-15** (branch `claude/roadmap-review-bugs-uinik2`).
+One of them is not finished by the code alone — see BUG-10's Owed line.
+
 | ID | Fix | Entry point | Pri |
 |---|---|---|---|
-| BUG-9 | Fab order not flipping 2→1 at paint → complete; order cleared inconsistently | `app/brain/job_log/features/fab_order/` (tier logic: Complete=NULL, 1, 2, dynamic 3+) | **high** |
-| BUG-10 | Sub invite email ships a `localhost:5173` link — `APP_BASE_URL` unset | `app/config.py:60`, `app/brain/tm/subcontractors/command.py:52`. Config fix (set in Render), + make the fallback loud outside local | **high — unblocks A1** |
-| BUG-8 | DWL release-number generator doesn't check the archive; job log rejects the number later | DWL number request path; JL guard is already correct | med |
+| BUG-9 | ~~Fab order not flipping 2→1 at paint → complete; order cleared inconsistently~~ **built** | `app/brain/job_log/features/fab_order/tier.py` (tier logic: Complete=NULL, 0, 1, 2, dynamic 3+) | **high** |
+| BUG-10 | Sub invite email ships a `localhost:5173` link — `APP_BASE_URL` unset | `app/config.py:76`, `app/brain/tm/subcontractors/command.py`. Code half **built** (loud fallback); **the Render config change is still owed** | **high — unblocks A1** |
+| BUG-8 | ~~DWL release-number generator doesn't check the archive; job log rejects the number later~~ **built** | `app/procore/procore.py` (`_archived_rel_numbers_for_job`) | med |
 
 **BUG-8 note:** shipping this as a **fix** ahead of its own audit (AUD2) is a
 deliberate call — it makes the generator agree with a rule that is already
@@ -767,30 +770,99 @@ wider distribution.
 - 2026-08-15 · decision · src — — reframed as the Release Modal: one canonical surface, distributed to other pages, refined in place; invoicing is the first target
 
 ### BUG-8 · DWL release-number generator skips the archive
-*W3 · not-started · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L177 · upd 2026-08-15*
+*W3 · built · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L177 · upd 2026-08-15*
 
-Effort S. See the Fix queue and AUD2. Ships **ahead of** its audit deliberately:
+Effort S. See the Fix queue and AUD2. Shipped **ahead of** its audit deliberately:
 it closes a gap against a rule already enforced and already confirmed correct.
 
-### BUG-9 · Fab order clunk at paint → complete
-*W3 · not-started · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L201 · upd 2026-08-15*
+**Built 2026-08-15.** `_globally_taken_rel_numbers` drew its release half from
+`active_releases_filter()`, so archiving a release silently handed its number
+back to the generator — and the job log, whose constraint is
+`(job, release, job_name)` *including archived rows*, rejected it later, after
+someone had done the work. `_archived_rel_numbers_for_job` now adds every Rel
+that job has ever used to the taken set, and both entry points pass the job:
+`next_rel_number(job_number=…)` (resolved in the `/rel/next` route from the
+submittal's `project_number`) and `assign_rel_manual`, which reports the archive
+collision in its own words rather than claiming an active release holds it.
 
-Effort S. *"When we're getting to the paint department and then complete, it's
-not flipping the two and the one… the fab order is being cleared and not
-cleared — there's just some clunkiness to the back end"* [#L201].
+**Scoped to the job on purpose.** Reserving archived numbers *globally* would
+burn the 101–998 range down over a few years — that exhaustion is exactly why
+the archive was excluded originally. Scoping to the job number closes the gap the
+job log actually enforces and costs nothing (a job holds a handful of releases).
+Another job's archived 108 is still fair game. Tests:
+`tests/procore/test_rel_assignment.py` (BUG-8 block) + two route tests in
+`tests/dwl/test_dwl_routes.py`.
+
+**Unchanged, and still AUD2's:** collision still **blocks and suggests** rather
+than auto-advancing — Bill wants advance [#L173] and that is a client decision,
+not a bug fix. Long-term identity likewise.
+
+**Trail**
+- 2026-08-15 · build · src — — archive-aware generator, scoped to the job number; block-vs-auto-advance deliberately left to AUD2
+
+### BUG-9 · Fab order clunk at paint → complete
+*W3 · built · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L201 · upd 2026-08-15*
+
+Effort S (**came in larger than S — it was structural, not a tweak**). *"When
+we're getting to the paint department and then complete, it's not flipping the
+two and the one… the fab order is being cleared and not cleared — there's just
+some clunkiness to the back end"* [#L201].
 
 **Bill twice called it a non-issue; Daniel overrode to high priority — "I want
-this clean." Do not wait on Bill to confirm.** Suspected surface is the unified
-`fab_order` tier logic (Complete = NULL, tier 1, tier 2, dynamic 3+) at the end
-of the fab lifecycle — the same values the FABRICATION renumber tool operates on,
-so tier drift drags renumber and the shop's ordering with it.
+this clean." Do not wait on Bill to confirm.** The override was right: the
+suspicion (tier drift dragging renumber and the shop's ordering with it) was
+correct, and the cause was worse than a tier bug.
+
+**Built 2026-08-15. Root cause: the tier rules were implemented once and skipped
+three times.** They lived inline inside `UpdateStageCommand`, so they only ran
+when a stage change came through that one command. Three other paths write a
+stage, and each answered differently:
+
+1. **The inbound Trello sync** (`TrelloListMapper.apply_trello_list_to_db`) —
+   *how the shop actually moves work* — set stage and `stage_group` and touched
+   `fab_order` not at all. A card dragged out of the paint list kept its tier-2
+   value forever. **That is Bill's "not flipping the two and the one" exactly**,
+   and it explains why it looked intermittent: the same move made in the Brain
+   worked, the same move made in Trello did not.
+2. **`update_job_comp` with a percentage** → `Install Start` (a tier-0 stage) via
+   `update_job_stage_fields`, leaving whatever the paint deck left behind — so a
+   dynamic-band value like 10 sat on a fixed-tier stage and sorted itself in
+   among live fab work.
+3. **`update_job_comp` with `X`** → `Install Complete`, and it *cleared*
+   `fab_order` to NULL — while `UpdateStageCommand` gives that same stage tier 0.
+   **One stage, two answers, chosen by which control the office pressed. That is
+   the "cleared and not cleared."**
+
+`app/brain/job_log/features/fab_order/tier.py` is now the single rule set
+(`plan_fab_order_for_stage` / `apply_fab_order_for_stage`) and all four paths
+call it. The rules themselves were never in dispute — they are stated identically
+in `FIXED_TIER_STAGES` and in `migrate_unified.py`'s invariants; this makes the
+code say them once. Two behavior changes worth naming:
+
+- **Backward moves are repaired.** A release landing on a dynamic stage while
+  holding a reserved value (< 3) or NULL — came back down from shipping, or was
+  reopened after Complete — used to keep it and sort in front of the entire shop.
+  It now goes to the back of that stage's deck (`Released` → the 80.555
+  placeholder, matching `fix_null_fab_orders`).
+- **The DB field is written even when the audit event deduplicates.** The old
+  inline code wrote `fab_order` only inside `if event:`, so a dropped event left
+  the release on a stale tier — a second, quieter source of the same symptom.
+
+**One prior decision was overruled, deliberately:** the comment on the job_comp
+percentage path said fab_order was left alone on purpose, and a test asserted it
+(`test_job_comp_percent_does_not_clear`). It contradicted the invariant written
+down in three places, so the invariant won and the test was rewritten to the
+unified rule. Worth a line to Bill only if Install Start ordering looks odd —
+it should look *more* correct, not less. Tests:
+`tests/brain/test_fab_order_tier.py` (rules, then each write path).
 
 **Trail**
 - 2026-08-15 · transcript · src bill-2026-08-15#L201 — reported and self-deprioritized as "really kind of a non-issue"
 - 2026-08-15 · decision · src — — elevated to high priority by Daniel over Bill's framing
+- 2026-08-15 · build · src — — root cause was scatter, not the tier values: rules extracted to `features/fab_order/tier.py` and applied by the Trello inbound sync and both job_comp paths, which had never applied them; backward tier drift repaired; field write decoupled from event dedup; job_comp-percentage exception overruled in favour of the documented invariant
 
 ### BUG-10 · Sub invite email ships a localhost link
-*W3 · not-started · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L81 · upd 2026-08-15*
+*W3 · in-progress · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L81 · upd 2026-08-15 · owed daniel/set-APP_BASE_URL-in-render*
 
 Effort S — **config, not code.** Bill: *"I did try to do one and I sent it to my
 Gmail, and **the link that it sends is like a broken link. It did not work.**"*
@@ -811,9 +883,30 @@ localhost outside the local environment, so it cannot fail silently twice.
 **Blocks A1** (Bill cannot test T&M without a sub in the system) and gates sub
 enrollment generally.
 
+**Rider built 2026-08-15; the config change is NOT done and cannot be done from
+a session — it is a Render dashboard edit.** The fallback is no longer silent:
+every outbound link now goes through `_external_link` in
+`app/brain/tm/subcontractors/command.py`, which **refuses to send** and logs an
+ERROR when it would build a link against the localhost default outside a local
+environment (`is_local_environment()` in `app/config.py`; anything unrecognised
+counts as deployed, so an odd `ENVIRONMENT` value cannot buy a pass). The invite
+and resend paths check *before* they write, so a misconfigured environment costs
+neither a dead `Subcontractor` row nor a rotated-away token, and the routes
+return a 500 that names the actual problem instead of a 502 blaming the mail
+server. The ticket-assignment link is covered by the same guard; there the send
+is best-effort, so it logs the ERROR and the assignment still stands. Tests:
+`tests/tm/test_outbound_link_config.py`.
+
+> ⚠️ **Still owed: set `APP_BASE_URL` to the Brain's public domain in Render**
+> (per deployed environment). Until that lands, invites now **fail loudly**
+> instead of mailing a dead link — which is the correct failure, but it is still
+> a failure, and **A1 stays blocked**. Re-test by sending Bill an invite and
+> confirming the link opens.
+
 **Trail**
 - 2026-08-15 · transcript · src bill-2026-08-15#L81 — invite link broken on a real send to an external mailbox
 - 2026-08-15 · note · src — — root cause found in code: unset `APP_BASE_URL` → localhost fallback; same var breaks the ticket-assignment link
+- 2026-08-15 · build · src — — rider shipped: outbound links refuse to build against the localhost default outside local, checked before any write; config change in Render still owed, so A1 remains blocked
 
 **The items W3 already carried, unchanged by the 8/15 pass:**
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,8 +14,8 @@ classes:                      # what KIND of work an item is — orthogonal to e
   deferred: off the active path, with a stated re-check trigger
 queue:                        # agent-maintained, set by agreement in session
   now: T1
-  next: [T2, AUD1]             # BUG-8/BUG-9 built 2026-08-15; BUG-10's code half built
-  awaiting: [A1, N11, BUG-10]  # BUG-10 awaits the Render APP_BASE_URL change, and A1 awaits BUG-10
+  next: [T2, A1, AUD1]  # fix queue cleared 2026-08-15; A1 elevated when BUG-10 landed
+  awaiting: [N11]
 ---
 
 # MHMW · ROADMAP
@@ -59,13 +59,13 @@ big. They are independent — a fix can be L, a build can be S.
 Small, self-contained, no client sign-off. Entry points included so a session can
 start cold (phone included) without exploring first.
 
-**All three cleared 2026-08-15** (branch `claude/roadmap-review-bugs-uinik2`).
-One of them is not finished by the code alone — see BUG-10's Owed line.
+**Queue cleared 2026-08-15** (branch `claude/roadmap-review-bugs-uinik2`).
+BUG-10's config half landed the same day and **elevated A1**.
 
 | ID | Fix | Entry point | Pri |
 |---|---|---|---|
 | BUG-9 | ~~Fab order not flipping 2→1 at paint → complete; order cleared inconsistently~~ **built** | `app/brain/job_log/features/fab_order/tier.py` (tier logic: Complete=NULL, 0, 1, 2, dynamic 3+) | **high** |
-| BUG-10 | Sub invite email ships a `localhost:5173` link — `APP_BASE_URL` unset | `app/config.py:76`, `app/brain/tm/subcontractors/command.py`. Code half **built** (loud fallback); **the Render config change is still owed** | **high — unblocks A1** |
+| BUG-10 | ~~Sub invite email ships a `localhost:5173` link — `APP_BASE_URL` unset~~ **built** (code + Render config) | `app/config.py:76`, `app/brain/tm/subcontractors/command.py`. Acceptance test — one real invite to Bill — still to run | **high — unblocked A1** |
 | BUG-8 | ~~DWL release-number generator doesn't check the archive; job log rejects the number later~~ **built** | `app/procore/procore.py` (`_archived_rel_numbers_for_job`) | med |
 
 **BUG-8 note:** shipping this as a **fix** ahead of its own audit (AUD2) is a
@@ -208,12 +208,17 @@ must be doing Trello's job before the plug comes out.
 - 2026-08-15 · decision · src — — end state is dead, not read-only; expedited; teardown waits on T1
 
 ### A1 · T&M package — gated, then elevated
-*W5 · blocked · class build · due — · deps BUG-10 · owner daniel · src bill-2026-08-15#L145 · upd 2026-08-15 · blocked-on BUG-10 since 2026-08-15*
+*W5 · not-started · class build · due — · deps BUG-10 · owner daniel · src bill-2026-08-15#L145 · upd 2026-08-15*
 
-Effort M. **Blocked on the invite link** — Bill cannot evaluate the sub side
-without a sub in the system: *"I still can't get a sub added to it to see how it
-looks on the back end yet"* [#L145]. **Elevates the moment BUG-10 lands**, which
-makes that config fix the pivot for two lanes.
+Effort M. **Unblocked 2026-08-15 — BUG-10 landed and this elevates with it, as
+planned.** It was blocked on the invite link, since Bill cannot evaluate the sub
+side without a sub in the system: *"I still can't get a sub added to it to see how
+it looks on the back end yet"* [#L145]. `APP_BASE_URL` is now set in Render to the
+service's public URL, so invites build a reachable link.
+
+**One step stands between "unblocked" and "confirmed":** nobody has yet watched a
+real invite arrive and open. Send Bill one before treating sub enrollment as
+working — that is also the acceptance test for BUG-10.
 
 **Delivery constraint, stated deliberately:** one package, not piecemeal —
 *"there's definitely some things that we saw in the initial run through that we
@@ -227,6 +232,7 @@ overall concept is right there… excited about being able to track that well."*
 - 2026-08-15 · transcript · src bill-2026-08-15#L145 — blocked on sub enrollment; deliver as one package, not piecemeal
 - 2026-08-15 · note · src bill-2026-08-15#L155 — Bill's original change notes lost; reproduction promised, treat as unlikely near-term
 - 2026-08-15 · decision · src — — gated on BUG-10, elevates on landing
+- 2026-08-15 · note · src — — unblocked: `APP_BASE_URL` set in Render; first real invite send is still the confirmation
 
 ---
 
@@ -862,7 +868,7 @@ it should look *more* correct, not less. Tests:
 - 2026-08-15 · build · src — — root cause was scatter, not the tier values: rules extracted to `features/fab_order/tier.py` and applied by the Trello inbound sync and both job_comp paths, which had never applied them; backward tier drift repaired; field write decoupled from event dedup; job_comp-percentage exception overruled in favour of the documented invariant
 
 ### BUG-10 · Sub invite email ships a localhost link
-*W3 · in-progress · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L81 · upd 2026-08-15 · owed daniel/set-APP_BASE_URL-in-render*
+*W3 · built · class fix · due — · deps — · owner daniel · src bill-2026-08-15#L81 · upd 2026-08-15*
 
 Effort S — **config, not code.** Bill: *"I did try to do one and I sent it to my
 Gmail, and **the link that it sends is like a broken link. It did not work.**"*
@@ -883,8 +889,14 @@ localhost outside the local environment, so it cannot fail silently twice.
 **Blocks A1** (Bill cannot test T&M without a sub in the system) and gates sub
 enrollment generally.
 
-**Rider built 2026-08-15; the config change is NOT done and cannot be done from
-a session — it is a Render dashboard edit.** The fallback is no longer silent:
+**Both halves done 2026-08-15.** The config change landed:
+`APP_BASE_URL=https://mile-high-metal-works-trello-onedrive.onrender.com` is set
+in Render, so invites now build
+`…onrender.com/sub/accept-invite/<token>` — verified against the link builder,
+and the Flask catch-all serves that React route (`App.jsx:91`,
+`app/__init__.py:697`), so the deep link resolves on a cold open.
+
+The rider is what keeps it fixed. The fallback is no longer silent:
 every outbound link now goes through `_external_link` in
 `app/brain/tm/subcontractors/command.py`, which **refuses to send** and logs an
 ERROR when it would build a link against the localhost default outside a local
@@ -897,16 +909,20 @@ server. The ticket-assignment link is covered by the same guard; there the send
 is best-effort, so it logs the ERROR and the assignment still stands. Tests:
 `tests/tm/test_outbound_link_config.py`.
 
-> ⚠️ **Still owed: set `APP_BASE_URL` to the Brain's public domain in Render**
-> (per deployed environment). Until that lands, invites now **fail loudly**
-> instead of mailing a dead link — which is the correct failure, but it is still
-> a failure, and **A1 stays blocked**. Re-test by sending Bill an invite and
-> confirming the link opens.
+**Acceptance test not yet run:** nobody has watched a real invite land and open.
+Send Bill one — that closes both this and A1's confirmation step. **Two riders
+worth carrying:** the guard only fires when `ENVIRONMENT` (or `FLASK_ENV`) is set
+to something non-local on the deployed service, so if that variable is ever unset
+in a new environment the localhost default goes quiet again; and the current value
+is the `onrender.com` host — **when a custom domain arrives, this variable moves
+with it**, since the link lands on a subcontractor's phone and outlives the
+sending session.
 
 **Trail**
 - 2026-08-15 · transcript · src bill-2026-08-15#L81 — invite link broken on a real send to an external mailbox
 - 2026-08-15 · note · src — — root cause found in code: unset `APP_BASE_URL` → localhost fallback; same var breaks the ticket-assignment link
-- 2026-08-15 · build · src — — rider shipped: outbound links refuse to build against the localhost default outside local, checked before any write; config change in Render still owed, so A1 remains blocked
+- 2026-08-15 · build · src — — rider shipped: outbound links refuse to build against the localhost default outside local, checked before any write
+- 2026-08-15 · build · src — — `APP_BASE_URL` set in Render to the service's public onrender.com URL; A1 unblocked; first real invite send is still the acceptance test, and the variable moves with any future custom domain
 
 **The items W3 already carried, unchanged by the 8/15 pass:**
 

--- a/frontend/src/pages/ReleasesLayout.jsx
+++ b/frontend/src/pages/ReleasesLayout.jsx
@@ -633,7 +633,10 @@ function ReleasesLayout() {
         if (!fields.release) {
             setVerbalFetchingNumber(true);
             try {
-                const nextRelease = await jobsApi.getNextReleaseNumber();
+                // The pasted row carries the job #, so the suggestion can skip
+                // numbers that job already burned (archived rows included) —
+                // otherwise the submit guard rejects a number we just handed out.
+                const nextRelease = await jobsApi.getNextReleaseNumber(fields.job);
                 setVerbalForm(prev => ({ ...prev, release: nextRelease || '' }));
             } catch (error) {
                 setVerbalError(error.message || 'Could not fetch the next release number — enter one manually.');

--- a/frontend/src/services/jobsApi.js
+++ b/frontend/src/services/jobsApi.js
@@ -353,9 +353,20 @@ class JobsApi {
         }
     }
 
-    async getNextReleaseNumber() {
+    /**
+     * Fetch the suggested next release number for the Verbal Release form.
+     * @param {string|number} [job] - job #, when known. Scopes the suggestion
+     *   past numbers that job already used (archived releases included), which
+     *   the submit-time collision guard would otherwise reject.
+     */
+    async getNextReleaseNumber(job) {
         try {
-            const response = await axios.get(`${API_BASE_URL}/brain/job-log/release/next-number`);
+            const params = (job !== undefined && job !== null && `${job}`.trim() !== '')
+                ? { job }
+                : {};
+            const response = await axios.get(
+                `${API_BASE_URL}/brain/job-log/release/next-number`, { params }
+            );
             return response.data.next_release;
         } catch (error) {
             throw this._handleError(error, 'Failed to fetch next release number');

--- a/tests/brain/test_fab_order_tier.py
+++ b/tests/brain/test_fab_order_tier.py
@@ -1,0 +1,232 @@
+"""BUG-9: one fab_order tier rule set, applied by every path that writes a stage.
+
+Bill's report was two symptoms of one cause: "when we're getting to the paint
+department and then complete, it's not flipping the two and the one… the fab
+order is being cleared and not cleared." The tier rules only ever ran inside
+UpdateStageCommand, so the Trello inbound sync (how the shop actually moves
+work) never re-tiered at all, and the job_comp route answered the same question
+differently.
+
+These tests pin the rules themselves, then each write path against them.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.api.helpers import DEFAULT_FAB_ORDER
+from app.brain.job_log.features.fab_order.tier import (
+    RESERVED_TIER_CEILING,
+    plan_fab_order_for_stage,
+)
+from app.models import ReleaseEvents, Releases, db
+from tests.conftest import make_release as _make_release
+
+
+@pytest.fixture(autouse=True)
+def setup_auth(admin_session):
+    yield
+
+
+def _stage_command_patches():
+    return (
+        patch("app.services.outbox_service.OutboxService.add"),
+        patch("app.brain.job_log.scheduling.service.recalculate_all_jobs_scheduling"),
+        patch("app.brain.job_log.routes.get_list_id_by_stage", return_value="list-1"),
+    )
+
+
+def _run_stage(job, release, stage):
+    from app.brain.job_log.features.stage.command import UpdateStageCommand
+
+    a, b, c = _stage_command_patches()
+    with a, b, c:
+        return UpdateStageCommand(job_id=job, release=release, stage=stage).execute()
+
+
+# ---------------------------------------------------------------------------
+# The rules, independent of who applies them
+# ---------------------------------------------------------------------------
+
+class TestPlan:
+    @pytest.mark.parametrize("stage,expected", [
+        ("Install Start", 0),
+        ("Install Complete", 0),
+        ("Ship Complete", 1),
+        ("Paint Complete", 2),
+        ("Store at MHMW", 2),
+        ("Ship Planning", 2),
+    ])
+    def test_fixed_tier_stages_take_their_tier(self, app, stage, expected):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Weld Complete", fab_order=42)
+            plan = plan_fab_order_for_stage(r, stage)
+            assert plan is not None and plan.fab_order == expected
+
+    def test_paint_complete_to_ship_complete_flips_two_to_one(self, app):
+        """The literal report: 2 → 1 at the paint → ship handoff."""
+        with app.app_context():
+            r = _make_release(1, "A", stage="Paint Complete", stage_group="READY_TO_SHIP", fab_order=2)
+            plan = plan_fab_order_for_stage(r, "Ship Complete", "READY_TO_SHIP")
+            assert plan is not None and plan.fab_order == 1
+
+    def test_complete_is_terminal(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Ship Complete", fab_order=1)
+            plan = plan_fab_order_for_stage(r, "Complete")
+            assert plan is not None and plan.fab_order is None
+
+    def test_already_correct_is_a_no_op(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Ship Complete", fab_order=1)
+            assert plan_fab_order_for_stage(r, "Ship Complete") is None
+
+    def test_hold_keeps_its_position(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Weld Start", fab_order=7)
+            assert plan_fab_order_for_stage(r, "Hold") is None
+
+    def test_valid_dynamic_position_is_left_to_the_user(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Cut Start", fab_order=12)
+            assert plan_fab_order_for_stage(r, "Cut Complete") is None
+
+    def test_dynamic_stage_never_keeps_a_reserved_tier_value(self, app):
+        """Coming back down from shipping used to leave a 1 on a fab row, which
+        sorts it in front of the entire shop."""
+        with app.app_context():
+            _make_release(2, "B", stage="Weld Complete", fab_order=11)
+            r = _make_release(1, "A", stage="Ship Complete", fab_order=1)
+            db.session.flush()
+
+            plan = plan_fab_order_for_stage(r, "Weld Complete", "COMPLETE")
+            assert plan is not None
+            assert plan.fab_order >= RESERVED_TIER_CEILING
+            assert plan.fab_order == 12  # back of the Weld Complete deck
+
+    def test_reopened_from_complete_gets_a_position_back(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Complete", stage_group="COMPLETE", fab_order=None)
+            plan = plan_fab_order_for_stage(r, "Weld Start", "COMPLETE")
+            assert plan is not None and plan.fab_order >= RESERVED_TIER_CEILING
+
+    def test_released_repairs_to_the_placeholder(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Ship Complete", fab_order=1)
+            plan = plan_fab_order_for_stage(r, "Released", "COMPLETE")
+            assert plan is not None and plan.fab_order == DEFAULT_FAB_ORDER
+
+    def test_paint_handoff_lands_at_the_back_of_the_booth(self, app):
+        with app.app_context():
+            _make_release(2, "B", stage="Paint Start", stage_group="READY_TO_SHIP", fab_order=9)
+            r = _make_release(1, "A", stage="Weld Complete", fab_order=20)
+            db.session.flush()
+
+            plan = plan_fab_order_for_stage(r, "Welded QC", "FABRICATION")
+            assert plan is not None and plan.fab_order == 10
+
+    def test_placeholder_rows_do_not_define_the_back_of_the_deck(self, app):
+        with app.app_context():
+            _make_release(2, "B", stage="Paint Start", stage_group="READY_TO_SHIP",
+                          fab_order=DEFAULT_FAB_ORDER)
+            r = _make_release(1, "A", stage="Weld Complete", fab_order=20)
+            db.session.flush()
+
+            plan = plan_fab_order_for_stage(r, "Welded QC", "FABRICATION")
+            assert plan is not None and plan.fab_order == 3
+
+    def test_unknown_stage_is_left_alone(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Cut Start", fab_order=5)
+            assert plan_fab_order_for_stage(r, "Wat") is None
+
+
+# ---------------------------------------------------------------------------
+# Every write path agrees
+# ---------------------------------------------------------------------------
+
+class TestWritePathsAgree:
+    def test_stage_command_applies_the_tier(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Paint Complete", stage_group="READY_TO_SHIP", fab_order=2)
+            db.session.commit()
+
+            result = _run_stage(1, "A", "Ship Complete")
+
+            db.session.refresh(r)
+            assert r.fab_order == 1
+            assert result.extras.get("fab_order") == 1
+
+            child = ReleaseEvents.query.filter_by(action="update_fab_order").first()
+            assert child is not None
+            assert child.payload["from"] == 2 and child.payload["to"] == 1
+            assert child.payload["parent_event_id"] is not None
+
+    def test_stage_command_clears_at_complete(self, app):
+        with app.app_context():
+            r = _make_release(1, "A", stage="Ship Complete", stage_group="COMPLETE", fab_order=1)
+            db.session.commit()
+
+            _run_stage(1, "A", "Complete")
+
+            db.session.refresh(r)
+            assert r.fab_order is None
+
+    def test_job_comp_x_and_stage_command_reach_the_same_state(self, app, admin_client):
+        """The 'cleared and not cleared' half: the same end stage, reached two
+        ways, used to leave fab_order NULL one way and tier 0 the other."""
+        with app.app_context():
+            via_route = _make_release(1, "A", stage="Paint Complete",
+                                      stage_group="READY_TO_SHIP", fab_order=2)
+            via_command = _make_release(2, "B", stage="Paint Complete",
+                                        stage_group="READY_TO_SHIP", fab_order=2)
+            db.session.commit()
+
+            resp = admin_client.patch("/brain/update-job-comp/1/A", json={"job_comp": "X"})
+            assert resp.status_code == 200
+            _run_stage(2, "B", "Install Complete")
+
+            db.session.expire_all()
+            a = Releases.query.filter_by(job=1, release="A").first()
+            b = Releases.query.filter_by(job=2, release="B").first()
+            assert a.stage == b.stage == "Install Complete"
+            assert a.fab_order == b.fab_order == 0
+
+    def test_trello_list_move_re_tiers(self, app):
+        """The shop's actual path. A card dragged out of the paint list used to
+        advance the stage and leave fab_order sitting on 2."""
+        with app.app_context():
+            from app.trello.list_mapper import TrelloListMapper
+            from app.brain.job_log.features.fab_order.tier import apply_fab_order_for_stage
+
+            r = _make_release(1, "A", stage="Paint Complete", stage_group="READY_TO_SHIP",
+                              fab_order=2, trello_card_id="card-1")
+            db.session.commit()
+
+            old_stage_group = r.stage_group
+            applied = TrelloListMapper.apply_trello_list_to_db(r, "Shipping completed", "op-1")
+            assert applied is True
+
+            plan = apply_fab_order_for_stage(
+                r, r.stage, old_stage_group, source="Trello", stage_reason="trello_list_move",
+            )
+            db.session.commit()
+
+            assert plan is not None
+            assert r.fab_order == 1  # tier for the Ship Complete zone
+            child = ReleaseEvents.query.filter_by(action="update_fab_order").first()
+            assert child is not None and child.payload["to"] == 1
+
+    def test_field_is_written_even_when_the_event_deduplicates(self, app):
+        """A dropped audit event must never leave fab_order stale — the old
+        inline code wrote the field only inside `if event:`."""
+        with app.app_context():
+            from app.brain.job_log.features.fab_order import tier
+
+            r = _make_release(1, "A", stage="Paint Complete", stage_group="READY_TO_SHIP", fab_order=2)
+            db.session.commit()
+
+            with patch.object(tier.JobEventService, "create", return_value=None):
+                plan = tier.apply_fab_order_for_stage(r, "Ship Complete", "READY_TO_SHIP")
+
+            assert plan is not None and plan.fab_order == 1
+            assert r.fab_order == 1

--- a/tests/brain/test_red_date_auto_clear.py
+++ b/tests/brain/test_red_date_auto_clear.py
@@ -323,7 +323,7 @@ class TestJobCompCascade:
             # (consistent with: "only clear when the user marks it complete now").
             assert r2.start_install_formulaTF is False
 
-    def test_job_comp_percent_does_not_clear(self, app, admin_client):
+    def test_job_comp_percent_does_not_clear_the_date_but_does_re_tier(self, app, admin_client):
         with app.app_context():
             r = _make_release(
                 1, "A",
@@ -342,7 +342,11 @@ class TestJobCompCascade:
             r2 = Releases.query.filter_by(job=1, release="A").first()
             assert r2.start_install_formulaTF is False  # not cleared
             assert r2.stage == "Install Start"  # a percentage means install has begun
-            assert r2.fab_order == 10  # fab_order untouched on percentage
+            # BUG-9: this route used to leave fab_order alone, so a release could
+            # sit on a fixed-tier stage holding a dynamic-band value (10) and sort
+            # itself in among live fab work. Install Start is tier 0 no matter
+            # which control put it there — same rule UpdateStageCommand applies.
+            assert r2.fab_order == 0
 
     def test_job_comp_non_numeric_leaves_stage_unchanged(self, app, admin_client):
         with app.app_context():

--- a/tests/dwl/test_dwl_routes.py
+++ b/tests/dwl/test_dwl_routes.py
@@ -753,3 +753,36 @@ class TestGetNextRel:
         assert json.loads(with_self.data)['next_rel'] == 251
         without = client.get('/brain/drafting-work-load/rel/next')
         assert json.loads(without.data)['next_rel'] == 301
+
+
+class TestNextRelRoute:
+    """BUG-8: /rel/next resolves the submittal's job so the suggestion can skip
+    Rels that job already burned on archived releases the DWL cannot see."""
+
+    def _seed(self):
+        from datetime import datetime
+        from app.models import Releases, Submittals, db
+
+        db.session.add(Releases(job=410, release="107", job_name="Columbine Square"))
+        db.session.add(Releases(job=410, release="108", job_name="Columbine Square",
+                                is_archived=True))
+        db.session.add(Submittals(
+            submittal_id="dwl-bug8", procore_project_id="1", project_number="410",
+            type="Drafting Release Review", status="Open", created_at=datetime.utcnow(),
+        ))
+        db.session.commit()
+
+    def test_suggestion_skips_the_jobs_archived_number(self, app, client):
+        with app.app_context():
+            self._seed()
+            resp = client.get('/brain/drafting-work-load/rel/next',
+                              query_string={'submittal_id': 'dwl-bug8'})
+            assert resp.status_code == 200
+            assert resp.get_json()['next_rel'] == 109
+
+    def test_without_a_submittal_the_suggestion_is_unscoped(self, app, client):
+        with app.app_context():
+            self._seed()
+            resp = client.get('/brain/drafting-work-load/rel/next')
+            assert resp.status_code == 200
+            assert resp.get_json()['next_rel'] == 108

--- a/tests/procore/test_rel_assignment.py
+++ b/tests/procore/test_rel_assignment.py
@@ -21,6 +21,7 @@ from app.procore.procore import (
     REL_MIN,
     REL_MAX,
     next_rel_number,
+    _archived_rel_numbers_for_job,
     assign_rel_manual,
     RelAssignmentError,
     create_submittal_from_webhook,
@@ -326,3 +327,84 @@ def test_create_webhook_does_not_assign_rel_for_non_drr(app):
         assert created is True
         assert record.rel is None
         assert record.rel_assigned_at is None
+
+
+# --- BUG-8: the generator must see the archive for its own job ---------------------
+# The job log's uniqueness constraint is (job, release, job_name) and counts
+# ARCHIVED rows, so an archived 410-108 blocks a new 410-108 forever. The
+# generator only looked at active releases, so it reissued the number and the
+# job log rejected the release later. Scoped to the job: another job's archived
+# 108 is still fair game, or the 101..998 range would burn down over time.
+
+def test_suggestion_skips_a_number_this_job_already_burned(app):
+    with app.app_context():
+        # Bill's case: archived 410-108 (the Columbine Square twin). Active work
+        # has climbed to 107, so the old code suggested 108 -- "it should have
+        # caught that when it got to 108."
+        db.session.add(_make_release(410, 107))
+        db.session.add(_make_release(410, 108, is_archived=True))
+        db.session.commit()
+
+        assert next_rel_number(job_number=410) == 109
+        # Unscoped (no job in hand) keeps the old, job-agnostic answer.
+        assert next_rel_number() == 108
+
+
+def test_suggestion_ignores_another_jobs_archive(app):
+    with app.app_context():
+        db.session.add(_make_release(410, 107))
+        db.session.add(_make_release(500, 108, is_archived=True))
+        db.session.commit()
+        # 500's archived 108 does not constrain job 410 -- the constraint
+        # includes the job number, so reserving it globally would be a
+        # self-inflicted exhaustion of the range.
+        assert next_rel_number(job_number=410) == 108
+
+
+def test_rollover_does_not_recycle_this_jobs_archived_number(app):
+    with app.app_context():
+        db.session.add(_make_release(998, REL_MAX))                    # forces rollover
+        db.session.add(_make_release(410, REL_MIN, is_archived=True))  # burned on 410
+        db.session.commit()
+        assert next_rel_number(job_number=410) == REL_MIN + 1
+        assert next_rel_number(job_number=500) == REL_MIN  # free for a different job
+
+
+def test_inactive_release_on_the_same_job_also_blocks(app):
+    with app.app_context():
+        # is_active=False is invisible to active_releases_filter too, and the
+        # unique constraint does not care about the flag either.
+        db.session.add(_make_release(410, 300, is_active=False))
+        db.session.commit()
+        assert 300 in _archived_rel_numbers_for_job(410)
+
+
+def test_assign_manual_rejects_a_number_archived_on_the_same_job(app):
+    with app.app_context():
+        db.session.add(_make_release(410, 108, is_archived=True))
+        drr = _make_submittal("bug8a", DRR_TYPE, status="Open", project_number="410")
+        db.session.add(drr)
+        db.session.commit()
+
+        with pytest.raises(RelAssignmentError) as exc:
+            assign_rel_manual(drr, 108)
+        assert exc.value.code == "collision"
+        assert "archived" in exc.value.message  # tells them which wall they hit
+        assert drr.rel is None
+
+
+def test_assign_manual_allows_a_number_archived_on_another_job(app):
+    with app.app_context():
+        db.session.add(_make_release(500, 108, is_archived=True))
+        drr = _make_submittal("bug8b", DRR_TYPE, status="Open", project_number="410")
+        db.session.add(drr)
+        db.session.commit()
+        assert assign_rel_manual(drr, 108) == 108
+
+
+def test_unknown_job_number_scopes_nothing(app):
+    with app.app_context():
+        db.session.add(_make_release(410, 108, is_archived=True))
+        db.session.commit()
+        assert _archived_rel_numbers_for_job(None) == set()
+        assert _archived_rel_numbers_for_job("not-a-number") == set()

--- a/tests/procore/test_rel_vs_joblog_agreement.py
+++ b/tests/procore/test_rel_vs_joblog_agreement.py
@@ -1,0 +1,160 @@
+"""BUG-8 cross-check: the DWL generator must never hand out a number the job
+log will refuse.
+
+The two sides do NOT enforce the same rule, and are not meant to:
+
+  job log  — hard uniqueness on (job, release, normalized job_name), archived
+             rows included (`_find_job_release_name_collision`, backed by the
+             `uq_releases_job_release_name` constraint). Job numbers wrap, so
+             archived 410-108 Columbine may not block a new 410-108 Alta Metro.
+  DWL      — a Rel is unique on the VALUE alone across all active releases
+             (job-agnostic, deliberately stricter), plus pending DRRs, plus —
+             since BUG-8 — every number the submittal's own job has used,
+             archived included.
+
+So the property that matters is not equality, it is containment: **anything the
+job log would reject, the DWL must already refuse.** That is the direction that
+was broken — the DWL issued 108, the job log rejected it later, after the work
+was done. These tests pin the containment in both directions, including the
+cases where the two deliberately disagree.
+"""
+import pytest
+
+from app.brain.job_log.routes import _find_job_release_name_collision
+from app.models import Releases, Submittals, db
+from app.procore.procore import (
+    DRR_TYPE,
+    RelAssignmentError,
+    assign_rel_manual,
+    next_rel_number,
+)
+
+
+def _release(job, release, job_name="Columbine Square", **kw):
+    r = Releases(job=job, release=str(release), job_name=job_name, **kw)
+    db.session.add(r)
+    return r
+
+
+def _drr(sid, project_number, project_name="Columbine Square"):
+    s = Submittals(
+        submittal_id=sid, procore_project_id="1",
+        project_number=str(project_number), project_name=project_name,
+        type=DRR_TYPE, status="Open",
+    )
+    db.session.add(s)
+    return s
+
+
+def _job_log_would_reject(job, release, job_name):
+    return _find_job_release_name_collision(job, release, job_name) is not None
+
+
+def _dwl_would_refuse(submittal, number):
+    try:
+        assign_rel_manual(submittal, number)
+        return False
+    except RelAssignmentError:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Containment: job log rejects => DWL already refused
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("archived", [False, True], ids=["active", "archived"])
+def test_anything_the_job_log_rejects_the_dwl_refuses(app, archived):
+    with app.app_context():
+        _release(410, 108, "Columbine Square", is_archived=archived)
+        drr = _drr("agree-1", 410, "Columbine Square")
+        db.session.commit()
+
+        # Same job, same release, same project name -> the job log's hard key.
+        assert _job_log_would_reject(410, "108", "Columbine Square") is True
+        assert _dwl_would_refuse(drr, 108) is True
+
+
+def test_the_archived_case_is_the_one_that_used_to_slip(app):
+    """Pre-BUG-8 the DWL saw only ACTIVE releases, so this pair disagreed: the
+    job log rejected 108 and the DWL had happily suggested it."""
+    with app.app_context():
+        _release(410, 107, "Columbine Square")                     # active high-water
+        _release(410, 108, "Columbine Square", is_archived=True)   # invisible pre-fix
+        _drr("agree-2", 410, "Columbine Square")
+        db.session.commit()
+
+        assert _job_log_would_reject(410, "108", "Columbine Square") is True
+        # The generator now climbs past it instead of handing it out.
+        assert next_rel_number(job_number=410) == 109
+
+
+# ---------------------------------------------------------------------------
+# Where they deliberately differ — documented, not accidental
+# ---------------------------------------------------------------------------
+
+def test_dwl_is_stricter_on_a_different_project_reusing_the_job_number(app):
+    """The job log ALLOWS archived 410-108 Columbine alongside a new 410-108
+    Alta Metro (different project name). The DWL still skips 108 for job 410,
+    because it scopes to the job number and ignores the name.
+
+    That asymmetry is intentional: `Submittals.project_name` and
+    `Releases.job_name` are populated from different sources, so name-matching
+    at suggestion time would miss collisions exactly where the data is fuzzy.
+    Being stricter costs a skipped number; being looser costs a rejected
+    release after the work is done.
+    """
+    with app.app_context():
+        _release(410, 108, "Columbine Square", is_archived=True)
+        drr = _drr("agree-3", 410, "Alta Metro")
+        db.session.commit()
+
+        assert _job_log_would_reject(410, "108", "Alta Metro") is False  # JL allows
+        assert _dwl_would_refuse(drr, 108) is True                       # DWL still skips
+        # Containment still holds — stricter is the safe direction.
+
+
+def test_dwl_is_stricter_across_jobs_on_active_work(app):
+    """Pre-existing design, unchanged by BUG-8: a Rel in use by an ACTIVE
+    release on ANY job blocks it everywhere, while the job log only cares about
+    the same job + project."""
+    with app.app_context():
+        _release(500, 108, "Novel Flatirons")       # active, different job
+        drr = _drr("agree-4", 410, "Columbine Square")
+        db.session.commit()
+
+        assert _job_log_would_reject(410, "108", "Columbine Square") is False
+        assert _dwl_would_refuse(drr, 108) is True
+
+
+def test_another_jobs_archive_does_not_leak_into_this_job(app):
+    """The one direction that must stay loose, or the 101-998 range burns down:
+    job 500's archived 108 has nothing to do with job 410."""
+    with app.app_context():
+        _release(500, 108, "Novel Flatirons", is_archived=True)
+        drr = _drr("agree-5", 410, "Columbine Square")
+        db.session.commit()
+
+        assert _job_log_would_reject(410, "108", "Columbine Square") is False
+        assert _dwl_would_refuse(drr, 108) is False  # allowed on both sides
+
+
+# ---------------------------------------------------------------------------
+# The job log's own suggester goes through the same generator
+# ---------------------------------------------------------------------------
+
+def test_verbal_release_suggestion_is_job_scoped_too(app, client, admin_session):
+    """/job-log/release/next-number shares next_rel_number with the DWL popup.
+    It was calling it unscoped, so the verbal form could prefill a number the
+    submit guard on the very next click would reject."""
+    with app.app_context():
+        _release(410, 107, "Columbine Square")
+        _release(410, 108, "Columbine Square", is_archived=True)
+        db.session.commit()
+
+        scoped = client.get('/brain/job-log/release/next-number', query_string={'job': 410})
+        assert scoped.status_code == 200
+        assert scoped.get_json()['next_release'] == '109'
+
+        # No job known yet (empty modal) -> unscoped, submit guard is the backstop.
+        unscoped = client.get('/brain/job-log/release/next-number')
+        assert unscoped.get_json()['next_release'] == '108'

--- a/tests/test_trello_stage_sync.py
+++ b/tests/test_trello_stage_sync.py
@@ -10,6 +10,8 @@ Two layers:
   has been replaced with target-list-differs, and that Hold transitions skip
   the outbox entirely.
 """
+from datetime import datetime, timedelta
+
 import pytest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -329,3 +331,91 @@ class TestUpdateStageCommandOutbound:
                 cmd.execute()
 
             assert m_add.called, "DB stage 'Store at MHMW' must push to its canonical Trello list"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the real inbound webhook path re-tiers fab_order (BUG-9)
+# ---------------------------------------------------------------------------
+
+class TestInboundListMoveRetiersFabOrder:
+    """Drives sync_from_trello itself, not the helper it calls.
+
+    This is the path the shop actually uses — a card dragged between lists on
+    the board. Before BUG-9 it advanced `stage` and left `fab_order` untouched,
+    so a release leaving the paint list kept tier 2 forever while the same move
+    made in the Brain flipped it to 1. That split is why it read as
+    "clunkiness" rather than a clean reproducible bug.
+    """
+
+    def _drive(self, app, to_list, from_list):
+        from app.models import Releases
+        from app.trello.sync import sync_from_trello
+
+        event_time = datetime.utcnow() + timedelta(hours=1)  # must beat last_updated_at
+        card = {"id": "card-1", "name": "500-101", "desc": "", "idList": "list-after", "due": None}
+        event_info = {
+            "handled": True,
+            "card_id": "card-1",
+            "time": event_time.isoformat() + "Z",
+            "event": "card_updated",
+            "change_types": ["list_change"],
+            "has_list_move": True,
+            "from": from_list,
+            "list_id_before": "list-before",
+            "list_id_after": "list-after",
+            "trello_user_id": None,
+        }
+
+        with patch("app.trello.sync.get_trello_card_by_id", return_value=card), \
+             patch("app.trello.sync.get_list_name_by_id", return_value=to_list), \
+             patch("app.trello.sync._is_brain_echo_webhook", return_value=False), \
+             patch("app.trello.sync.update_trello_card_description"), \
+             patch("app.brain.job_log.scheduling.service.recalculate_all_jobs_scheduling"):
+            sync_from_trello(event_info)
+
+        db.session.expire_all()
+        return Releases.query.filter_by(trello_card_id="card-1").first()
+
+    def test_paint_list_to_shipping_flips_two_to_one(self, app):
+        """Bill's exact report: 'it's not flipping the two and the one'."""
+        with app.app_context():
+            make_release(500, "101", "Paint Complete", "READY_TO_SHIP", 2,
+                         trello_card_id="card-1", trello_list_name="Paint complete",
+                         last_updated_at=datetime.utcnow())
+            db.session.commit()
+
+            rec = self._drive(app, to_list="Shipping completed", from_list="Paint complete")
+
+            assert rec.stage == "Ship Complete"   # the move landed
+            assert rec.fab_order == 1             # ...and the tier came with it
+
+    def test_the_move_also_records_the_fab_order_event(self, app):
+        with app.app_context():
+            from app.models import ReleaseEvents
+
+            make_release(500, "101", "Paint Complete", "READY_TO_SHIP", 2,
+                         trello_card_id="card-1", trello_list_name="Paint complete",
+                         last_updated_at=datetime.utcnow())
+            db.session.commit()
+
+            self._drive(app, to_list="Shipping completed", from_list="Paint complete")
+
+            fab_events = ReleaseEvents.query.filter_by(action="update_fab_order").all()
+            assert len(fab_events) == 1
+            assert fab_events[0].source == "Trello"
+            assert fab_events[0].payload["from"] == 2
+            assert fab_events[0].payload["to"] == 1
+
+    def test_rank_gated_move_leaves_fab_order_alone(self, app):
+        """A backward drag is refused by the rank gate; fab_order must not move
+        either, or the sync would half-apply an inbound it explicitly rejected."""
+        with app.app_context():
+            make_release(500, "101", "Ship Complete", "COMPLETE", 1,
+                         trello_card_id="card-1", trello_list_name="Shipping completed",
+                         last_updated_at=datetime.utcnow())
+            db.session.commit()
+
+            rec = self._drive(app, to_list="Paint complete", from_list="Shipping completed")
+
+            assert rec.stage == "Ship Complete"  # gate held
+            assert rec.fab_order == 1            # untouched

--- a/tests/tm/test_outbound_link_config.py
+++ b/tests/tm/test_outbound_link_config.py
@@ -1,0 +1,92 @@
+"""BUG-10: an unset APP_BASE_URL must never reach a recipient's inbox.
+
+The invite link is built as `{APP_BASE_URL}/sub/accept-invite/{token}` and
+APP_BASE_URL falls back to the local Vite dev server. On a deployed
+environment that fallback produced a real email carrying a localhost link,
+with no error anywhere — the only symptom was the client reporting "the link
+doesn't work". These tests pin the two halves of the fix: the fallback is
+still fine locally, and it is fatal (before any state is written) once the
+environment is anything else.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.brain.tm.subcontractors import command
+from app.config import LOCAL_APP_BASE_URL
+from app.models import Subcontractor, TMTicket, db
+from tests.conftest import make_subcontractor
+
+
+@pytest.fixture
+def deployed_env():
+    """Run the body as if we were on Render, with APP_BASE_URL unset."""
+    with patch.dict('os.environ', {'ENVIRONMENT': 'production'}, clear=False), \
+            patch.object(command.cfg, 'APP_BASE_URL', LOCAL_APP_BASE_URL):
+        yield
+
+
+@pytest.fixture
+def local_env():
+    with patch.dict('os.environ', {'ENVIRONMENT': 'local'}, clear=False), \
+            patch.object(command.cfg, 'APP_BASE_URL', LOCAL_APP_BASE_URL):
+        yield
+
+
+def _invite(email='newsub@acme.test'):
+    return command.InviteSubcontractorCommand(
+        company_name='Acme Electrical',
+        contact_name='Sam Sub',
+        email=email,
+        invited_by_user_id=None,
+        invited_by_email='admin@mhmw.test',
+        invited_by_name='Admin',
+    )
+
+
+def test_localhost_base_is_allowed_locally(app, local_env, mock_send_mail):
+    sub = _invite().execute()
+
+    assert sub.id is not None
+    html = mock_send_mail.call_args_list[0].kwargs['html_content']
+    assert f'{LOCAL_APP_BASE_URL}/sub/accept-invite/' in html
+
+
+def test_invite_refuses_localhost_link_when_deployed(app, deployed_env, mock_send_mail):
+    with pytest.raises(command.OutboundLinkNotConfiguredError):
+        _invite().execute()
+
+    mock_send_mail.assert_not_called()
+    # Refused before the row was written, so there is no dead subcontractor to clean up.
+    assert Subcontractor.query.filter_by(email='newsub@acme.test').first() is None
+
+
+def test_resend_refuses_before_rotating_the_token(app, deployed_env, mock_send_mail):
+    sub = make_subcontractor('sam@acme.test')
+    command._generate_and_store_invite_token(sub)
+    db.session.commit()
+    original_hash = sub.invite_token_hash
+
+    with pytest.raises(command.OutboundLinkNotConfiguredError):
+        command.resend_invite(sub, resent_by_email='admin@mhmw.test', resent_by_name='Admin')
+
+    mock_send_mail.assert_not_called()
+    db.session.refresh(sub)
+    assert sub.invite_token_hash == original_hash  # still the working token
+
+
+def test_ticket_assignment_link_is_covered_by_the_same_guard(app, deployed_env):
+    # Same variable, second link — broken identically, just never hit yet.
+    ticket = TMTicket(job='500-998', location='Bay 3')
+    db.session.add(ticket)
+    sub = make_subcontractor('sam@acme.test', accepted=True)
+    db.session.commit()
+
+    with pytest.raises(command.OutboundLinkNotConfiguredError):
+        command._assignment_email_html(ticket, sub, 'Admin')
+
+
+def test_a_real_domain_passes_and_does_not_double_slash(app):
+    with patch.dict('os.environ', {'ENVIRONMENT': 'production'}, clear=False), \
+            patch.object(command.cfg, 'APP_BASE_URL', 'https://brain.mhmw.test/'):
+        assert command._external_link('/sub/tickets/7') == 'https://brain.mhmw.test/sub/tickets/7'


### PR DESCRIPTION
## Summary

This PR lands three bug fixes from the queue, each addressing a gap where business logic was implemented once but skipped by other code paths:

1. **BUG-9**: Fab order tier rules now apply consistently across all four stage-write paths (UpdateStageCommand, Trello sync, job_comp percentage, job_comp 'X')
2. **BUG-10**: Outbound invite links are now guarded against shipping localhost URLs to deployed environments
3. **BUG-8**: The DWL release-number generator now respects archived releases on the same job, preventing collisions the job log would reject

## Key Changes

### BUG-9: Unified fab_order tier logic
- **New module** `app/brain/job_log/features/fab_order/tier.py` — single source of truth for fab_order assignment rules
  - `plan_fab_order_for_stage()` decides what value a stage change implies (returns `None` = no change needed)
  - `apply_fab_order_for_stage()` executes the plan and emits the linked audit event
  - Rules: Complete=NULL, fixed tiers (0/1/2), dynamic stages ≥3, paint handoff lands at back of booth, reserved tiers repaired on re-entry
- **Updated write paths** to call the shared tier module instead of deciding independently:
  - `UpdateStageCommand` — removed inline tier logic, now delegates to `apply_fab_order_for_stage()`
  - `update_job_comp` (percentage branch) — now re-tiers instead of leaving fab_order untouched
  - `update_job_comp` ('X' branch) — now uses shared rules instead of clearing to NULL
  - `TrelloListMapper` (inbound sync) — now re-tiers on card moves
- **Comprehensive test suite** (`tests/brain/test_fab_order_tier.py`) pins the rules independently, then verifies all four write paths agree

### BUG-10: Outbound link configuration guard
- **New config helpers** in `app/config.py`:
  - `LOCAL_APP_BASE_URL` constant for recognizing the unconfigured state
  - `current_environment()` and `is_local_environment()` to detect deployment context
- **New guard** `_external_link()` in `app/brain/tm/subcontractors/command.py`:
  - Raises `OutboundLinkNotConfiguredError` if APP_BASE_URL is unset or localhost on a deployed environment
  - Allows localhost locally (legitimate for Vite dev server)
  - Called by invite and ticket-assignment link builders before any state is written
- **Error handling** in routes catches the exception and returns 500 with clear messaging
- **Test suite** (`tests/tm/test_outbound_link_config.py`) verifies the guard works locally and refuses on deployed environments

### BUG-8: Archive-aware release-number generator
- **New function** `_archived_rel_numbers_for_job()` in `app/procore/procore.py`:
  - Returns all Rel numbers (active + archived) for a given job
  - Scoped to one job to avoid exhausting the 101–998 range globally
  - Returns empty set when job is unknown (unscoped suggestions get no archive constraint)
- **Updated** `_globally_taken_rel_numbers()` to accept optional `job_number` parameter
- **Updated** `next_rel_number()` to accept `job_number` and pass it through
- **Updated** `/brain/drafting-work-load/rel/next` route to resolve the submittal's job and pass it to the suggestion
- **Updated** frontend `getNextReleaseNumber()` to accept optional job parameter
- **Test suite** (`tests/procore/test_rel_vs_joblog_agreement.py`) verifies containment: anything the job log rejects, the DWL refuses; documents intentional asymmetries (DWL stricter across jobs, job log allows name reuse)

## Notable Implementation Details

- **

https://claude.ai/code/session_01LGUcDgCGEYSMgxRYqNRNjb