### PR TITLE
Scrub hardcoded DB credentials from three ops scripts

### DIFF
--- a/scripts/copy_releases_to_sandbox.py
+++ b/scripts/copy_releases_to_sandbox.py
@@ -2,11 +2,17 @@
 Copy non-Trello fields from production releases table to sandbox releases table.
 Upserts by (job, release) unique constraint.
 """
+import os
+import sys
+
 import psycopg2
 import psycopg2.extras
 
-PROD_URL = "postgresql://mile_high_metal_works_trello_onedrive_user:G97rTBCFgwUubIokFMf85i7f4hwOCNUR@dpg-d3in27ogjchc73efo2l0-a.oregon-postgres.render.com/mile_high_metal_works_trello_onedrive"
-SANDBOX_URL = "postgresql://sandbox_mhmw_db_user:SLnOrx7QQXDrWmXhKgQx9Dm84dqQZEqJ@dpg-d51h1uemcj7s73c31p20-a.oregon-postgres.render.com/sandbox_mhmw_db"
+try:  # allow both `python -m scripts.copy_releases_to_sandbox` and direct execution
+    from scripts._db_urls import mask, prod_url, sandbox_url
+except ImportError:  # pragma: no cover - path fixup for direct execution
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts._db_urls import mask, prod_url, sandbox_url
 
 # Non-Trello columns to copy (excludes: trello_card_id, trello_card_name, trello_list_id,
 # trello_list_name, trello_card_description, trello_card_date, viewer_url)
@@ -23,9 +29,12 @@ UPDATE_COLS = [c for c in COLUMNS if c not in ("job", "release")]
 
 
 def main():
+    prod, sandbox = prod_url(), sandbox_url()
+    print(f"source: {mask(prod)}  ->  target: {mask(sandbox)}")
+
     # Read from production
-    prod_conn = psycopg2.connect(PROD_URL)
-    sandbox_conn = psycopg2.connect(SANDBOX_URL)
+    prod_conn = psycopg2.connect(prod)
+    sandbox_conn = psycopg2.connect(sandbox)
 
     try:
         with prod_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:

--- a/scripts/drop_submittal.py
+++ b/scripts/drop_submittal.py
@@ -12,11 +12,17 @@ Tables affected (by submittal_id string match):
   - notifications (also cascades via FK, deleted explicitly for counting)
 """
 import argparse
+import os
 import sys
+
 import psycopg2
 import psycopg2.extras
 
-PROD_URL = "postgresql://mile_high_metal_works_trello_onedrive_user:G97rTBCFgwUubIokFMf85i7f4hwOCNUR@dpg-d3in27ogjchc73efo2l0-a.oregon-postgres.render.com/mile_high_metal_works_trello_onedrive"
+try:  # allow both `python -m scripts.drop_submittal` and direct execution
+    from scripts._db_urls import mask, prod_url
+except ImportError:  # pragma: no cover - path fixup for direct execution
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts._db_urls import mask, prod_url
 
 TARGET_SUBMITTAL_ID = "69656624"
 
@@ -29,9 +35,11 @@ def main():
 
     sid = args.submittal_id
     mode = "EXECUTE" if args.execute else "DRY RUN"
-    print(f"=== {mode} — dropping submittal_id={sid} from PRODUCTION ===\n")
+    url = prod_url()
+    print(f"=== {mode} — dropping submittal_id={sid} from PRODUCTION ===")
+    print(f"target: {mask(url)}\n")
 
-    conn = psycopg2.connect(PROD_URL)
+    conn = psycopg2.connect(url)
     try:
         with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
             # Preview main submittal row

--- a/scripts/fix_release_pm.py
+++ b/scripts/fix_release_pm.py
@@ -8,11 +8,17 @@ Usage:
   python scripts/fix_release_pm.py --env sandbox --execute         # apply, sandbox
 """
 import argparse
+import os
+import sys
+
 import psycopg2
 import psycopg2.extras
 
-PROD_URL = "postgresql://mile_high_metal_works_trello_onedrive_user:G97rTBCFgwUubIokFMf85i7f4hwOCNUR@dpg-d3in27ogjchc73efo2l0-a.oregon-postgres.render.com/mile_high_metal_works_trello_onedrive"
-SANDBOX_URL = "postgresql://sandbox_mhmw_db_user:SLnOrx7QQXDrWmXhKgQx9Dm84dqQZEqJ@dpg-d51h1uemcj7s73c31p20-a.oregon-postgres.render.com/sandbox_mhmw_db"
+try:  # allow both `python -m scripts.fix_release_pm` and direct execution
+    from scripts._db_urls import mask, prod_url, sandbox_url
+except ImportError:  # pragma: no cover - path fixup for direct execution
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts._db_urls import mask, prod_url, sandbox_url
 
 TARGET_JOB = 999
 TARGET_RELEASE = "598"
@@ -26,9 +32,10 @@ def main():
     parser.add_argument("--env", choices=["prod", "sandbox"], default="prod", help="Target database (default: prod)")
     args = parser.parse_args()
 
-    db_url = PROD_URL if args.env == "prod" else SANDBOX_URL
+    db_url = prod_url() if args.env == "prod" else sandbox_url()
     mode = "EXECUTE" if args.execute else "DRY RUN"
-    print(f"=== {mode} [{args.env.upper()}] — updating releases.pm for job={TARGET_JOB} release={TARGET_RELEASE} ===\n")
+    print(f"=== {mode} [{args.env.upper()}] — updating releases.pm for job={TARGET_JOB} release={TARGET_RELEASE} ===")
+    print(f"target: {mask(db_url)}\n")
 
     conn = psycopg2.connect(db_url)
     try:


### PR DESCRIPTION
## What

`scripts/copy_releases_to_sandbox.py`, `scripts/drop_submittal.py`, and `scripts/fix_release_pm.py` each carried the live production and/or sandbox Postgres URL — **password included** — as a module constant. This repository is public.

All three now resolve their URL through `scripts/_db_urls.py`, the helper that already exists for this and whose docstring says credentials must never be hardcoded "(it is public)". It reads `PRODUCTION_DATABASE_URL` / `DATABASE_URL` / `SANDBOX_DATABASE_URL` from the environment and exits with a clear message when one is unset, instead of silently connecting somewhere unexpected.

The import uses the try/except form already in `backup_postgres.py`, so both `python scripts/x.py` and `python -m scripts.x` keep working.

Each script also now prints its resolved target via `mask()` (host/db only, never credentials). Two of these mutate **production** off a hardcoded default target, so showing which database is about to be touched earns its line.

Behavior is otherwise unchanged — same flags, same dry-run defaults, same SQL.

## ⚠️ This does not close the exposure

The credentials are removed from the working tree but **remain in git history on a public repo**. Both database passwords should be treated as compromised and **rotated in Render**. After rotating, update every copy of the URL: the Render web service, the scheduler instance, the sandbox service, local `.env`, and the backup cron's environment.

`scripts/backup_postgres.py` already reads through `_db_urls.py`, so it picks up a new value automatically — but confirm its next run succeeds, since a broken backup fails quietly.

## Verification

- `git grep -nE "postgres(ql)?://[^ \"']*:[^ @\"']{8,}@" -- scripts/` → no matches
- Scanned all 1,002 tracked files for the two live password strings → both clean
- `py_compile` passes on all three
- `--help` parses for both argparse scripts, in direct and `-m` form; `_db_urls` resolution verified for the sandbox path and confirmed to exit cleanly for the (currently commented-out) prod var
- Full suite: `4 failed, 1276 passed` — the same 4 pre-existing failures in `tests/tm/test_subcontractor_assignment.py`, unrelated to this change and tracked separately

No script was executed against a database. `copy_releases_to_sandbox.py` in particular has no dry-run guard and writes on run.

## Left alone deliberately

- `copy_releases_to_sandbox.py` has no `--apply`/dry-run guard (unlike its two siblings) and its hardcoded `COLUMNS` list is stale against the current `releases` schema — it omits several columns including `start_install_no_color`.
- `drop_submittal.py` and `fix_release_pm.py` keep hardcoded default targets.
- The pre-existing `chore/scrub-db-credentials` branch attempted this but is based on a much older `main` (~4,800 lines of newer work would be reverted). It can be deleted in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)